### PR TITLE
Avoid blocking DNS at several ISPs in Indonesia

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -409,7 +409,9 @@ fi
 }
 
 Check_Organization() {
-if [[ "$(curl --silent --max-time 10 -4 curl ipinfo.io/org)" = "AS17451 BIZNET NETWORKS" ]]; then
+if [[ "$(curl --silent --max-time 10 -4 curl ipinfo.io/org)" = "AS7713 PT Telekomunikasi Indonesia" ]]; then
+  Server_Organization="Telkom Indonesia"
+elif [[ "$(curl --silent --max-time 10 -4 curl ipinfo.io/org)" = "AS17451 BIZNET NETWORKS" ]]; then
   Server_Organization="Biznet Networks"
 else
   Server_Organization="Undefined"
@@ -1203,20 +1205,17 @@ if ! grep -q "pid_max" /etc/rc.local 2>/dev/null ; then
 
   rm -f /etc/resolv.conf
 
-  if [[ "$Server_Provider" = "Tencent Cloud" ]] ; then
-    echo -e "nameserver 183.60.83.19" > /etc/resolv.conf
-    echo -e "nameserver 183.60.82.98" >> /etc/resolv.conf
-  elif [[ "$Server_Provider" = "Alibaba Cloud" ]] ; then
-    echo -e "nameserver 100.100.2.136" > /etc/resolv.conf
-    echo -e "nameserver 100.100.2.138" >> /etc/resolv.conf
-  else
-    # Avoid blocking DNS at several ISPs in Indonesia.
-    if [[ "$Server_Organization" = "Biznet Networks" ]] ; then
-      echo -e "nameserver 203.142.82.222" > /etc/resolv.conf
-      echo -e "nameserver 203.142.84.222" >> /etc/resolv.conf
+  # Avoid blocking DNS at several ISPs in Indonesia.
+  if [[ "$Server_Organization" != "Biznet Networks" || "$Server_Organization" != "Telkom Indonesia" ]] ; then
+    if [[ "$Server_Provider" = "Tencent Cloud" ]] ; then
+      echo -e "nameserver 183.60.83.19" > /etc/resolv.conf
+      echo -e "nameserver 183.60.82.98" >> /etc/resolv.conf
+    elif [[ "$Server_Provider" = "Alibaba Cloud" ]] ; then
+      echo -e "nameserver 100.100.2.136" > /etc/resolv.conf
+      echo -e "nameserver 100.100.2.138" >> /etc/resolv.conf
     else
-      echo -e "nameserver 1.1.1.1" > /etc/resolv.conf
-      echo -e "nameserver 8.8.8.8" >> /etc/resolv.conf
+        echo -e "nameserver 1.1.1.1" > /etc/resolv.conf
+        echo -e "nameserver 8.8.8.8" >> /etc/resolv.conf
     fi
   fi
 

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -1935,6 +1935,8 @@ Check_Process
 
 Check_Provider
 
+Check_Organization
+
 Check_Argument "$@"
 
 if [[ $Silent = "On" ]]; then

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -21,6 +21,7 @@
 #Check_Panel() --->  check to make sure no other panel is installed
 #Check_Process() ---> check no other process like Apache is running
 #Check_Provider() ---> check the provider, certain provider like Alibaba or Tencent Yun may need some special change
+#Check_Organization() ---> check the organization, certain provider or organization like Telkom Indonesia or Biznet Networks Indonesia may need some special change
 #Check_Argument() ---> parse argument and go to Argument_Mode() or Interactive_Mode() respectively
 #Pre_Install_Setup_Repository() ---> setup/install repositories for centos system.
 #go to Pre_Install_Setup_CN_Repository() if server is within China.
@@ -65,6 +66,7 @@ Server_Country="Unknow"
 Server_OS=""
 Server_OS_Version=""
 Server_Provider='Undefined'
+Server_Organization='Undefined'
 
 Watchdog="On"
 Redis_Hosting="No"
@@ -403,6 +405,18 @@ fi
 
 if [[ "$Debug" = "On" ]] ; then
   Debug_Log "Server_Provider" "$Server_Provider"
+fi
+}
+
+Check_Organization() {
+if [[ "$(curl --silent --max-time 10 -4 curl ipinfo.io/org)" = "AS17451 BIZNET NETWORKS" ]]; then
+  Server_Organization="Biznet Networks"
+else
+  Server_Organization="Undefined"
+fi
+
+if [[ "$Debug" = "On" ]] ; then
+  Debug_Log "Server_Organization" "$Server_Organization"
 fi
 }
 
@@ -1196,8 +1210,14 @@ if ! grep -q "pid_max" /etc/rc.local 2>/dev/null ; then
     echo -e "nameserver 100.100.2.136" > /etc/resolv.conf
     echo -e "nameserver 100.100.2.138" >> /etc/resolv.conf
   else
-    echo -e "nameserver 1.1.1.1" > /etc/resolv.conf
-    echo -e "nameserver 8.8.8.8" >> /etc/resolv.conf
+    # Avoid blocking DNS at several ISPs in Indonesia.
+    if [[ "$Server_Organization" = "Biznet Networks" ]] ; then
+      echo -e "nameserver 203.142.82.222" > /etc/resolv.conf
+      echo -e "nameserver 203.142.84.222" >> /etc/resolv.conf
+    else
+      echo -e "nameserver 1.1.1.1" > /etc/resolv.conf
+      echo -e "nameserver 8.8.8.8" >> /etc/resolv.conf
+    fi
   fi
 
   systemctl restart systemd-networkd >/dev/null 2>&1


### PR DESCRIPTION
- Avoid DNS blocking and prevent editing of the /etc/resolv.conf file.
- Add Function Check_Organization to check Organization Name using ipinfo.io API.