### PR TITLE
fixed path to where static files are served

### DIFF
--- a/pluginInstaller/pluginInstaller.py
+++ b/pluginInstaller/pluginInstaller.py
@@ -94,7 +94,7 @@ class pluginInstaller:
     def staticContent():
         currentDir = os.getcwd()
 
-        command = "rm -rf /usr/local/lscp/cyberpanel/static"
+        command = "rm -rf /usr/local/CyberCP/public/static/*"
         subprocess.call(shlex.split(command))
 
         os.chdir('/usr/local/CyberCP')
@@ -102,7 +102,7 @@ class pluginInstaller:
         command = "/usr/local/CyberCP/bin/python manage.py collectstatic --noinput"
         subprocess.call(shlex.split(command))
 
-        command = "mv /usr/local/CyberCP/static /usr/local/lscp/cyberpanel"
+        command = "cp -R  /usr/local/CyberCP/static/* /usr/local/CyberCP/public/static/"
         subprocess.call(shlex.split(command))
 
 


### PR DESCRIPTION
updated static files path to use /usr/local/CyberCP/public/static instead of /usr/local/lscp/cyberpanel/static which was left over from when gunicorn was in use

please let me know if this is incorrect.

currently running collectstatic and placing static files in /usr/local/lscp/cyberpanel/static has no effect, you can even delete /usr/local/lscp/cyberpanel/static and everything works

while replacing /usr/local/CyberCP/public/static and referencing those static files does work.