### PR TITLE
Update vhost.py

### DIFF
--- a/plogical/vhost.py
+++ b/plogical/vhost.py
@@ -910,7 +910,7 @@ class vhost:
             else:
                 groupName = 'nogroup'
 
-            command = 'sudo -u %s chown %s:%s %s' % (virtualHostUser, virtualHostUser, groupName, path)
+            command = 'chown %s:%s %s' % (virtualHostUser, groupName, path)
             ProcessUtilities.normalExecutioner(command)
 
             command = "sudo -u %s chmod 750 %s" % (virtualHostUser, path)

--- a/websiteFunctions/website.py
+++ b/websiteFunctions/website.py
@@ -2316,7 +2316,7 @@ StrictHostKeyChecking no
             data['dkimCheck'] = 0
             data['openBasedir'] = 1
             data['adminEmail'] = data['ownerEmail']
-            data['phpSelection'] = "PHP 7.0"
+            data['phpSelection'] = "PHP 7.4"
             data['package'] = data['packageName']
             try:
                 websitesLimit = data['websitesLimit']


### PR DESCRIPTION
Changing chown cmd to not use sudo under createDirectoryForDomain
sudo -u does not make sense for chown, as chown requires root privileges, and the command results in 
`chown: changing ownership of 'path': Operation not permitted`