### PR TITLE
Add PHP 8.1 to Install PHP Extensions Page

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -21,7 +21,6 @@
 #Check_Panel() --->  check to make sure no other panel is installed
 #Check_Process() ---> check no other process like Apache is running
 #Check_Provider() ---> check the provider, certain provider like Alibaba or Tencent Yun may need some special change
-#Check_Organization() ---> check the organization, certain provider or organization like Telkom Indonesia or Biznet Networks Indonesia may need some special change
 #Check_Argument() ---> parse argument and go to Argument_Mode() or Interactive_Mode() respectively
 #Pre_Install_Setup_Repository() ---> setup/install repositories for centos system.
 #go to Pre_Install_Setup_CN_Repository() if server is within China.
@@ -66,7 +65,6 @@ Server_Country="Unknow"
 Server_OS=""
 Server_OS_Version=""
 Server_Provider='Undefined'
-Server_Organization='Undefined'
 
 Watchdog="On"
 Redis_Hosting="No"
@@ -405,18 +403,6 @@ fi
 
 if [[ "$Debug" = "On" ]] ; then
   Debug_Log "Server_Provider" "$Server_Provider"
-fi
-}
-
-Check_Organization() {
-if [[ "$(curl --silent --max-time 10 -4 curl ipinfo.io/org)" = "AS17451 BIZNET NETWORKS" ]]; then
-  Server_Organization="Biznet Networks"
-else
-  Server_Organization="Undefined"
-fi
-
-if [[ "$Debug" = "On" ]] ; then
-  Debug_Log "Server_Organization" "$Server_Organization"
 fi
 }
 
@@ -1210,14 +1196,8 @@ if ! grep -q "pid_max" /etc/rc.local 2>/dev/null ; then
     echo -e "nameserver 100.100.2.136" > /etc/resolv.conf
     echo -e "nameserver 100.100.2.138" >> /etc/resolv.conf
   else
-    # Avoid blocking DNS at several ISPs in Indonesia.
-    if [[ "$Server_Organization" = "Biznet Networks" ]] ; then
-      echo -e "nameserver 203.142.82.222" > /etc/resolv.conf
-      echo -e "nameserver 203.142.84.222" >> /etc/resolv.conf
-    else
-      echo -e "nameserver 1.1.1.1" > /etc/resolv.conf
-      echo -e "nameserver 8.8.8.8" >> /etc/resolv.conf
-    fi
+    echo -e "nameserver 1.1.1.1" > /etc/resolv.conf
+    echo -e "nameserver 8.8.8.8" >> /etc/resolv.conf
   fi
 
   systemctl restart systemd-networkd >/dev/null 2>&1

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -21,6 +21,7 @@
 #Check_Panel() --->  check to make sure no other panel is installed
 #Check_Process() ---> check no other process like Apache is running
 #Check_Provider() ---> check the provider, certain provider like Alibaba or Tencent Yun may need some special change
+#Check_Organization() ---> check the organization, certain provider or organization like Telkom Indonesia or Biznet Networks Indonesia may need some special change
 #Check_Argument() ---> parse argument and go to Argument_Mode() or Interactive_Mode() respectively
 #Pre_Install_Setup_Repository() ---> setup/install repositories for centos system.
 #go to Pre_Install_Setup_CN_Repository() if server is within China.
@@ -65,6 +66,7 @@ Server_Country="Unknow"
 Server_OS=""
 Server_OS_Version=""
 Server_Provider='Undefined'
+Server_Organization='Undefined'
 
 Watchdog="On"
 Redis_Hosting="No"
@@ -403,6 +405,18 @@ fi
 
 if [[ "$Debug" = "On" ]] ; then
   Debug_Log "Server_Provider" "$Server_Provider"
+fi
+}
+
+Check_Organization() {
+if [[ "$(curl --silent --max-time 10 -4 curl ipinfo.io/org)" = "AS17451 BIZNET NETWORKS" ]]; then
+  Server_Organization="Biznet Networks"
+else
+  Server_Organization="Undefined"
+fi
+
+if [[ "$Debug" = "On" ]] ; then
+  Debug_Log "Server_Organization" "$Server_Organization"
 fi
 }
 
@@ -1196,8 +1210,14 @@ if ! grep -q "pid_max" /etc/rc.local 2>/dev/null ; then
     echo -e "nameserver 100.100.2.136" > /etc/resolv.conf
     echo -e "nameserver 100.100.2.138" >> /etc/resolv.conf
   else
-    echo -e "nameserver 1.1.1.1" > /etc/resolv.conf
-    echo -e "nameserver 8.8.8.8" >> /etc/resolv.conf
+    # Avoid blocking DNS at several ISPs in Indonesia.
+    if [[ "$Server_Organization" = "Biznet Networks" ]] ; then
+      echo -e "nameserver 203.142.82.222" > /etc/resolv.conf
+      echo -e "nameserver 203.142.84.222" >> /etc/resolv.conf
+    else
+      echo -e "nameserver 1.1.1.1" > /etc/resolv.conf
+      echo -e "nameserver 8.8.8.8" >> /etc/resolv.conf
+    fi
   fi
 
   systemctl restart systemd-networkd >/dev/null 2>&1

--- a/managePHP/php81.xml
+++ b/managePHP/php81.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" ?>
+<php>
+     <name>php81</name>
+
+     <extension>
+         <extensionName>lsphp81-debuginfo</extensionName>
+         <extensionDescription>Debug information for package lsphp81</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pecl-igbinary-debuginfo</extensionName>
+         <extensionDescription>Debug information for package lsphp81-pecl-igbinary</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pecl-mcrypt-debuginfo</extensionName>
+         <extensionDescription>lsphp81 lsphp81-pecl-mcrypt-debuginfo Extension</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-bcmath</extensionName>
+         <extensionDescription>A extension for PHP applications for using the bcmath library.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-common</extensionName>
+         <extensionDescription>Common files for PHP.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-dba</extensionName>
+         <extensionDescription>A database abstraction layer extension for PHP applications.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-devel</extensionName>
+         <extensionDescription>Files needed for building PHP extensions.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-enchant</extensionName>
+         <extensionDescription>Enchant spelling extension for PHP applications.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-gd</extensionName>
+         <extensionDescription>A extension for PHP applications for using the gd graphics library.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-gmp</extensionName>
+         <extensionDescription>A extension for PHP applications for using the GNU MP library.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-imap</extensionName>
+         <extensionDescription>A extension for PHP applications that use IMAP.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-intl</extensionName>
+         <extensionDescription>Internationalization extension for PHP applications.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-json</extensionName>
+         <extensionDescription>lsphp81 Json PHP Extension</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-ldap</extensionName>
+         <extensionDescription>A extension for PHP applications that use LDAP.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-mbstring</extensionName>
+         <extensionDescription>A extension for PHP applications which need multi-byte string handling.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-mysqlnd</extensionName>
+         <extensionDescription>A extension for PHP applications that use MySQL databases.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-odbc</extensionName>
+         <extensionDescription>A extension for PHP applications that use ODBC databases.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-opcache</extensionName>
+         <extensionDescription>The Zend OPcache.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pdo</extensionName>
+         <extensionDescription>A database access abstraction extension for PHP applications.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pear</extensionName>
+         <extensionDescription>PHP Extension and Application Repository framework.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pecl-apcu</extensionName>
+         <extensionDescription>APC User Cache.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pecl-apcu-devel</extensionName>
+         <extensionDescription>APCu developer files (header).</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pecl-apcu-panel</extensionName>
+         <extensionDescription>APCu control panel.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pecl-igbinary</extensionName>
+         <extensionDescription>Replacement for the standard PHP serializer.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+    <extension>
+         <extensionName>lsphp81-pecl-igbinary-devel</extensionName>
+         <extensionDescription>Igbinary developer files (header).</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pecl-mcrypt</extensionName>
+         <extensionDescription>lsphp81 lsphp81-pecl-mcrypt Extension.</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pecl-memcache</extensionName>
+         <extensionDescription>Extension to work with the Memcached caching daemon.</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pecl-memcached</extensionName>
+         <extensionDescription>Extension to work with the Memcached caching daemon.</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pecl-msgpack</extensionName>
+         <extensionDescription>API for communicating with MessagePack serialization.</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pecl-msgpack-devel</extensionName>
+         <extensionDescription>MessagePack developer files (header).</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pecl-redis</extensionName>
+         <extensionDescription>Extension for communicating with the Redis key-value store.</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pgsql</extensionName>
+         <extensionDescription>A PostgreSQL database extension for PHP.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-process</extensionName>
+         <extensionDescription>extensions for PHP script using system process interfaces.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pspell</extensionName>
+         <extensionDescription>A extension for PHP applications for using pspell interfaces.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-recode</extensionName>
+         <extensionDescription>A extension for PHP applications for using the recode library.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-snmp</extensionName>
+         <extensionDescription>A extension for PHP applications that query SNMP-managed devices.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-soap</extensionName>
+         <extensionDescription>A extension for PHP applications that use the SOAP protocol.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-tidy</extensionName>
+         <extensionDescription>Standard PHP extension provides tidy library support.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-xml</extensionName>
+         <extensionDescription>A module for PHP applications which use XML.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-xmlrpc</extensionName>
+         <extensionDescription>A extension for PHP applications which use the XML-RPC protocol.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-zip</extensionName>
+         <extensionDescription>ZIP archive management extension for PHP</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-mcrypt</extensionName>
+         <extensionDescription>Standard PHP extension provides mcrypt library support.</extensionDescription>
+         <status>1</status>
+    </extension>
+
+	<extension>
+         <extensionName>lsphp81-dbg</extensionName>
+         <extensionDescription>php73-dbg lsphp81-package</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-ioncube</extensionName>
+         <extensionDescription>ioncube loaders</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-pecl-imagick</extensionName>
+         <extensionDescription>Extension to create and modify images using ImageMagick</extensionDescription>
+         <status>0</status>
+    </extension>
+
+    <extension>
+         <extensionName>lsphp81-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
+</php>

--- a/managePHP/ubuntuphp81.xml
+++ b/managePHP/ubuntuphp81.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" ?>
+<php>
+     <name>php81</name>
+
+     <extension>
+         <extensionName>lsphp81-common</extensionName>
+         <extensionDescription>Most of what you need.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-curl</extensionName>
+         <extensionDescription>Curl (common web tools) required for PHP</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-dbg</extensionName>
+         <extensionDescription>Debugging extension</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-dev</extensionName>
+         <extensionDescription>Development features almost always required.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-imap</extensionName>
+         <extensionDescription>Email extensions for PHP.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-intl</extensionName>
+         <extensionDescription>Extensions for countries other than the U.S.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-json</extensionName>
+         <extensionDescription>PHP extensions for JavaScript Object Notation.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-ldap</extensionName>
+         <extensionDescription>PHP extensions for LDAP (directory access protocol)</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-modules-source</extensionName>
+         <extensionDescription>PHP source modules for virtually everything.  Very large.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-mysql</extensionName>
+         <extensionDescription>PHP extension for MySQL or MariaDB databases.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-opcache</extensionName>
+         <extensionDescription>PHP low-level caching of code.  Very important for performance.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pgsql</extensionName>
+         <extensionDescription>A PostgreSQL database extension for PHP.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-pspell</extensionName>
+         <extensionDescription>PHP spell checking extensions.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-recode</extensionName>
+         <extensionDescription>PHP extension to transform data between different character sets.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-snmp</extensionName>
+         <extensionDescription>PHP network management extensions.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-sqlite3</extensionName>
+         <extensionDescription>An extension for PHP applications that use the SQLite v3 features.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-sybase</extensionName>
+         <extensionDescription>An extension for PHP applications that use Sybase databases.</extensionDescription>
+         <status>0</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-tidy</extensionName>
+         <extensionDescription>PHP extensions for manipulating HTML, XHTML and XML documents.</extensionDescription>
+         <status>1</status>
+     </extension>
+
+     <extension>
+         <extensionName>lsphp81-ioncube</extensionName>
+         <extensionDescription>ioncube loaders</extensionDescription>
+         <status>0</status>
+     </extension>
+
+    <extension>
+         <extensionName>lsphp81-imagick</extensionName>
+         <extensionDescription>Extension to create and modify images using ImageMagick</extensionDescription>
+         <status>0</status>
+     </extension>
+
+    <extension>
+         <extensionName>lsphp81-sodium</extensionName>
+         <extensionDescription>The php-sodium extension provides strong encryption capabilities in an easy and consistent way.</extensionDescription>
+         <status>0</status>
+    </extension>
+
+</php>

--- a/managePHP/views.py
+++ b/managePHP/views.py
@@ -1237,7 +1237,36 @@ def installExtensions(request):
                 phpExtension.save()
         except:
             pass
+        
+        try:
+            newPHP81 = PHP(phpVers="php81")
+            newPHP81.save()
 
+            php81Path = ''
+
+            if ProcessUtilities.decideDistro() == ProcessUtilities.centos or ProcessUtilities.decideDistro() == ProcessUtilities.cent8:
+                php81Path = os.path.join('/usr', 'local', 'CyberCP', 'managePHP', 'php81.xml')
+            else:
+                php81Path = os.path.join('/usr', 'local', 'CyberCP', 'managePHP', 'ubuntuphp81.xml')
+
+            php81 = ElementTree.parse(php81Path)
+
+            php81Extensions = php81.findall('extension')
+
+            for extension in php81Extensions:
+                extensionName = extension.find('extensionName').text
+                extensionDescription = extension.find('extensionDescription').text
+                status = int(extension.find('status').text)
+
+                phpExtension = installedPackages(phpVers=newPHP81,
+                                                 extensionName=extensionName,
+                                                 description=extensionDescription,
+                                                 status=status)
+
+                phpExtension.save()
+        except:
+            pass
+        
         proc = httpProc(request, 'managePHP/installExtensions.html',
                         {'phps': PHPManager.findPHPVersions()}, 'admin')
         return proc.render()


### PR DESCRIPTION
Fixed an error on the **Install PHP Extensions** page when select PHP 8.1.

Error Message : `Cannot fetch details. Error message: PHP matching query does not exist.`