### PR TITLE
fix ius el7 repo

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -445,7 +445,7 @@ if [[ $DEV == "ON" ]] ; then
 			if [[ $SERVER_COUNTRY == "CN" ]] ; then
 				wget -O /etc/yum.repos.d/ius.repo https://$DOWNLOAD_SERVER/ius/ius.repo
 			else
-      	yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+      	yum -y install https://repo.ius.io/ius-release-el7.rpm
 			fi
 			yum -y install python36u python36u-pip python36u-devel
 			check_return


### PR DESCRIPTION
replace 
https://centos7.iuscommunity.org/ius-release.rpm 
with 
https://repo.ius.io/ius-release-el7.rpm
Which cause install fail on centos 7