### PR TITLE
ManagePHP: Add lsphp-sodium extension

### DIFF
--- a/install/installCyberPanel.py
+++ b/install/installCyberPanel.py
@@ -191,7 +191,7 @@ class InstallCyberPanel:
             command = 'DEBIAN_FRONTEND=noninteractive apt-get -y install ' \
                       'lsphp7? lsphp7?-common lsphp7?-curl lsphp7?-dev lsphp7?-imap lsphp7?-intl lsphp7?-json ' \
                       'lsphp7?-ldap lsphp7?-mysql lsphp7?-opcache lsphp7?-pspell lsphp7?-recode ' \
-                      'lsphp7?-sqlite3 lsphp7?-tidy'
+                      'lsphp7?-sqlite3 lsphp7?-tidy lsphp7?-sodium'
 
             os.system(command)
 
@@ -218,7 +218,7 @@ class InstallCyberPanel:
             command = 'yum install -y lsphp72 lsphp72-json lsphp72-xmlrpc lsphp72-xml lsphp72-soap lsphp72-snmp ' \
                       'lsphp72-recode lsphp72-pspell lsphp72-process lsphp72-pgsql lsphp72-pear lsphp72-pdo lsphp72-opcache ' \
                       'lsphp72-odbc lsphp72-mysqlnd lsphp72-mcrypt lsphp72-mbstring lsphp72-ldap lsphp72-intl lsphp72-imap ' \
-                      'lsphp72-gmp lsphp72-gd lsphp72-enchant lsphp72-dba  lsphp72-common  lsphp72-bcmath'
+                      'lsphp72-gmp lsphp72-gd lsphp72-enchant lsphp72-dba  lsphp72-common  lsphp72-bcmath lsphp72-sodium'
 
             install.preFlightsChecks.call(command, self.distro, command, command, 1, 0, os.EX_OSERR)
 
@@ -227,7 +227,7 @@ class InstallCyberPanel:
             command = 'yum install -y lsphp73 lsphp73-json lsphp73-xmlrpc lsphp73-xml lsphp73-tidy lsphp73-soap lsphp73-snmp ' \
                       'lsphp73-recode lsphp73-pspell lsphp73-process lsphp73-pgsql lsphp73-pear lsphp73-pdo lsphp73-opcache ' \
                       'lsphp73-odbc lsphp73-mysqlnd lsphp73-mcrypt lsphp73-mbstring lsphp73-ldap lsphp73-intl lsphp73-imap ' \
-                      'lsphp73-gmp lsphp73-gd lsphp73-enchant lsphp73-dba  lsphp73-common  lsphp73-bcmath'
+                      'lsphp73-gmp lsphp73-gd lsphp73-enchant lsphp73-dba  lsphp73-common  lsphp73-bcmath lsphp73-sodium'
 
             install.preFlightsChecks.call(command, self.distro, command, command, 1, 0, os.EX_OSERR)
 
@@ -235,7 +235,7 @@ class InstallCyberPanel:
             command = 'yum install -y lsphp74 lsphp74-json lsphp74-xmlrpc lsphp74-xml lsphp74-tidy lsphp74-soap lsphp74-snmp ' \
                       'lsphp74-recode lsphp74-pspell lsphp74-process lsphp74-pgsql lsphp74-pear lsphp74-pdo lsphp74-opcache ' \
                       'lsphp74-odbc lsphp74-mysqlnd lsphp74-mcrypt lsphp74-mbstring lsphp74-ldap lsphp74-intl lsphp74-imap ' \
-                      'lsphp74-gmp lsphp74-gd lsphp74-enchant lsphp74-dba lsphp74-common  lsphp74-bcmath'
+                      'lsphp74-gmp lsphp74-gd lsphp74-enchant lsphp74-dba lsphp74-common  lsphp74-bcmath lsphp74-sodium'
 
             install.preFlightsChecks.call(command, self.distro, command, command, 1, 0, os.EX_OSERR)
 

--- a/managePHP/php72.xml
+++ b/managePHP/php72.xml
@@ -272,4 +272,10 @@
          <status>0</status>
     </extension>
 
+    <extension>
+         <extensionName>lsphp72-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
 </php>

--- a/managePHP/php73.xml
+++ b/managePHP/php73.xml
@@ -272,4 +272,10 @@
          <status>0</status>
     </extension>
 
+    <extension>
+         <extensionName>lsphp73-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
 </php>

--- a/managePHP/php74.xml
+++ b/managePHP/php74.xml
@@ -272,4 +272,10 @@
          <status>0</status>
     </extension>
 
+    <extension>
+         <extensionName>lsphp74-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
 </php>

--- a/managePHP/php80.xml
+++ b/managePHP/php80.xml
@@ -272,4 +272,10 @@
          <status>0</status>
     </extension>
 
+    <extension>
+         <extensionName>lsphp80-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
 </php>

--- a/managePHP/ubuntuphp72.xml
+++ b/managePHP/ubuntuphp72.xml
@@ -122,4 +122,10 @@
          <status>0</status>
      </extension>
 
+    <extension>
+         <extensionName>lsphp72-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
 </php>

--- a/managePHP/ubuntuphp73.xml
+++ b/managePHP/ubuntuphp73.xml
@@ -122,4 +122,10 @@
          <status>0</status>
      </extension>
 
+    <extension>
+         <extensionName>lsphp73-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
 </php>

--- a/managePHP/ubuntuphp74.xml
+++ b/managePHP/ubuntuphp74.xml
@@ -122,4 +122,10 @@
          <status>0</status>
      </extension>
 
+    <extension>
+         <extensionName>lsphp74-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
 </php>

--- a/managePHP/ubuntuphp80.xml
+++ b/managePHP/ubuntuphp80.xml
@@ -122,4 +122,10 @@
          <status>0</status>
      </extension>
 
+    <extension>
+         <extensionName>lsphp80-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
 </php>


### PR DESCRIPTION
Add lsphp-sodium extension required by Magento

```
lsphp72-sodium.x86_64                     7.2.34-1.el7                   litespeed
lsphp73-sodium.x86_64                     7.3.29-1.el7                   litespeed
lsphp74-sodium.x86_64                     7.4.22-1.el7                   litespeed
lsphp80-sodium.x86_64                     8.0.9-1.el7                    litespeed
```