### PR TITLE
Michael

### DIFF
--- a/CyberCP/secMiddleware.py
+++ b/CyberCP/secMiddleware.py
@@ -3,46 +3,42 @@ import json
 from django.shortcuts import HttpResponse
 import re
 
-# Create option to enable/disable sessionIPValidation for Dynamic IP's
-sessionIPValidation = 'true'
-
 class secMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        if sessionIPValidation == 'true':
-            try:
-                uID = request.session['userID']
-                ipAddr = request.META.get('REMOTE_ADDR')
+        try:
+            uID = request.session['userID']
+            ipAddr = request.META.get('REMOTE_ADDR')
 
-                if ipAddr.find('.') > -1:
-                    if request.session['ipAddr'] == ipAddr:
-                        pass
-                    else:
-                        del request.session['userID']
-                        del request.session['ipAddr']
-                        logging.writeToFile(request.META.get('REMOTE_ADDR'))
-                        final_dic = {'error_message': "Session reuse detected, IPAddress logged. Toggle off sessionIPValidation in secMiddleware.py if seeing this frequently with Dynamic IP",
-                                     "errorMessage": "Session reuse detected, IPAddress logged. Toggle off sessionIPValidation in secMiddleware.py if seeing this frequently with Dynamic IP"}
-                        final_json = json.dumps(final_dic)
-                        return HttpResponse(final_json)
+            if ipAddr.find('.') > -1:
+                if request.session['ipAddr'] == ipAddr:
+                    pass
                 else:
-                    ipAddr = request.META.get('REMOTE_ADDR').split(':')[:3]
+                    del request.session['userID']
+                    del request.session['ipAddr']
+                    logging.writeToFile(request.META.get('REMOTE_ADDR'))
+                    final_dic = {'error_message': "Session reuse detected, IPAddress logged.",
+                                 "errorMessage": "Session reuse detected, IPAddress logged."}
+                    final_json = json.dumps(final_dic)
+                    return HttpResponse(final_json)
+            else:
+                ipAddr = request.META.get('REMOTE_ADDR').split(':')[:3]
 
-                    if request.session['ipAddr'] == ipAddr:
-                        pass
-                    else:
-                        del request.session['userID']
-                        del request.session['ipAddr']
-                        logging.writeToFile(request.META.get('REMOTE_ADDR'))
-                        final_dic = {'error_message': "Session reuse detected, IPAddress logged. Toggle off sessionIPValidation in secMiddleware.py if seeing this frequently with Dynamic IP",
-                                     "errorMessage": "Session reuse detected, IPAddress logged. Toggle off sessionIPValidation in secMiddleware.py if seeing this frequently with Dynamic IP"}
-                        final_json = json.dumps(final_dic)
-                        return HttpResponse(final_json)
-            except:
-                pass
+                if request.session['ipAddr'] == ipAddr:
+                    pass
+                else:
+                    del request.session['userID']
+                    del request.session['ipAddr']
+                    logging.writeToFile(request.META.get('REMOTE_ADDR'))
+                    final_dic = {'error_message': "Session reuse detected, IPAddress logged.",
+                                 "errorMessage": "Session reuse detected, IPAddress logged."}
+                    final_json = json.dumps(final_dic)
+                    return HttpResponse(final_json)
+        except:
+            pass
         if request.method == 'POST':
             try:
                 #logging.writeToFile(request.body)

--- a/CyberCP/secMiddleware.py
+++ b/CyberCP/secMiddleware.py
@@ -3,42 +3,46 @@ import json
 from django.shortcuts import HttpResponse
 import re
 
+# Create option to enable/disable sessionIPValidation for Dynamic IP's
+sessionIPValidation = 'true'
+
 class secMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        try:
-            uID = request.session['userID']
-            ipAddr = request.META.get('REMOTE_ADDR')
+        if sessionIPValidation == 'true':
+            try:
+                uID = request.session['userID']
+                ipAddr = request.META.get('REMOTE_ADDR')
 
-            if ipAddr.find('.') > -1:
-                if request.session['ipAddr'] == ipAddr:
-                    pass
+                if ipAddr.find('.') > -1:
+                    if request.session['ipAddr'] == ipAddr:
+                        pass
+                    else:
+                        del request.session['userID']
+                        del request.session['ipAddr']
+                        logging.writeToFile(request.META.get('REMOTE_ADDR'))
+                        final_dic = {'error_message': "Session reuse detected, IPAddress logged. Toggle off sessionIPValidation in secMiddleware.py if seeing this frequently with Dynamic IP",
+                                     "errorMessage": "Session reuse detected, IPAddress logged. Toggle off sessionIPValidation in secMiddleware.py if seeing this frequently with Dynamic IP"}
+                        final_json = json.dumps(final_dic)
+                        return HttpResponse(final_json)
                 else:
-                    del request.session['userID']
-                    del request.session['ipAddr']
-                    logging.writeToFile(request.META.get('REMOTE_ADDR'))
-                    final_dic = {'error_message': "Session reuse detected, IPAddress logged.",
-                                 "errorMessage": "Session reuse detected, IPAddress logged."}
-                    final_json = json.dumps(final_dic)
-                    return HttpResponse(final_json)
-            else:
-                ipAddr = request.META.get('REMOTE_ADDR').split(':')[:3]
+                    ipAddr = request.META.get('REMOTE_ADDR').split(':')[:3]
 
-                if request.session['ipAddr'] == ipAddr:
-                    pass
-                else:
-                    del request.session['userID']
-                    del request.session['ipAddr']
-                    logging.writeToFile(request.META.get('REMOTE_ADDR'))
-                    final_dic = {'error_message': "Session reuse detected, IPAddress logged.",
-                                 "errorMessage": "Session reuse detected, IPAddress logged."}
-                    final_json = json.dumps(final_dic)
-                    return HttpResponse(final_json)
-        except:
-            pass
+                    if request.session['ipAddr'] == ipAddr:
+                        pass
+                    else:
+                        del request.session['userID']
+                        del request.session['ipAddr']
+                        logging.writeToFile(request.META.get('REMOTE_ADDR'))
+                        final_dic = {'error_message': "Session reuse detected, IPAddress logged. Toggle off sessionIPValidation in secMiddleware.py if seeing this frequently with Dynamic IP",
+                                     "errorMessage": "Session reuse detected, IPAddress logged. Toggle off sessionIPValidation in secMiddleware.py if seeing this frequently with Dynamic IP"}
+                        final_json = json.dumps(final_dic)
+                        return HttpResponse(final_json)
+            except:
+                pass
         if request.method == 'POST':
             try:
                 #logging.writeToFile(request.body)

--- a/plogical/csf.py
+++ b/plogical/csf.py
@@ -73,10 +73,10 @@ class CSF(multi.Thread):
 
             # install required packages for CSF perl and /usr/bin/host
             if ProcessUtilities.decideDistro() == ProcessUtilities.centos:
-                command = 'yum install bind-utils net-tools perl-libwww-perl.noarch perl-LWP-Protocol-https.noarch perl-GDGraph -y'
+                command = 'yum install bind-utils net-tools perl-libwww-perl.noarch perl-LWP-Protocol-https.noarch perl-GDGraph ipset -y'
                 ProcessUtilities.normalExecutioner(command)
             elif ProcessUtilities.decideDistro() == ProcessUtilities.ubuntu:
-                command = 'apt-get install dnsutils libwww-perl liblwp-protocol-https-perl libgd-graph-perl net-tools -y'
+                command = 'apt-get install dnsutils libwww-perl liblwp-protocol-https-perl libgd-graph-perl net-tools ipset -y'
                 ProcessUtilities.normalExecutioner(command)
                 command = 'ln -s /bin/systemctl /usr/bin/systemctl'
                 ProcessUtilities.normalExecutioner(command)
@@ -279,6 +279,10 @@ class CSF(multi.Thread):
                 #  Check the PT_LOAD_AVG minute Load Average (can be set to 1 5 or 15 and defaults to 5 if set otherwise) on the server every PT_LOAD seconds. Disabled
                 elif items.find('PT_LOAD =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('PT_LOAD = "0"\n')
+
+                #  Enable LF_IPSET for CSF for more efficient ipables rules with ipset
+                elif items.find('LF_IPSET =') > -1 and items.find('=') > -1 and (items[0] != '#'):
+                    writeToConf.writelines('LF_IPSET = "1"\n')
 
                 #  HTACCESS_LOG is ins main error.log
                 elif items.find('HTACCESS_LOG =') > -1 and items.find('=') > -1 and (items[0] != '#'):

--- a/plogical/csf.py
+++ b/plogical/csf.py
@@ -73,10 +73,10 @@ class CSF(multi.Thread):
 
             # install required packages for CSF perl and /usr/bin/host
             if ProcessUtilities.decideDistro() == ProcessUtilities.centos:
-                command = 'yum install bind-utils net-tools perl-libwww-perl.noarch perl-LWP-Protocol-https.noarch perl-GDGraph ipset -y'
+                command = 'yum install bind-utils net-tools perl-libwww-perl.noarch perl-LWP-Protocol-https.noarch perl-GDGraph -y'
                 ProcessUtilities.normalExecutioner(command)
             elif ProcessUtilities.decideDistro() == ProcessUtilities.ubuntu:
-                command = 'apt-get install dnsutils libwww-perl liblwp-protocol-https-perl libgd-graph-perl net-tools ipset -y'
+                command = 'apt-get install dnsutils libwww-perl liblwp-protocol-https-perl libgd-graph-perl net-tools -y'
                 ProcessUtilities.normalExecutioner(command)
                 command = 'ln -s /bin/systemctl /usr/bin/systemctl'
                 ProcessUtilities.normalExecutioner(command)
@@ -279,10 +279,6 @@ class CSF(multi.Thread):
                 #  Check the PT_LOAD_AVG minute Load Average (can be set to 1 5 or 15 and defaults to 5 if set otherwise) on the server every PT_LOAD seconds. Disabled
                 elif items.find('PT_LOAD =') > -1 and items.find('=') > -1 and (items[0] != '#'):
                     writeToConf.writelines('PT_LOAD = "0"\n')
-
-                #  Enable LF_IPSET for CSF for more efficient ipables rules with ipset
-                elif items.find('LF_IPSET =') > -1 and items.find('=') > -1 and (items[0] != '#'):
-                    writeToConf.writelines('LF_IPSET = "1"\n')
 
                 #  HTACCESS_LOG is ins main error.log
                 elif items.find('HTACCESS_LOG =') > -1 and items.find('=') > -1 and (items[0] != '#'):


### PR DESCRIPTION
Enable ipset to be installed when CSF installed for apt/yum. Enable ipset in CSF settings.

Source: https://portal.cloudunboxed.net/knowledgebase/22/Improve-CSF-iptables-performance-with-ipset.html
> Servers running iptables with CSF firewall can become slow and bogged down while processing the sometimes hundreds of IP addresses in CSF's iptables chains. Thankfully, it is possible to quickly and easily alleviate this slowdown by installing and configuring a took called ipset.
> 
> IP sets are a framework inside the Linux kernel that can store IP addresses, networks, TCP/UDP port numbers, MAC addresses - or combinations of some/all of the prior. These IP sets are stored in a fast and efficient manor that allows for quick access and searching, plus seamless updates to the IP sets without having to reload iptables.