### PR TITLE
fixing install Mautic link and title.

### DIFF
--- a/websiteFunctions/templates/websiteFunctions/website.html
+++ b/websiteFunctions/templates/websiteFunctions/website.html
@@ -1049,8 +1049,8 @@
                             </div>
 
                             <div class="col-md-3 panel-body">
-                                <a href="{$ installMagentoURL $}" target="_blank"
-                                   title="{% trans 'Install Magento' %}">
+                                <a href="{$ installMauticURL $}" target="_blank"
+                                   title="{% trans 'Install Mautic' %}">
                                     <img src="{% static 'images/icons/mautic.png' %}" width="65" class="mr-10">
                                 </a>
                                 <a href="{$ installMauticURL $}" target="_blank"


### PR DESCRIPTION
the Mautic image button refers to install Magento both as href and title