### PR TITLE
backupUtilities.py

### DIFF
--- a/plogical/backupUtilities.py
+++ b/plogical/backupUtilities.py
@@ -208,7 +208,7 @@ class backupUtilities:
                 reparsed = minidom.parseString(rough_string)
                 return reparsed.toprettyxml(indent="  ")
 
-            ## /home/example.com/backup/backup-example-06-50-03-Thu-Feb-2018/meta.xml -- metaPath
+            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03/meta.xml -- metaPath
 
             metaPath = '/tmp/%s' % (str(randint(1000, 9999)))
 
@@ -221,7 +221,7 @@ class backupUtilities:
             ## meta generated
 
 
-            newBackup = Backups(website=website, fileName=backupName, date=time.strftime("%I-%M-%S-%a-%b-%Y"),
+            newBackup = Backups(website=website, fileName=backupName, date=time.strftime("%m.%d.%Y_%H-%M-%S"),
                                 size=0, status=1)
             newBackup.save()
 
@@ -238,7 +238,7 @@ class backupUtilities:
     def startBackup(tempStoragePath, backupName, backupPath, metaPath = None):
         try:
 
-            ## /home/example.com/backup/backup-example-06-50-03-Thu-Feb-2018 -- tempStoragePath
+            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03 -- tempStoragePath
             ## /home/example.com/backup - backupPath
 
             ##### Writing the name of backup file.
@@ -256,7 +256,7 @@ class backupUtilities:
 
             ##### Parsing XML Meta file!
 
-            ## /home/example.com/backup/backup-example-06-50-03-Thu-Feb-2018 -- tempStoragePath
+            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03 -- tempStoragePath
 
             metaPathInBackup = os.path.join(tempStoragePath,'meta.xml')
 
@@ -279,7 +279,7 @@ class backupUtilities:
             if os.path.exists(backupUtilities.licenseKey):
                 copy(completPathToConf, tempStoragePath + '/vhost.conf')
 
-            ## /home/example.com/backup/backup-example-06-50-03-Thu-Feb-2018 -- tempStoragePath
+            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03 -- tempStoragePath
             ## shutil.make_archive
 
             make_archive(os.path.join(tempStoragePath,"public_html"), 'gztar', os.path.join("/home",domainName,"public_html"))
@@ -534,7 +534,7 @@ class backupUtilities:
             status = os.path.join(completPath,'status')
             logging.CyberCPLogFileWriter.statusWriter(status, "Extracting Main Archive!")
 
-            ## Converting /home/backup/backup-example-06-50-03-Thu-Feb-2018.tar.gz -> /home/backup/backup-example-06-50-03-Thu-Feb-2018
+            ## Converting /home/backup/backup-example-02.15.2018_06-50-03.tar.gz -> /home/backup/backup-example-02.15.2018_06-50-03
 
             tar = tarfile.open(originalFile)
             tar.extractall(completPath)
@@ -690,7 +690,7 @@ class backupUtilities:
 
             logging.CyberCPLogFileWriter.statusWriter(status, "Extracting web home data!")
 
-            # /home/backup/backup-example-06-50-03-Thu-Feb-2018/public_html.tar.gz
+            # /home/backup/backup-example-02.15.2018_06-50-03/public_html.tar.gz
 
             tar = tarfile.open(pathToCompressedHome)
             tar.extractall(websiteHome)
@@ -1021,8 +1021,8 @@ class backupUtilities:
 
 def submitBackupCreation(tempStoragePath, backupName, backupPath, backupDomain):
     try:
-        ## /home/example.com/backup/backup-example-06-50-03-Thu-Feb-2018 -- tempStoragePath
-        ## backup-example-06-50-03-Thu-Feb-2018 -- backup name
+        ## /home/example.com/backup/backup-example-02.15.2018_06-50-03 -- tempStoragePath
+        ## backup-example-02.15.2018_06-50-03 -- backup name
         ## /home/example.com/backup - backupPath
         ## /home/cyberpanel/1047.xml - metaPath
 

--- a/plogical/backupUtilities.py
+++ b/plogical/backupUtilities.py
@@ -208,7 +208,7 @@ class backupUtilities:
                 reparsed = minidom.parseString(rough_string)
                 return reparsed.toprettyxml(indent="  ")
 
-            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03/meta.xml -- metaPath
+            ## /home/example.com/backup/backup-example.com-02.13.2018_10-24-52/meta.xml -- metaPath
 
             metaPath = '/tmp/%s' % (str(randint(1000, 9999)))
 
@@ -238,7 +238,7 @@ class backupUtilities:
     def startBackup(tempStoragePath, backupName, backupPath, metaPath = None):
         try:
 
-            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03 -- tempStoragePath
+            ## /home/example.com/backup/backup-example.com-02.13.2018_10-24-52 -- tempStoragePath
             ## /home/example.com/backup - backupPath
 
             ##### Writing the name of backup file.
@@ -256,7 +256,7 @@ class backupUtilities:
 
             ##### Parsing XML Meta file!
 
-            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03 -- tempStoragePath
+            ## /home/example.com/backup/backup-example.com-02.13.2018_10-24-52 -- tempStoragePath
 
             metaPathInBackup = os.path.join(tempStoragePath,'meta.xml')
 
@@ -279,7 +279,7 @@ class backupUtilities:
             if os.path.exists(backupUtilities.licenseKey):
                 copy(completPathToConf, tempStoragePath + '/vhost.conf')
 
-            ## /home/example.com/backup/backup-example-02.15.2018_06-50-03 -- tempStoragePath
+            ## /home/example.com/backup/backup-example.com-02.13.2018_10-24-52 -- tempStoragePath
             ## shutil.make_archive
 
             make_archive(os.path.join(tempStoragePath,"public_html"), 'gztar', os.path.join("/home",domainName,"public_html"))
@@ -534,7 +534,7 @@ class backupUtilities:
             status = os.path.join(completPath,'status')
             logging.CyberCPLogFileWriter.statusWriter(status, "Extracting Main Archive!")
 
-            ## Converting /home/backup/backup-example-02.15.2018_06-50-03.tar.gz -> /home/backup/backup-example-02.15.2018_06-50-03
+            ## Converting /home/backup/backup-example.com-02.13.2018_10-24-52.tar.gz -> /home/backup/backup-example.com-02.13.2018_10-24-52
 
             tar = tarfile.open(originalFile)
             tar.extractall(completPath)
@@ -690,7 +690,7 @@ class backupUtilities:
 
             logging.CyberCPLogFileWriter.statusWriter(status, "Extracting web home data!")
 
-            # /home/backup/backup-example-02.15.2018_06-50-03/public_html.tar.gz
+            # /home/backup/backup-example.com-02.13.2018_10-24-52/public_html.tar.gz
 
             tar = tarfile.open(pathToCompressedHome)
             tar.extractall(websiteHome)
@@ -1021,8 +1021,8 @@ class backupUtilities:
 
 def submitBackupCreation(tempStoragePath, backupName, backupPath, backupDomain):
     try:
-        ## /home/example.com/backup/backup-example-02.15.2018_06-50-03 -- tempStoragePath
-        ## backup-example-02.15.2018_06-50-03 -- backup name
+        ## /home/example.com/backup/backup-example.com-02.13.2018_10-24-52 -- tempStoragePath
+        ## backup-example.com-02.13.2018_10-24-52 -- backup name
         ## /home/example.com/backup - backupPath
         ## /home/cyberpanel/1047.xml - metaPath
 


### PR DESCRIPTION
Updated to have a more logical human-readable Date_time format. This will make reviewing backup files by name way easier to work with and more standardized. The current date only shows the day of week and month and year not the day of the month. Those doing daily backups are going to have a hard time telling which 1 of 4 Thursday the default would have been.

From:
time.strftime("%I-%M-%S-%a-%b-%Y")
06-50-03-Thu-Feb-2018
backup-example-06-50-03-Thu-Feb-2018

To:
time.strftime("%m.%d.%Y_%H-%M-%S")
02.15.2018_06-50-03
backup-example-02.15.2018_06-50-03

Also goes with my other proposed pull request for Update backupManager.py #126
https://github.com/usmannasir/cyberpanel/pull/126

Thanks