### PR TITLE
Update backupManager.py

### DIFF
--- a/plogical/backupManager.py
+++ b/plogical/backupManager.py
@@ -134,8 +134,8 @@ class BackupManager:
 
             ## /home/example.com/backup
             backupPath = os.path.join("/home", backupDomain, "backup/")
-            domainUser = website.externalApp
-            backupName = 'backup-' + domainUser + "-" + time.strftime("%m.%d.%Y_%H-%M-%S")
+            backupDomainName = data['websiteToBeBacked']
+            backupName = 'backup-' + backupDomainName + "-" + time.strftime("%m.%d.%Y_%H-%M-%S")
 
             ## /home/example.com/backup/backup-example-02.15.2018_06-50-03
             tempStoragePath = os.path.join(backupPath, backupName)

--- a/plogical/backupManager.py
+++ b/plogical/backupManager.py
@@ -137,7 +137,7 @@ class BackupManager:
             backupDomainName = data['websiteToBeBacked']
             backupName = 'backup-' + backupDomainName + "-" + time.strftime("%m.%d.%Y_%H-%M-%S")
 
-            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03
+            ## /home/example.com/backup/backup-example.com-02.15.2018_06-50-03
             tempStoragePath = os.path.join(backupPath, backupName)
 
             execPath = "sudo nice -n 10 python " + virtualHostUtilities.cyberPanel + "/plogical/backupUtilities.py"

--- a/plogical/backupManager.py
+++ b/plogical/backupManager.py
@@ -135,9 +135,9 @@ class BackupManager:
             ## /home/example.com/backup
             backupPath = os.path.join("/home", backupDomain, "backup/")
             domainUser = website.externalApp
-            backupName = 'backup-' + domainUser + "-" + time.strftime("%I-%M-%S-%a-%b-%Y")
+            backupName = 'backup-' + domainUser + "-" + time.strftime("%m.%d.%Y_%H-%M-%S")
 
-            ## /home/example.com/backup/backup-example-06-50-03-Thu-Feb-2018
+            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03
             tempStoragePath = os.path.join(backupPath, backupName)
 
             execPath = "sudo nice -n 10 python " + virtualHostUtilities.cyberPanel + "/plogical/backupUtilities.py"


### PR DESCRIPTION
Updated to have a more logical human-readable Date_time format. This will make reviewing backup files by name way easier to work with and more standardized. The current date only shows the day of week and month and year not the day of the month. Those doing daily backups are going to have a hard time telling which 1 of 4 Thursday the default would have been.

From:
time.strftime("%I-%M-%S-%a-%b-%Y")
06-50-03-Thu-Feb-2018
backup-example-06-50-03-Thu-Feb-2018

To:
time.strftime("%m.%d.%Y_%H-%M-%S")
02.15.2018_06-50-03
backup-example-02.15.2018_06-50-03

Thanks