### PR TITLE
UI fix duplicate path names for active menu detection

### DIFF
--- a/baseTemplate/static/baseTemplate/assets/finalJS/final.js
+++ b/baseTemplate/static/baseTemplate/assets/finalJS/final.js
@@ -883,11 +883,13 @@ $(document).ready(function() {
         });
 
         //automatically open the current path
-        var path = window.location.pathname.split('/');
-        path = path[path.length-1];
+        let path = window.location.pathname;
         if (path !== undefined) {
-            $("#sidebar-menu").find("a[href$='" + path + "']").addClass('sfActive');
-            $("#sidebar-menu").find("a[href$='" + path + "']").parents().eq(3).superclick('show');
+            let menuItem = $("#sidebar-menu").find("a[href$='" + path + "']");
+            if (menuItem !== undefined) {
+                menuItem.addClass('sfActive');
+                menuItem.parents().eq(3).superclick('show');
+            }
         }
 
     });

--- a/static/baseTemplate/assets/finalJS/final.js
+++ b/static/baseTemplate/assets/finalJS/final.js
@@ -883,11 +883,13 @@ $(document).ready(function() {
         });
 
         //automatically open the current path
-        var path = window.location.pathname.split('/');
-        path = path[path.length-1];
+        let path = window.location.pathname;
         if (path !== undefined) {
-            $("#sidebar-menu").find("a[href$='" + path + "']").addClass('sfActive');
-            $("#sidebar-menu").find("a[href$='" + path + "']").parents().eq(3).superclick('show');
+            let menuItem = $("#sidebar-menu").find("a[href$='" + path + "']");
+            if (menuItem !== undefined) {
+                menuItem.addClass('sfActive');
+                menuItem.parents().eq(3).superclick('show');
+            }
         }
 
     });


### PR DESCRIPTION
adjusted the active menu detection to use full path since both backups and Inc backups have the same page name, this caused both menu items to attempt to be active at the same time.