### PR TITLE
Rewriting install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,32 +1,38 @@
 #!/bin/sh
 
-OUTPUT=$(cat /etc/*release)
-if  echo $OUTPUT | grep -q "CentOS Linux 7" ; then
-	echo "Checking and installing curl and wget"
-yum install curl wget -y 1> /dev/null
-yum update curl wget ca-certificates -y 1> /dev/null
-		SERVER_OS="CentOS"
-elif echo $OUTPUT | grep -q "CentOS Linux 8" ; then
-	echo -e "\nDetecting Centos 8...\n"
-	SERVER_OS="CentOS8"
-yum install curl wget -y 1> /dev/null
-yum update curl wget ca-certificates -y 1> /dev/null
-elif echo $OUTPUT | grep -q "CloudLinux 7" ; then
-	echo "Checking and installing curl and wget"
-yum install curl wget -y 1> /dev/null
-yum update curl wget ca-certificates -y 1> /dev/null
-		SERVER_OS="CloudLinux"
-elif echo $OUTPUT | grep -q "Ubuntu 18.04" ; then
-apt install -y -qq wget curl
-		SERVER_OS="Ubuntu"
+if [ -f "/etc/os-release" ]; then 
+  . /etc/os-release
 else
-		echo -e "\nUnable to detect your OS...\n"
-		echo -e "\nCyberPanel is supported on Ubuntu 18.04, CentOS 7.x and CloudLinux 7.x...\n"
-		exit 1
+  ID="unsupported"
+  PRETTY_NAME="Your OS does not have a /etc/os-release file"
 fi
 
-rm -f cyberpanel.sh
-rm -f install.tar.gz
-curl --silent -o cyberpanel.sh "https://cyberpanel.sh/?dl&$SERVER_OS" 2>/dev/null
+if [ "$ID" = "ubuntu" ] && [ "$UBUNTU_CODENAME" = "bionic" ]; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt -q -y -o Dpkg::Options::=--force-confnew update
+  apt -q -y -o Dpkg::Options::=--force-confnew install wget curl
+  SERVER_OS="$NAME"
+elif [ "$ID" = "centos" ] || [ "$ID" = "cloudlinux" ]; then
+  case "$VERSION_ID" in
+    7|7.*)
+      yum install curl wget -y 1> /dev/null
+      yum update curl wget ca-certificates -y 1> /dev/null
+      SERVER_OS="$NAME"
+      ;;
+    8|8.*)
+      printf >&2 '\nCentOS 8/CloudLinux 8 support is currently experimental!\n'
+      yum install curl wget -y 1> /dev/null
+      yum update curl wget ca-certificates -y 1> /dev/null
+      SERVER_OS="${NAME}${VERSION_ID}"
+      ;;
+  esac
+else 
+  printf >&2 '\nYour OS -- %s -- is not currently supported!\n' "$PRETTY_NAME"
+  printf >&2 '\nCyberPanel is currently supported on Ubuntu 18.04, CentOS 7 and CloudLinux 7.\n'
+  exit 1
+fi
+
+rm -f cyberpanel.sh install.tar.gz 
+curl --silent -o cyberpanel.sh "https://cyberpanel.sh/?dl&${SERVER_OS}" 2>/dev/null
 chmod +x cyberpanel.sh
-./cyberpanel.sh $@
+./cyberpanel.sh "$@"


### PR DESCRIPTION
Putting some make-up on the install.sh script"

- This relies on the `/etc/os-release` file which is present on all modern distributions that you are currently supporting. More info on: https://www.freedesktop.org/software/systemd/man/os-release.html
- I've taken the liberty of including a warning message for CentOS 8 / CloudLinux 8
- I've also derived `SERVER_OS` from the proper strings. I suggest you end up using a variable directly from `/etc/os-release` instead, tough, as it's just extra-fluff right now, and it seems you are using it just for statistics purposes
- I have also switched to using `printf >&2`  to output the messages to `stderr` instead of `stdout` because they are technically warnings