### PR TITLE
Fix Missing Security related plugins

### DIFF
--- a/firewall/templates/firewall/index.html
+++ b/firewall/templates/firewall/index.html
@@ -43,6 +43,49 @@
                                     </a>
                     </div>
 
+                    <div class="col-lg-5 col-md-6 btn-min-width">
+                                    <a href="{% url 'csf' %}" title="{% trans 'ConfigServer Security & Firewall (CSF)' %}" class="tile-box tile-box-shortcut btn-primary">
+                                        <div class="tile-header">
+                                            {% trans "CSF" %}
+                                        </div>
+                                        <div class="tile-content-wrapper">
+                                            <i class="fa fa-lock"></i>
+                                        </div>
+                                    </a>
+                    </div>
+
+                    <div class="col-lg-5 col-md-6 btn-min-width">
+                                    <a href="{% url 'modSecurity' %}" title="{% trans 'ModSecurity Configurations' %}" class="tile-box tile-box-shortcut btn-primary">
+                                        <div class="tile-header">
+                                            {% trans "ModSecurity Conf" %}
+                                        </div>
+                                        <div class="tile-content-wrapper">
+                                            <i class="fa fa-lock"></i>
+                                        </div>
+                                    </a>
+                    </div>
+
+                    <div class="col-lg-5 col-md-6 btn-min-width">
+                                    <a href="{% url 'modSecRules' %}" title="{% trans 'ModSecurity Rules' %}" class="tile-box tile-box-shortcut btn-primary">
+                                        <div class="tile-header">
+                                            {% trans "ModSecurity Rules" %}
+                                        </div>
+                                        <div class="tile-content-wrapper">
+                                            <i class="fa fa-lock"></i>
+                                        </div>
+                                    </a>
+                    </div>
+
+                    <div class="col-lg-5 col-md-6 btn-min-width">
+                                    <a href="{% url 'modSecRulesPacks' %}" title="{% trans 'ModSecurity Rules Packs' %}" class="tile-box tile-box-shortcut btn-primary">
+                                        <div class="tile-header">
+                                            {% trans "ModSecurity Rules Packs" %}
+                                        </div>
+                                        <div class="tile-content-wrapper">
+                                            <i class="fa fa-lock"></i>
+                                        </div>
+                                    </a>
+                    </div>                   
 
                 </div>
              </div>


### PR DESCRIPTION
This shows all the missing(CSF/Modsec) Security related plugins from sidebar in the dashboard 
https://IP:8090/firewall/securityHome

Before:
![image](https://user-images.githubusercontent.com/1596188/66264072-c1aa0300-e7cc-11e9-8814-d3112446f279.png)

After:
![image](https://user-images.githubusercontent.com/1596188/66264073-d25a7900-e7cc-11e9-8f9a-39bff49ca992.png)
