### PR TITLE
Add 'From' header to email message if missing

### DIFF
--- a/plogical/CyberCPLogFileWriter.py
+++ b/plogical/CyberCPLogFileWriter.py
@@ -17,7 +17,7 @@ class CyberCPLogFileWriter:
 
             return message
         except BaseException as msg:
-            return "Can not add From header to message."
+            CyberCPLogFileWriter.writeToFile(str(msg) + ' [AddFromHeader]')
 
     @staticmethod
     def SendEmail(sender, receivers, message, subject=None, type=None):

--- a/plogical/CyberCPLogFileWriter.py
+++ b/plogical/CyberCPLogFileWriter.py
@@ -8,6 +8,18 @@ class CyberCPLogFileWriter:
     fileName = "/home/cyberpanel/error-logs.txt"
 
     @staticmethod
+    def AddFromHeader(sender, message):
+        try:
+            import re
+
+            if not re.search('^From: ', message, re.MULTILINE):
+                message = 'From: {}\n{}'.format(sender, message)
+
+            return message
+        except BaseException as msg:
+            return "Can not add From header to message."
+
+    @staticmethod
     def SendEmail(sender, receivers, message, subject=None, type=None):
         try:
             smtpPath = '/home/cyberpanel/smtpDetails'
@@ -29,9 +41,12 @@ class CyberCPLogFileWriter:
                 if subject != None:
                     message = 'Subject: {}\n\n{}'.format(subject, message)
 
+                message = CyberCPLogFileWriter.AddFromHeader(sender, message)
                 smtpServer.sendmail(smtpUserName, receivers, message)
             else:
                 smtpObj = smtplib.SMTP('localhost')
+
+                message = CyberCPLogFileWriter.AddFromHeader(sender, message)
                 smtpObj.sendmail(sender, receivers, message)
         except BaseException as msg:
             CyberCPLogFileWriter.writeToFile(str(msg))


### PR DESCRIPTION
Adds 'From' header to SendEmail message if missing.

**Reason**
Gmail rejects messages without a From header, with the following error:
"Our system has detected that this message is 5.7.1 not RFC 5322 compliant: 5.7.1 'From' header is missing."