### PR TITLE
Removing duplicate file so no collisions on case insensitive filesystems

### DIFF
--- a/install/cyberpanel.repo
+++ b/install/cyberpanel.repo
@@ -1,5 +1,0 @@
-[CyberPanel]
-name=CyberPanel
-baseurl=https://rep.cyberpanel.net/
-gpgkey=https://rep.cyberpanel.net/RPM-GPG-KEY-cyberpanel
-gpgcheck=1

--- a/install/unInstall.py
+++ b/install/unInstall.py
@@ -14,7 +14,7 @@ class unInstallCyberPanel:
     def unInstallCyberPanelRepo(self):
 
         try:
-            copyPath = "/etc/yum.repos.d/cyberpanel.repo"
+            copyPath = "/etc/yum.repos.d/CyberPanel.repo"
             os.remove(copyPath)
 
         except OSError as msg:


### PR DESCRIPTION
Rerequesting #403 & #449 on latest dev branch.

@myst3k explained very well.

There were 2 references to `CyberPanel.repo` and only 1 to `cyberpanel.repo`, plus @myst3k also deleted the lowercase one, so that's why `cyberpanel.repo` gets the boot.