### PR TITLE
improved error message for self signed SSL

### DIFF
--- a/plogical/sslUtilities.py
+++ b/plogical/sslUtilities.py
@@ -390,7 +390,7 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None):
 
             if sslUtilities.installSSLForDomain(domain) == 1:
                 logging.CyberCPLogFileWriter.writeToFile("Self signed SSL issued for " + domain + ".")
-                return [1, "None"]
+                return [0, "Self signed certificate was issued. [issueSSLForDomain]"]
             else:
                 return [0, "210 Failed to install SSL for domain. [issueSSLForDomain]"]
 


### PR DESCRIPTION
Problem:
When cyberpanel fails to get a valid SSL certificate from Let's Encrypt, it will generate a self signed certificate.
An error message is logged to the error log, but a normal success message is sent to the user and displayed in the web UI.

The user should be informed right away that the cert generated was self signed, since chrome and firefox will give warning in the browser for most self signed certificates.

Solution:
Give the user a message in the control panel that will indicate that a self signed cert was generated. This way they can investigate further if the desire.