### PR TITLE
Rename Elastic Search to Elasticsearch

### DIFF
--- a/manageServices/views.py
+++ b/manageServices/views.py
@@ -276,7 +276,7 @@ def manageApplications(request):
     else:
         rInstalled = 'Not-Installed'
 
-    elasticSearch = {'image': '/static/manageServices/images/elastic-search.png', 'name': 'Elastic Search',
+    elasticSearch = {'image': '/static/manageServices/images/elastic-search.png', 'name': 'Elasticsearch',
                      'installed': installed}
     redis = {'image': '/static/manageServices/images/redis.png', 'name': 'Redis',
              'installed': rInstalled}


### PR DESCRIPTION
I noticed in the view the spelling is incorrect so this PR fixes that. The proper spelling has no space and the "s" is not capitalized. See https://www.elastic.co/legal/trademarks for proper spelling and usage.