### PR TITLE
updated CSF defaults for cyberpanel

### DIFF
--- a/plogical/csf.py
+++ b/plogical/csf.py
@@ -73,6 +73,186 @@ class CSF(multi.Thread):
                     writeToConf.writelines('UDP_IN = "20,21,53"\n')
                 elif items.find('UDP_OUT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('UDP_OUT = "20,21,53,113,123"\n')
+                    		# setting RESTRICT_SYSLOG to "3" for use with option RESTRICT_SYSLOG_GROUP to restrict access to the syslog/rsyslog unix socket(s)
+                elif items.find('RESTRICT_SYSLOG') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RESTRICT_SYSLOG = "3"\n')
+
+		        #  Send an email alert if an IP address is blocked by one of the [*] triggers: disabled
+                elif items.find('LF_EMAIL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_EMAIL_ALERT = "0"\n')
+
+		        # Set LF_PERMBLOCK_ALERT to "0" to disable this feature
+                elif items.find('LF_PERMBLOCK_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_PERMBLOCK_ALERT = "0"\n')
+
+		        #  Set LF_NETBLOCK_ALERT to "0" to disable this feature
+                elif items.find('LF_NETBLOCK_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_NETBLOCK_ALERT = "0"\n')
+
+		        # Login Failure Blocking and Alerts  
+		        # LF_TRIGGER_PERM = "1800" => the IP is blocked temporarily for 30 minutes 
+                elif items.find('LF_TRIGGER_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_TRIGGER_PERM = "1800"\n')
+
+		        #  Enable login failure detection of sshd connections: 10 failures triggers
+                elif items.find('LF_SSHD') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_SSHD = "10"\n')
+
+		        #  LF_SSHD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+                elif items.find('LF_SSHD_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_SSHD_PERM = "1800"\n')
+
+		        #  Enable login failure detection of ftp connections: 10 failures triggers
+                elif items.find('LF_FTPD') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_FTPD = "10"\n')
+
+		        #  LF_FTPD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+                elif items.find('LF_FTPD_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_FTPD_PERM = "1800"\n')
+
+		        #  Enable login failure detection of SMTP AUTH connections: 10 failures triggers
+                elif items.find('LF_SMTPAUTH') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_SMTPAUTH = "10"\n')
+
+		        #  LF_SMTPAUTH_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+                elif items.find('LF_SMTPAUTH_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_SMTPAUTH_PERM = "1800"\n')
+
+		        #  Enable login failure detection of pop3 connections: 10 failures triggers
+                elif items.find('LF_POP3D') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_POP3D = "10"\n')
+
+		        #  LF_POP3D_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+                elif items.find('LF_POP3D_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_POP3D_PERM = "1800"\n')
+
+		        #  Enable login failure detection of imap connections: 10 failures triggers
+                elif items.find('LF_IMAPD') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_IMAPD = "1800"\n')
+
+		        #  LF_IMAPD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+                elif items.find('LF_IMAPD_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_IMAPD_PERM = "1800"\n')
+
+		        #  LF_HTACCESS_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+                elif items.find('LF_HTACCESS_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_HTACCESS_PERM = "1800"\n')
+
+		        #  Enable failure detection of repeated Apache mod_security rule triggers: 10 failures triggers
+                elif items.find('LF_MODSEC') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_MODSEC = "10"\n')
+
+		        #  LF_MODSEC_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+                elif items.find('LF_MODSEC_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_MODSEC_PERM = "1800"\n')
+
+		        #  MODSEC_LOG location
+                elif items.find('MODSEC_LOG') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('MODSEC_LOG = "/usr/local/lsws/logs/auditmodsec.log"\n')
+
+		        #  Send an email alert if anyone logs in successfully using SSH: Disabled
+                elif items.find('LF_SSH_EMAIL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_SSH_EMAIL_ALERT = "0"\n')
+
+		        #  Send an email alert if anyone accesses webmin: Disabled not applicable
+                elif items.find('LF_WEBMIN_EMAIL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_WEBMIN_EMAIL_ALERT = "0"\n')
+
+		        #  LF_QUEUE_ALERT disabled
+                elif items.find('LF_QUEUE_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_QUEUE_ALERT = "0"\n')
+
+		        #  LF_QUEUE_INTERVAL disabled
+                elif items.find('LF_QUEUE_INTERVAL = "0"') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_TRIGGER_PERM = "1800"\n')
+
+		        #  Relay Tracking. This allows you to track email that is relayed through the server. Disabled
+                elif items.find('RT_RELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_RELAY_ALERT = "0"\n')
+
+		        #  RT_[relay type]_LIMIT: the limit/hour afterwhich an email alert will be sent
+                elif items.find('RT_RELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_RELAY_LIMIT = "500"\n')
+
+		        #  RT_[relay type]_BLOCK: 0 = no block;1 = perm block;nn=temp block for nn secs
+                elif items.find('RT_RELAY_BLOCK') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_RELAY_BLOCK = "0"\n')
+
+		        #   This option triggers for email authenticated by SMTP AUTH disabled
+                elif items.find('RT_AUTHRELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_AUTHRELAY_ALERT = "0"\n')
+
+		        #  RT_AUTHRELAY_LIMIT set to 100
+                elif items.find('RT_AUTHRELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_AUTHRELAY_LIMIT = "100"\n')
+
+		        #  RT_AUTHRELAY_LIMIT set to 0
+                elif items.find('RT_AUTHRELAY_BLOCK') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_AUTHRELAY_BLOCK = "0"\n')
+
+		        #   This option triggers for email authenticated by POP before SMTP
+                elif items.find('RT_POPRELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_POPRELAY_ALERT = "0"\n')
+
+		        #   This option triggers for email authenticated by POP before SMTP
+                elif items.find('RT_POPRELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_POPRELAY_LIMIT = "100"\n')
+
+		        #  RT_POPRELAY_BLOCK disabled
+                elif items.find('RT_POPRELAY_BLOCK') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_POPRELAY_BLOCK = "0"\n')
+
+		        #   This option triggers for email sent via /usr/sbin/sendmail or /usr/sbin/exim: Disabled
+                elif items.find('RT_LOCALRELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_LOCALRELAY_ALERT = "0"\n')
+
+		        #   This option triggers for email sent via a local IP addresses
+                elif items.find('RT_LOCALRELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_LOCALRELAY_LIMIT = "100"\n')
+
+		        #   This option triggers for email sent via a local IP addresses
+                elif items.find('RT_LOCALHOSTRELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_LOCALHOSTRELAY_ALERT = "0"\n')
+
+		        #   This option triggers for email sent via a local IP addresses disabled
+                elif items.find('RT_LOCALHOSTRELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_LOCALHOSTRELAY_LIMIT = "100"\n')
+
+		        #  If an RT_* event is triggered, then if the following contains the path to a script
+                elif items.find('RT_ACTION') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('RT_ACTION = ""\n')
+
+		        #   Send an email alert if an IP address is blocked due to connection tracking disabled
+                elif items.find('CT_EMAIL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('CT_EMAIL_ALERT = "0"\n')
+
+		        #  User Process Tracking.  Set to 0 to disable this feature
+                elif items.find('PT_USERPROC') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('PT_USERPROC = "0"\n')
+
+		        #  This User Process Tracking option sends an alert if any user process exceeds the virtual memory usage set (MB). Set to 0 to disable this feature
+                elif items.find('PT_USERMEM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('PT_USERMEM = "0"\n')
+
+		        #  This User Process Tracking option sends an alert if any user process exceeds the RSS memory usage set (MB) - RAM used, not virtual.
+                elif items.find('PT_USERRSS') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('PT_USERRSS = "0"\n')
+
+		        #  If this option is set then processes detected by PT_USERMEM, PT_USERTIME or PT_USERPROC are killed. Disabled
+                elif items.find('PT_USERTIME') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('PT_USERTIME = "0"\n')
+
+		        #  If you want to disable email alerts if PT_USERKILL is triggered, then set this option to 0. Disabled
+                elif items.find('PT_USERKILL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('PT_USERKILL_ALERT = "0"\n')
+
+		        #  Check the PT_LOAD_AVG minute Load Average (can be set to 1 5 or 15 and defaults to 5 if set otherwise) on the server every PT_LOAD seconds. Disabled
+                elif items.find('PT_LOAD') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('PT_LOAD = "0"\n')
+
+		        #  HTACCESS_LOG is ins main error.log
+                elif items.find('HTACCESS_LOG') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('HTACCESS_LOG = "/usr/local/lsws/logs/error.log"\n')
                 else:
                     writeToConf.writelines(items)
 

--- a/plogical/csf.py
+++ b/plogical/csf.py
@@ -73,185 +73,185 @@ class CSF(multi.Thread):
                     writeToConf.writelines('UDP_IN = "20,21,53"\n')
                 elif items.find('UDP_OUT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('UDP_OUT = "20,21,53,113,123"\n')
-                    		# setting RESTRICT_SYSLOG to "3" for use with option RESTRICT_SYSLOG_GROUP to restrict access to the syslog/rsyslog unix socket(s)
-                elif items.find('RESTRICT_SYSLOG') > -1 and items.find('=') > -1 and (items[0] != '#'):
+    		# setting RESTRICT_SYSLOG to "3" for use with option RESTRICT_SYSLOG_GROUP to restrict access to the syslog/rsyslog unix socket(s)
+                elif items.find('RESTRICT_SYSLOG =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RESTRICT_SYSLOG = "3"\n')
 
-		        #  Send an email alert if an IP address is blocked by one of the [*] triggers: disabled
+		#  Send an email alert if an IP address is blocked by one of the [*] triggers: disabled
                 elif items.find('LF_EMAIL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_EMAIL_ALERT = "0"\n')
 
-		        # Set LF_PERMBLOCK_ALERT to "0" to disable this feature
+		# Set LF_PERMBLOCK_ALERT to "0" to disable this feature
                 elif items.find('LF_PERMBLOCK_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_PERMBLOCK_ALERT = "0"\n')
 
-		        #  Set LF_NETBLOCK_ALERT to "0" to disable this feature
+		#  Set LF_NETBLOCK_ALERT to "0" to disable this feature
                 elif items.find('LF_NETBLOCK_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_NETBLOCK_ALERT = "0"\n')
 
-		        # Login Failure Blocking and Alerts  
-		        # LF_TRIGGER_PERM = "1800" => the IP is blocked temporarily for 30 minutes 
+		# Login Failure Blocking and Alerts  
+		# LF_TRIGGER_PERM = "1800" => the IP is blocked temporarily for 30 minutes 
                 elif items.find('LF_TRIGGER_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_TRIGGER_PERM = "1800"\n')
 
-		        #  Enable login failure detection of sshd connections: 10 failures triggers
-                elif items.find('LF_SSHD') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  Enable login failure detection of sshd connections: 10 failures triggers
+                elif items.find('LF_SSHD =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_SSHD = "10"\n')
 
-		        #  LF_SSHD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+		#  LF_SSHD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
                 elif items.find('LF_SSHD_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_SSHD_PERM = "1800"\n')
 
-		        #  Enable login failure detection of ftp connections: 10 failures triggers
-                elif items.find('LF_FTPD') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  Enable login failure detection of ftp connections: 10 failures triggers
+                elif items.find('LF_FTPD =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_FTPD = "10"\n')
 
-		        #  LF_FTPD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+		#  LF_FTPD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
                 elif items.find('LF_FTPD_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_FTPD_PERM = "1800"\n')
 
-		        #  Enable login failure detection of SMTP AUTH connections: 10 failures triggers
-                elif items.find('LF_SMTPAUTH') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  Enable login failure detection of SMTP AUTH connections: 10 failures triggers
+                elif items.find('LF_SMTPAUTH =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_SMTPAUTH = "10"\n')
 
-		        #  LF_SMTPAUTH_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+		#  LF_SMTPAUTH_PERM = "1800" => the IP is blocked temporarily for 30 minutes
                 elif items.find('LF_SMTPAUTH_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_SMTPAUTH_PERM = "1800"\n')
 
-		        #  Enable login failure detection of pop3 connections: 10 failures triggers
-                elif items.find('LF_POP3D') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  Enable login failure detection of pop3 connections: 10 failures triggers
+                elif items.find('LF_POP3D =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_POP3D = "10"\n')
 
-		        #  LF_POP3D_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+		#  LF_POP3D_PERM = "1800" => the IP is blocked temporarily for 30 minutes
                 elif items.find('LF_POP3D_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_POP3D_PERM = "1800"\n')
 
-		        #  Enable login failure detection of imap connections: 10 failures triggers
-                elif items.find('LF_IMAPD') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  Enable login failure detection of imap connections: 10 failures triggers
+                elif items.find('LF_IMAPD =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_IMAPD = "1800"\n')
 
-		        #  LF_IMAPD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+		#  LF_IMAPD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
                 elif items.find('LF_IMAPD_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_IMAPD_PERM = "1800"\n')
 
-		        #  LF_HTACCESS_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+		#  LF_HTACCESS_PERM = "1800" => the IP is blocked temporarily for 30 minutes
                 elif items.find('LF_HTACCESS_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_HTACCESS_PERM = "1800"\n')
 
-		        #  Enable failure detection of repeated Apache mod_security rule triggers: 10 failures triggers
-                elif items.find('LF_MODSEC') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  Enable failure detection of repeated Apache mod_security rule triggers: 10 failures triggers
+                elif items.find('LF_MODSEC =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_MODSEC = "10"\n')
 
-		        #  LF_MODSEC_PERM = "1800" => the IP is blocked temporarily for 30 minutes
+		#  LF_MODSEC_PERM = "1800" => the IP is blocked temporarily for 30 minutes
                 elif items.find('LF_MODSEC_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_MODSEC_PERM = "1800"\n')
 
-		        #  MODSEC_LOG location
-                elif items.find('MODSEC_LOG') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  MODSEC_LOG location
+                elif items.find('MODSEC_LOG =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('MODSEC_LOG = "/usr/local/lsws/logs/auditmodsec.log"\n')
 
-		        #  Send an email alert if anyone logs in successfully using SSH: Disabled
+		#  Send an email alert if anyone logs in successfully using SSH: Disabled
                 elif items.find('LF_SSH_EMAIL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_SSH_EMAIL_ALERT = "0"\n')
 
-		        #  Send an email alert if anyone accesses webmin: Disabled not applicable
+		#  Send an email alert if anyone accesses webmin: Disabled not applicable
                 elif items.find('LF_WEBMIN_EMAIL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_WEBMIN_EMAIL_ALERT = "0"\n')
 
-		        #  LF_QUEUE_ALERT disabled
+		#  LF_QUEUE_ALERT disabled
                 elif items.find('LF_QUEUE_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_QUEUE_ALERT = "0"\n')
 
-		        #  LF_QUEUE_INTERVAL disabled
+		#  LF_QUEUE_INTERVAL disabled
                 elif items.find('LF_QUEUE_INTERVAL = "0"') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('LF_TRIGGER_PERM = "1800"\n')
 
-		        #  Relay Tracking. This allows you to track email that is relayed through the server. Disabled
+		#  Relay Tracking. This allows you to track email that is relayed through the server. Disabled
                 elif items.find('RT_RELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_RELAY_ALERT = "0"\n')
 
-		        #  RT_[relay type]_LIMIT: the limit/hour afterwhich an email alert will be sent
+		#  RT_[relay type]_LIMIT: the limit/hour afterwhich an email alert will be sent
                 elif items.find('RT_RELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_RELAY_LIMIT = "500"\n')
 
-		        #  RT_[relay type]_BLOCK: 0 = no block;1 = perm block;nn=temp block for nn secs
+		#  RT_[relay type]_BLOCK: 0 = no block;1 = perm block;nn=temp block for nn secs
                 elif items.find('RT_RELAY_BLOCK') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_RELAY_BLOCK = "0"\n')
 
-		        #   This option triggers for email authenticated by SMTP AUTH disabled
+		#   This option triggers for email authenticated by SMTP AUTH disabled
                 elif items.find('RT_AUTHRELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_AUTHRELAY_ALERT = "0"\n')
 
-		        #  RT_AUTHRELAY_LIMIT set to 100
+		#  RT_AUTHRELAY_LIMIT set to 100
                 elif items.find('RT_AUTHRELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_AUTHRELAY_LIMIT = "100"\n')
 
-		        #  RT_AUTHRELAY_LIMIT set to 0
+		#  RT_AUTHRELAY_LIMIT set to 0
                 elif items.find('RT_AUTHRELAY_BLOCK') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_AUTHRELAY_BLOCK = "0"\n')
 
-		        #   This option triggers for email authenticated by POP before SMTP
+		#   This option triggers for email authenticated by POP before SMTP
                 elif items.find('RT_POPRELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_POPRELAY_ALERT = "0"\n')
 
-		        #   This option triggers for email authenticated by POP before SMTP
+		#   This option triggers for email authenticated by POP before SMTP
                 elif items.find('RT_POPRELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_POPRELAY_LIMIT = "100"\n')
 
-		        #  RT_POPRELAY_BLOCK disabled
+		#  RT_POPRELAY_BLOCK disabled
                 elif items.find('RT_POPRELAY_BLOCK') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_POPRELAY_BLOCK = "0"\n')
 
-		        #   This option triggers for email sent via /usr/sbin/sendmail or /usr/sbin/exim: Disabled
+		#   This option triggers for email sent via /usr/sbin/sendmail or /usr/sbin/exim: Disabled
                 elif items.find('RT_LOCALRELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_LOCALRELAY_ALERT = "0"\n')
 
-		        #   This option triggers for email sent via a local IP addresses
+		#   This option triggers for email sent via a local IP addresses
                 elif items.find('RT_LOCALRELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_LOCALRELAY_LIMIT = "100"\n')
 
-		        #   This option triggers for email sent via a local IP addresses
+		#   This option triggers for email sent via a local IP addresses
                 elif items.find('RT_LOCALHOSTRELAY_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_LOCALHOSTRELAY_ALERT = "0"\n')
 
-		        #   This option triggers for email sent via a local IP addresses disabled
+		#   This option triggers for email sent via a local IP addresses disabled
                 elif items.find('RT_LOCALHOSTRELAY_LIMIT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_LOCALHOSTRELAY_LIMIT = "100"\n')
 
-		        #  If an RT_* event is triggered, then if the following contains the path to a script
+		#  If an RT_* event is triggered, then if the following contains the path to a script
                 elif items.find('RT_ACTION') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('RT_ACTION = ""\n')
 
-		        #   Send an email alert if an IP address is blocked due to connection tracking disabled
+		#   Send an email alert if an IP address is blocked due to connection tracking disabled
                 elif items.find('CT_EMAIL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('CT_EMAIL_ALERT = "0"\n')
 
-		        #  User Process Tracking.  Set to 0 to disable this feature
-                elif items.find('PT_USERPROC') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  User Process Tracking.  Set to 0 to disable this feature
+                elif items.find('PT_USERPROC =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('PT_USERPROC = "0"\n')
 
-		        #  This User Process Tracking option sends an alert if any user process exceeds the virtual memory usage set (MB). Set to 0 to disable this feature
-                elif items.find('PT_USERMEM') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  This User Process Tracking option sends an alert if any user process exceeds the virtual memory usage set (MB). Set to 0 to disable this feature
+                elif items.find('PT_USERMEM =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('PT_USERMEM = "0"\n')
 
-		        #  This User Process Tracking option sends an alert if any user process exceeds the RSS memory usage set (MB) - RAM used, not virtual.
-                elif items.find('PT_USERRSS') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  This User Process Tracking option sends an alert if any user process exceeds the RSS memory usage set (MB) - RAM used, not virtual.
+                elif items.find('PT_USERRSS =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('PT_USERRSS = "0"\n')
 
-		        #  If this option is set then processes detected by PT_USERMEM, PT_USERTIME or PT_USERPROC are killed. Disabled
-                elif items.find('PT_USERTIME') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  If this option is set then processes detected by PT_USERMEM, PT_USERTIME or PT_USERPROC are killed. Disabled
+                elif items.find('PT_USERTIME =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('PT_USERTIME = "0"\n')
 
-		        #  If you want to disable email alerts if PT_USERKILL is triggered, then set this option to 0. Disabled
+		#  If you want to disable email alerts if PT_USERKILL is triggered, then set this option to 0. Disabled
                 elif items.find('PT_USERKILL_ALERT') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('PT_USERKILL_ALERT = "0"\n')
 
-		        #  Check the PT_LOAD_AVG minute Load Average (can be set to 1 5 or 15 and defaults to 5 if set otherwise) on the server every PT_LOAD seconds. Disabled
-                elif items.find('PT_LOAD') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  Check the PT_LOAD_AVG minute Load Average (can be set to 1 5 or 15 and defaults to 5 if set otherwise) on the server every PT_LOAD seconds. Disabled
+                elif items.find('PT_LOAD =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('PT_LOAD = "0"\n')
 
-		        #  HTACCESS_LOG is ins main error.log
-                elif items.find('HTACCESS_LOG') > -1 and items.find('=') > -1 and (items[0] != '#'):
+		#  HTACCESS_LOG is ins main error.log
+                elif items.find('HTACCESS_LOG =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('HTACCESS_LOG = "/usr/local/lsws/logs/error.log"\n')
                 else:
                     writeToConf.writelines(items)

--- a/plogical/csf.py
+++ b/plogical/csf.py
@@ -128,7 +128,7 @@ class CSF(multi.Thread):
 
 		#  Enable login failure detection of imap connections: 10 failures triggers
                 elif items.find('LF_IMAPD =') > -1 and items.find('=') > -1 and (items[0] != '#'):
-                    writeToConf.writelines('LF_IMAPD = "1800"\n')
+                    writeToConf.writelines('LF_IMAPD = "10"\n')
 
 		#  LF_IMAPD_PERM = "1800" => the IP is blocked temporarily for 30 minutes
                 elif items.find('LF_IMAPD_PERM') > -1 and items.find('=') > -1 and (items[0] != '#'):


### PR DESCRIPTION
Disable unnecessary alerts and unused functions. Enable other functions. Map log universal logs files to the proper location for cyberpanel. This will save a lot of frustration upon initial install with good defaults that aren't too aggressive and cause conflicts.

@usmannasir  If there is a way to have an additional OS-specific version set of commands run on CSF install based on OS version the below also needs to be used so the logs LFD and CSF are mapped properly.  I ran out of steam and not sure how best to detect that so that might be best done by someone else logic wise.

For Ubuntu base Cyberpanel with CSF
sed -i 's|^SSHD_LOG =.*|SSHD_LOG = "/var/log/auth.log"|g' /etc/csf/csf.conf
sed -i 's|^SU_LOG =.*|SU_LOG = "/var/log/auth.log"|g' /etc/csf/csf.conf
sed -i 's|^FTPD_LOG =.*|FTPD_LOG = "/var/log/auth.log"|g' /etc/csf/csf.conf
sed -i 's|^SMTPAUTH_LOG =.*|SMTPAUTH_LOG = "/var/log/mail.log"|g' /etc/csf/csf.conf
sed -i 's|^POP3D_LOG =.*|POP3D_LOG = "/var/log/mail.log"|g' /etc/csf/csf.conf
sed -i 's|^IMAPD_LOG =.*|IMAPD_LOG = "/var/log/mail.log"|g' /etc/csf/csf.conf
sed -i 's|^IPTABLES_LOG =.*|IPTABLES_LOG = "/var/log/kern.log"|g' /etc/csf/csf.conf
sed -i 's|^SYSLOG_LOG =.*|SYSLOG_LOG = "/var/log/syslog"|g' /etc/csf/csf.conf

For Centos based Cyberpanel with CSF

sed -i 's|^SSHD_LOG =.*|SSHD_LOG = "/var/log/secure"|g' /etc/csf/csf.conf
sed -i 's|^SU_LOG =.*|SU_LOG = "/var/log/secure"|g' /etc/csf/csf.conf
sed -i 's|^FTPD_LOG =.*|FTPD_LOG = "/var/log/messages"|g' /etc/csf/csf.conf
sed -i 's|^POP3D_LOG =.*|POP3D_LOG = "/var/log/maillog"|g' /etc/csf/csf.conf
sed -i 's|^SMTPAUTH_LOG =.*|SMTPAUTH_LOG = "/var/log/maillog"|g' /etc/csf/csf.conf
sed -i 's|^IMAPD_LOG =.*|IMAPD_LOG = "/var/log/maillog"|g' /etc/csf/csf.conf
sed -i 's|^IPTABLES_LOG =.*|IPTABLES_LOG = "/var/log/messages"|g' /etc/csf/csf.conf
sed -i 's|^SYSLOG_LOG =.*|SYSLOG_LOG = "/var/log/messages"|g' /etc/csf/csf.conf