### PR TITLE
Fixed --password issue

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -1555,7 +1555,7 @@ else
 						elif [[ "${1}" == 'r' ]] || [[ $1 == 'random' ]] ; then
 							ADMIN_PASS=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16 ; echo '')
 						else
-							if [ ${1} -lt 8 ] ; then
+							if [ ${#1} -lt 8 ] ; then
 								echo -e "\nPassword lenth less than 8 digital, please choose a more complicated password.\n"
 								exit
 							fi


### PR DESCRIPTION
- This fixes the length check for the argument length supplied to `--password`, specifically:
```./cyberpanel.sh: line 1554: [: testpassw0rd: integer expression expected```
- This also fixes passing the password value quoted:
```
sh install.sh -v ols -p 'testpassw0rd'
...
./cyberpanel.sh: 1: ./cyberpanel.sh: You: not found
```
