### PR TITLE
Update MarkSafe version

### DIFF
--- a/requirments.txt
+++ b/requirments.txt
@@ -29,7 +29,7 @@ jmespath==0.9.3
 josepy==1.1.0
 jsonpatch==1.2
 jsonpointer==1.9
-MarkupSafe==0.11
+MarkupSafe==0.19
 mock==2.0.0
 mysqlclient==1.4.6
 paramiko==2.6.0


### PR DESCRIPTION
Updated MarkSafe version to 0.19 to fix this issue https://forums.cyberpanel.net/discussion/4051/issue-with-python-markupsafe-module-on-install#latest