### PR TITLE
Fix Angular URL in FileManager

### DIFF
--- a/filemanager/templates/filemanager/index.html
+++ b/filemanager/templates/filemanager/index.html
@@ -18,7 +18,7 @@
 
     <!-- Angular JS -->
 
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.6/angular.min.js"></script>
+    <script src="https://cdn.bootcss.com/angular.js/1.6.6/angular.min.js"></script>
     <script src="{% static 'filemanager/js/fileManager.js' %}"></script>
 
     <!-- Fix for old browsers -->


### PR DESCRIPTION
Use BootCSS instead of GooglAPIs since mainland China cannot access Google.
As I have posted in https://forums.cyberpanel.net/discussion/400/file-manager-bug#latest, the file manager used googleapis to access angular JS file, I used BootCDN instead.