### PR TITLE
Update Latest Core Rule Set

### DIFF
--- a/plogical/modSec.py
+++ b/plogical/modSec.py
@@ -416,7 +416,7 @@ modsecurity_rules_file /usr/local/lsws/conf/modsec/rules.conf
             if os.path.exists('owasp.tar.gz'):
                 os.remove('owasp.tar.gz')
 
-            command = "wget https://github.com/SpiderLabs/owasp-modsecurity-crs/archive/v3.2/master.zip -O /usr/local/lsws/conf/modsec/owasp.zip"
+            command = "wget https://github.com/coreruleset/coreruleset/archive/v3.3.2/master.zip -O /usr/local/lsws/conf/modsec/owasp.zip"
             result = subprocess.call(shlex.split(command))
 
             if result != 0:


### PR DESCRIPTION
The OWASP ModSecurity Core Rule Set (CRS) has moved to https://github.com/coreruleset/coreruleset.

So we also should change the URL address with the latest one. 

OLS and Lsws ent are both compatible with Core Rule Set.