### PR TITLE
Add `|| true` to lib64 chown

### DIFF
--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -715,7 +715,7 @@ rm -f /usr/local/composer.sh
 rm -f /usr/local/requirments.txt
 
 chown -R cyberpanel:cyberpanel /usr/local/CyberCP/lib
-chown -R cyberpanel:cyberpanel /usr/local/CyberCP/lib64
+chown -R cyberpanel:cyberpanel /usr/local/CyberCP/lib64 || true
 systemctl restart lscpd
 
 }


### PR DESCRIPTION
~~Without this, upgrade fails on Ubuntu 20.04 LTS ( and possibly other distros? )
The thought process of this is detailed in #817~~
This doesn't actually solve the problem. Putting it behind a distro check is better, and actually works.