### PR TITLE
Ui fix duplicate backup path conflicts

### DIFF
--- a/baseTemplate/static/baseTemplate/assets/finalJS/final.js
+++ b/baseTemplate/static/baseTemplate/assets/finalJS/final.js
@@ -883,8 +883,7 @@ $(document).ready(function() {
         });
 
         //automatically open the current path
-        var path = window.location.pathname.split('/');
-        path = path[path.length-1];
+        var path = window.location.pathname
         if (path !== undefined) {
             $("#sidebar-menu").find("a[href$='" + path + "']").addClass('sfActive');
             $("#sidebar-menu").find("a[href$='" + path + "']").parents().eq(3).superclick('show');

--- a/static/baseTemplate/assets/finalJS/final.js
+++ b/static/baseTemplate/assets/finalJS/final.js
@@ -883,10 +883,13 @@ $(document).ready(function() {
         });
 
         //automatically open the current path
-        var path = window.location.pathname
+        let path = window.location.pathname;
         if (path !== undefined) {
-            $("#sidebar-menu").find("a[href$='" + path + "']").addClass('sfActive');
-            $("#sidebar-menu").find("a[href$='" + path + "']").parents().eq(3).superclick('show');
+            let menuItem = $("#sidebar-menu").find("a[href$='" + path + "']");
+            if (menuItem !== undefined) {
+                menuItem.addClass('sfActive');
+                menuItem.parents().eq(3).superclick('show');
+            }
         }
 
     });

--- a/static/baseTemplate/assets/finalJS/final.js
+++ b/static/baseTemplate/assets/finalJS/final.js
@@ -883,8 +883,7 @@ $(document).ready(function() {
         });
 
         //automatically open the current path
-        var path = window.location.pathname.split('/');
-        path = path[path.length-1];
+        var path = window.location.pathname
         if (path !== undefined) {
             $("#sidebar-menu").find("a[href$='" + path + "']").addClass('sfActive');
             $("#sidebar-menu").find("a[href$='" + path + "']").parents().eq(3).superclick('show');


### PR DESCRIPTION
both Backup and Incremental Backup have the same last path name, this caused ui conflicts when clicking on the items in Backups, where Incremental Backups submenu would be active up due to it being loaded last.
/backup/scheduleBackup
/backup/backupDestinations
/IncrementalBackups/backupDestinations
/IncrementalBackups/scheduleBackups

Updated final.js to use the full path to match which sidebar should be opened on page load.