### PR TITLE
fix createUser and modifyUser securityLevel defaults

### DIFF
--- a/CyberCP/SecurityLevel.py
+++ b/CyberCP/SecurityLevel.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class SecurityLevel(Enum):
+    HIGH = 0
+    LOW = 1
+
+    @staticmethod
+    def list():
+        return list(map(lambda s: s.name, SecurityLevel))

--- a/loginSystem/models.py
+++ b/loginSystem/models.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
-
-
 from django.db import models
+from CyberCP.SecurityLevel import SecurityLevel
+
 
 # Create your models here.
-
 class ACL(models.Model):
    name = models.CharField(unique=True,max_length = 50)
    adminStatus = models.IntegerField(default=0)
@@ -85,7 +83,10 @@ class Administrator(models.Model):
    owner = models.IntegerField(default=1)
    token = models.CharField(max_length=500, default='None')
    api = models.IntegerField(default=0)
-   securityLevel = models.IntegerField(default=0)
+   securityLevel = models.IntegerField(
+      default=0,
+      choices=[(tag, tag.value) for tag in SecurityLevel]
+   )
    state = models.CharField(max_length=10, default='ACTIVE')
 
    initWebsitesLimit = models.IntegerField(default=0)

--- a/static/userManagment/userManagment.js
+++ b/static/userManagment/userManagment.js
@@ -188,7 +188,8 @@ app.controller('modifyUser', function ($scope, $http) {
                 $scope.firstName = userDetails.firstName;
                 $scope.lastName = userDetails.lastName;
                 $scope.email = userDetails.email;
-                $scope.secLevel = userDetails.securityLevel;
+                $scope.securityLevel = userDetails.securityLevel;
+                $scope.currentSecurityLevel = userDetails.securityLevel;
                 $scope.twofa = Boolean(userDetails.twofa);
 
                 qrCode.set({

--- a/userManagment/static/userManagment/userManagment.js
+++ b/userManagment/static/userManagment/userManagment.js
@@ -188,7 +188,8 @@ app.controller('modifyUser', function ($scope, $http) {
                 $scope.firstName = userDetails.firstName;
                 $scope.lastName = userDetails.lastName;
                 $scope.email = userDetails.email;
-                $scope.secLevel = userDetails.securityLevel;
+                $scope.securityLevel = userDetails.securityLevel;
+                $scope.currentSecurityLevel = userDetails.securityLevel;
                 $scope.twofa = Boolean(userDetails.twofa);
 
                 qrCode.set({

--- a/userManagment/templates/userManagment/createUser.html
+++ b/userManagment/templates/userManagment/createUser.html
@@ -106,9 +106,9 @@
                         <div ng-hide="acctDetailsFetched" class="form-group">
                             <label class="col-sm-3 control-label">{% trans "Security Level" %}</label>
                             <div class="col-sm-6">
-                                <select ng-change="fetchUserDetails()" ng-model="securityLevel" class="form-control">
-                                    <option>HIGH</option>
-                                    <option>LOW</option>
+                                <select ng-init="securityLevels={{ securityLevels }};securityLevel='HIGH'"
+                                        ng-model="securityLevel" ng-options="s for s in securityLevels track by s"
+                                        class="form-control">
                                 </select>
                             </div>
                         </div>

--- a/userManagment/templates/userManagment/modifyUser.html
+++ b/userManagment/templates/userManagment/modifyUser.html
@@ -101,13 +101,13 @@
                         <div ng-hide="acctDetailsFetched" class="form-group">
                             <label class="col-sm-3 control-label">{% trans "Security Level" %}</label>
                             <div class="col-sm-6">
-                                <select ng-change="fetchUserDetails()" ng-model="securityLevel" class="form-control">
-                                    <option>HIGH</option>
-                                    <option>LOW</option>
+                                <select ng-init="securityLevels={{ securityLevels }}"
+                                        ng-model="securityLevel" ng-options="s for s in securityLevels track by s"
+                                        class="form-control">
                                 </select>
                             </div>
                             <div class="col-sm-3">
-                                Currently: {$ secLevel $}
+                                Currently: {$ currentSecurityLevel $}
                             </div>
                         </div>
 

--- a/userManagment/views.py
+++ b/userManagment/views.py
@@ -11,6 +11,7 @@ from plogical import CyberCPLogFileWriter as logging
 from plogical.acl import ACLManager
 from plogical.virtualHostUtilities import virtualHostUtilities
 from CyberCP.secMiddleware import secMiddleware
+from CyberCP.SecurityLevel import SecurityLevel
 
 # Create your views here.
 
@@ -58,13 +59,16 @@ def createUser(request):
 
         if currentACL['admin'] == 1:
             aclNames = ACLManager.unFileteredACLs()
-            return render(request, 'userManagment/createUser.html', {'aclNames': aclNames})
+            return render(request, 'userManagment/createUser.html',
+                          {'aclNames': aclNames, 'securityLevels': SecurityLevel.list()})
         elif currentACL['changeUserACL'] == 1:
             aclNames = ACLManager.unFileteredACLs()
-            return render(request, 'userManagment/createUser.html', {'aclNames': aclNames})
+            return render(request, 'userManagment/createUser.html',
+                          {'aclNames': aclNames, 'securityLevels': SecurityLevel.list()})
         elif currentACL['createNewUser'] == 1:
             aclNames = ['user']
-            return render(request, 'userManagment/createUser.html', {'aclNames': aclNames})
+            return render(request, 'userManagment/createUser.html',
+                          {'aclNames': aclNames, 'securityLevels': SecurityLevel.list()})
         else:
             return ACLManager.loadError()
 
@@ -244,11 +248,13 @@ def submitUserCreation(request):
         json_data = json.dumps(data_ret)
         return HttpResponse(json_data)
 
+
 def modifyUsers(request):
     try:
         userID = request.session['userID']
-        adminNames = ACLManager.loadAllUsers(userID)
-        return render(request, 'userManagment/modifyUser.html', {"acctNames": adminNames})
+        userNames = ACLManager.loadAllUsers(userID)
+        return render(request, 'userManagment/modifyUser.html',
+                      {"acctNames": userNames, 'securityLevels': SecurityLevel.list()})
     except KeyError:
         return redirect(loadLoginPage)
 
@@ -281,12 +287,6 @@ def fetchUserDetails(request):
                 email = user.email
 
                 websitesLimit = user.initWebsitesLimit
-                securityLevel = ''
-
-                if user.securityLevel == secMiddleware.LOW:
-                    securityLevel = 'Low'
-                else:
-                    securityLevel = 'High'
 
                 import pyotp
 
@@ -303,7 +303,7 @@ def fetchUserDetails(request):
                     "email": email,
                     "acl": user.acl.name,
                     "websitesLimit": websitesLimit,
-                    "securityLevel": securityLevel,
+                    "securityLevel": SecurityLevel(user.securityLevel).name,
                     "otpauth": otpauth,
                     'twofa': user.twoFA
                 }


### PR DESCRIPTION
currently the createUser page does not populate with any Security Level
currently the modifyUser page does not have any Security Level selected after choosing a user to modify, and loading the existing data

fix for both of them

updated createUser to have populated default security level of HIGH
updated modifyUser to populate the security level with the current security level of the user
updated both select boxes to be populated from view with list of levels
enum for SecurityLevel for this use case, and for future use cases
updated Administrator model to reflect SecurityLevel enum choices as well as 0,1 (the current way)