### PR TITLE
enforce disk quotation limit only in public_html

### DIFF
--- a/plogical/IncScheduler.py
+++ b/plogical/IncScheduler.py
@@ -764,10 +764,10 @@ Automatic backup failed for %s on %s.
 
                 if website.package.enforceDiskLimits:
                     if config['DiskUsagePercentage'] >= 100:
-                        command = 'chattr -R +i /home/%s' % (website.domain)
+                        command = 'chattr -R +i /home/%s/public_html/' % (website.domain)
                         ProcessUtilities.executioner(command)
                     else:
-                        command = 'chattr -R -i /home/%s' % (website.domain)
+                        command = 'chattr -R -i /home/%s/public_html/' % (website.domain)
                         ProcessUtilities.executioner(command)
 
                 ## Calculate bw usage

--- a/plogical/IncScheduler.py
+++ b/plogical/IncScheduler.py
@@ -780,7 +780,7 @@ Automatic backup failed for %s on %s.
                         ProcessUtilities.executioner(command)
                         
                     else:
-                        command = 'chattr -R -i /home/%s/public_html/' % (website.domain)
+                        command = 'chattr -R -i /home/%s/' % (website.domain)
                         ProcessUtilities.executioner(command)
 
                 ## Calculate bw usage

--- a/plogical/IncScheduler.py
+++ b/plogical/IncScheduler.py
@@ -764,8 +764,21 @@ Automatic backup failed for %s on %s.
 
                 if website.package.enforceDiskLimits:
                     if config['DiskUsagePercentage'] >= 100:
-                        command = 'chattr -R +i /home/%s/public_html/' % (website.domain)
+                        command = 'chattr -R +i /home/%s/' % (website.domain)
                         ProcessUtilities.executioner(command)
+                        
+                        command = 'chattr -R -i /home/%s/logs/' % (website.domain)
+                        ProcessUtilities.executioner(command)
+                        
+                        command = 'chattr -R -i /home/%s/.trash/' % (website.domain)
+                        ProcessUtilities.executioner(command)
+                        
+                        command = 'chattr -R -i /home/%s/backup/' % (website.domain)
+                        ProcessUtilities.executioner(command)
+                        
+                        command = 'chattr -R -i /home/%s/incbackup/' % (website.domain)
+                        ProcessUtilities.executioner(command)
+                        
                     else:
                         command = 'chattr -R -i /home/%s/public_html/' % (website.domain)
                         ProcessUtilities.executioner(command)


### PR DESCRIPTION
lock only public_html directory when user exceed disk usage limit. Openlitespeed keep restarting when it failed to write logs and cache file inside users home/domain.com/logs/ directory. moreover user cant remove files from trash folder after directory become immutable. It's better to lock only public_html directory upon exceeding the disk quota limit.