### PR TITLE
File manager logo returns user back to website panel.

### DIFF
--- a/filemanager/templates/filemanager/index.html
+++ b/filemanager/templates/filemanager/index.html
@@ -41,7 +41,7 @@
 
 <nav id="navBar" class="navbar navbar-expand-lg navbar-light bg-light">
     <div class="header-logo">
-        <a href="#"><img src="{% static 'filemanager/images/fileManager.png' %}"> <span style="display: none" id="domainNameInitial">{{ domainName }}</span></a>
+        <a href="/websites/{{ domainName }}"><img src="{% static 'filemanager/images/fileManager.png' %}"> <span style="display: none" id="domainNameInitial">{{ domainName }}</span></a>
     </div>
     <!--- second bar ---->
 


### PR DESCRIPTION
Since the file manager link uses the same frame and does not open in new tab, I think it is worth providing a way for the user to get back to the website panel.  The logo doesn't go anywhere so it makes sense to allow it to take them back to the selected website panel. 