### PR TITLE
Removing duplicate file so no collisions on case insensitive filesystems

### DIFF
--- a/install/cyberpanel.repo
+++ b/install/cyberpanel.repo
@@ -1,5 +1,0 @@
-[CyberPanel]
-name=CyberPanel
-baseurl=https://rep.cyberpanel.net/
-gpgkey=https://rep.cyberpanel.net/RPM-GPG-KEY-cyberpanel
-gpgcheck=1

--- a/install/unInstall.py
+++ b/install/unInstall.py
@@ -14,7 +14,7 @@ class unInstallCyberPanel:
     def unInstallCyberPanelRepo(self):
 
         try:
-            copyPath = "/etc/yum.repos.d/cyberpanel.repo"
+            copyPath = "/etc/yum.repos.d/CyberPanel.repo"
             os.remove(copyPath)
 
         except OSError as msg:


### PR DESCRIPTION
Removing duplicate repo files. This causes collisions in git on case-insensitive filesystems.

In install directory there is two files "CyberPanel.repo", and "cyberpanel.repo".

Only one is necessary.