### PR TITLE
Fixed watchdog PowerDNS service name.

### DIFF
--- a/CPScripts/watchdog.sh
+++ b/CPScripts/watchdog.sh
@@ -137,7 +137,7 @@ elif [[ $1 == "web" ]] || [[ $1 == "lsws" ]] || [[ $1 == "litespeed" ]] || [[ $1
 	NAME="lsws"
 	echo "Watchdog on LiteSpeed is started up ..."
 elif [[ $1 == "powerdns" ]] || [[ $1 == "dns" ]] ; then
-	NAME="powerdns"
+	NAME="pdns"
 	echo "Watchdog on PowerDNS is starting up ..."
 elif [[ $1 == "dovecot" ]] || [[ $1 == "imap" ]] || [[ $1 == "pop3" ]]; then
 	NAME="dovecot"


### PR DESCRIPTION
Sorry, Usman, it appears I accidentally used **powerdns** as the service name, not the correct **pdns**.
Simple but stupid mistake, I tested everything on a test install that didn't have the watchdog emailing service failure. When I copied it onto my proper webserver, it emailed me every minute.

I hope I have better luck when I try to add IPv6 support.