### PR TITLE
Fixed backup naming scheme, date field and a typo.

### DIFF
--- a/backup/backupManager.py
+++ b/backup/backupManager.py
@@ -141,8 +141,8 @@ class BackupManager:
 
             ## /home/example.com/backup
             backupPath = os.path.join("/home", backupDomain, "backup/")
-            domainUser = website.externalApp
-            backupName = 'backup-' + domainUser + "-" + time.strftime("%I-%M-%S-%a-%b-%Y")
+            backupDomainName = data['websiteToBeBacked']
+            backupName = 'backup-' + backupDomainName + "-" + time.strftime("%H-%M-%S-%b-%d-%Y")
 
             ## /home/example.com/backup/backup-example-06-50-03-Thu-Feb-2018
             tempStoragePath = os.path.join(backupPath, backupName)

--- a/plogical/backupUtilities.py
+++ b/plogical/backupUtilities.py
@@ -207,7 +207,7 @@ class backupUtilities:
             ## meta generated
 
 
-            newBackup = Backups(website=website, fileName=backupName, date=time.strftime("%I-%M-%S-%a-%b-%Y"),
+            newBackup = Backups(website=website, fileName=backupName, date=time.strftime("%b-%d-%Y"),
                                 size=0, status=1)
             newBackup.save()
 

--- a/plogical/backupUtilities.py
+++ b/plogical/backupUtilities.py
@@ -211,7 +211,7 @@ class backupUtilities:
                                 size=0, status=1)
             newBackup.save()
 
-            logging.CyberCPLogFileWriter.statusWriter(status, 'Meta data us ready..')
+            logging.CyberCPLogFileWriter.statusWriter(status, 'Meta data is ready..')
 
             return 1,'None', metaPath
 


### PR DESCRIPTION
For backup/backupManager.py:

1. Now it will show backup name as, `backup-example.com-01-01-01-Jan-01-2020` instead of `backup-example-01-01-01-Sun-Jan-2020`.

For plogical/backupUtilities.py

1. Now it will show date field as, `Jan-01-2020` instead of `01-01-01-Sun-Jan-2020`.
2. Fixed a typo.