### PR TITLE
bug fix: loading plugins to the interface list

### DIFF
--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -919,6 +919,7 @@
                                 <li><a href="{% url 'installed' %}"
                                        title="{% trans 'Installed Plugins' %}"><span>{% trans "Installed" %}</span></a>
                                 </li>
+                                {# pluginsList #}
                             </ul>
 
                         </div><!-- .sidebar-submenu -->

--- a/pluginInstaller/pluginInstaller.py
+++ b/pluginInstaller/pluginInstaller.py
@@ -75,10 +75,11 @@ class pluginInstaller:
         writeToFile = open("/usr/local/CyberCP/baseTemplate/templates/baseTemplate/index.html", 'w')
 
         for items in data:
-            if items.find("{% url 'installed' %}") > -1:
+            if items.find("{# pluginsList #}") > -1:
                 writeToFile.writelines(items)
+                writeToFile.writelines("                                ")
                 writeToFile.writelines(
-                    '<li><a href="{% url \'' + pluginName + '\' %}" title="{% trans \'' + pluginName + '\' %}"><span>{% trans "' + pluginName + '" %}</span></a></li>')
+                    '<li><a href="{% url \'' + pluginName + '\' %}" title="{% trans \'' + pluginName + '\' %}"><span>{% trans "' + pluginName + '" %}</span></a></li>\n')
             else:
                 writeToFile.writelines(items)
 


### PR DESCRIPTION
temp quick fix for [/how-to-recover-from-beatifulnames-uninstall-bug](https://forums.cyberpanel.net/discussion/4535/how-to-recover-from-beatifulnames-uninstall-bug#latest) until this can be loaded into the database
