### PR TITLE
Fixed managePDNS: select pdns.conf path according to OS; removed unne…

### DIFF
--- a/dns/dnsManager.py
+++ b/dns/dnsManager.py
@@ -140,7 +140,7 @@ class DNSManager:
 
             zoneDomain = data['zoneDomain']
 
-            newZone = Domains(admin=admin, name=zoneDomain, type="NATIVE")
+            newZone = Domains(admin=admin, name=zoneDomain, type="MASTER")
             newZone.save()
 
             content = "ns1." + zoneDomain + " hostmaster." + zoneDomain + " 1 10800 3600 604800 3600"

--- a/manageServices/serviceManager.py
+++ b/manageServices/serviceManager.py
@@ -93,6 +93,9 @@ class ServiceManager:
 
                 counter = 0
 
+                tempPath = "/home/cyberpanel/" + str(randint(1000, 9999))
+                writeToFile = open(tempPath, 'w')
+
                 for items in data:
                     if items.find('allow-axfr-ips') > -1:
                         continue
@@ -111,10 +114,6 @@ class ServiceManager:
 
                     counter = counter + 1
 
-                tempPath = "/home/cyberpanel/" + str(randint(1000, 9999))
-                writeToFile = open(tempPath, 'w')
-
-                for items in data:
                     writeToFile.writelines(items  + '\n')
 
                 slaveData = """
@@ -128,7 +127,7 @@ class ServiceManager:
                 slave-cycle-interval=60
                 setgid=pdns
                 setuid=pdns
-                superslave=yes        
+                superslave=yes
                 """
 
                 writeToFile.writelines(slaveData)

--- a/manageServices/serviceManager.py
+++ b/manageServices/serviceManager.py
@@ -22,7 +22,11 @@ class ServiceManager:
 
     def managePDNS(self):
         type = self.extraArgs['type']
-        path = '/etc/pdns/pdns.conf'
+
+        if ProcessUtilities.decideDistro() == ProcessUtilities.centos or ProcessUtilities.decideDistro() == ProcessUtilities.cent8:
+            path = '/etc/pdns/pdns.conf'
+        else:
+            path = '/etc/powerdns/pdns.conf'
 
         data = ProcessUtilities.outputExecutioner('sudo cat ' + path).splitlines()
         #data = subprocess.check_output(shlex.split('sudo cat ' + path)).decode("utf-8").splitlines()
@@ -35,8 +39,9 @@ class ServiceManager:
             ipStringNoSubnet = ''
 
             for items in SlaveServers.objects.all():
-                ipsString = ipsString + '%s/32, ' % (items.slaveServerIP)
-                ipStringNoSubnet = ipStringNoSubnet + '%s, ' % (items.slaveServerIP)
+                if items.slaveServerIP:
+                    ipsString = ipsString + '%s/32, ' % (items.slaveServerIP)
+                    ipStringNoSubnet = ipStringNoSubnet + '%s, ' % (items.slaveServerIP)
 
             ipsString = ipsString.rstrip(', ')
             ipStringNoSubnet = ipStringNoSubnet.rstrip(', ')
@@ -74,6 +79,9 @@ class ServiceManager:
             writeToFile.writelines('disable-axfr=no\n')
             writeToFile.writelines('master=yes\n')
             writeToFile.close()
+
+            command = 'sudo mv ' + tempPath + ' ' + path
+            ProcessUtilities.executioner(command)
         else:
             import os
 
@@ -110,18 +118,18 @@ class ServiceManager:
                     writeToFile.writelines(items  + '\n')
 
                 slaveData = """
-slave=yes
-daemon=yes
-disable-axfr=yes
-guardian=yes
-local-address=0.0.0.0
-local-port=53
-master=no
-slave-cycle-interval=60
-setgid=pdns
-setuid=pdns
-superslave=yes        
-"""
+                slave=yes
+                daemon=yes
+                disable-axfr=yes
+                guardian=yes
+                local-address=0.0.0.0
+                local-port=53
+                master=no
+                slave-cycle-interval=60
+                setgid=pdns
+                setuid=pdns
+                superslave=yes        
+                """
 
                 writeToFile.writelines(slaveData)
                 writeToFile.close()
@@ -146,14 +154,14 @@ superslave=yes
             repoPath = '/etc/yum.repos.d/elasticsearch.repo'
 
             content = '''[elasticsearch]
-name=Elasticsearch repository for 7.x packages
-baseurl=https://artifacts.elastic.co/packages/7.x/yum
-gpgcheck=1
-gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
-enabled=0
-autorefresh=1
-type=rpm-md
-'''
+            name=Elasticsearch repository for 7.x packages
+            baseurl=https://artifacts.elastic.co/packages/7.x/yum
+            gpgcheck=1
+            gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+            enabled=0
+            autorefresh=1
+            type=rpm-md
+            '''
 
             writeToFile = open(repoPath, 'w')
             writeToFile.write(content)
@@ -317,4 +325,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
1. Script now selects the right pdns.conf path according to OS;
2. Removed unnecessary addition of /32 (subnets) if IP is not set. Previously line allow-axfr-ips had "<IP>/32, /32, /32" and PDNS was unable to start, because of empty IP's in the line;
3. In master configuration, now it actually moves the temp file to its correct location (previously temp file was moved only in slave configuration, therefore for a lot of people master/slave configuration never worked).

These changes were tested and are working in ubuntu.