### PR TITLE
Remove website screenshots

### DIFF
--- a/websiteFunctions/templates/websiteFunctions/listChildDomains.html
+++ b/websiteFunctions/templates/websiteFunctions/listChildDomains.html
@@ -41,234 +41,223 @@
              style="padding: 0px; box-shadow: 0px 0px 1px 0px #888888;">
             <div class="">
                 <div class="table-responsive no-gutter text-nowrap" style="overflow-x: hidden;">
-                    <div style="background-image: url('https://cdn.statically.io/screenshot/{$ web.domain $}?fullPage=true');;
-                            height: 160px;
-                            width: 200px;
-                            background-position: top;
-                            background-repeat: no-repeat;
-                            background-size: cover;
-                            position: relative;" class="col-lg-3 col-md-12">
+
+                    <div style="border-bottom: 1px solid #888888" class="col-md-12">
+                        <div class="col-lg-10 content-box-header" style="text-transform: none;">
+                            <a href="http://{$ web.domain $}" target="_blank" title="Visit Site">
+                                <h2 style="display: inline; color: #414C59;" ng-bind="web.domain"></h2>
+                            </a>
+                            <a target="_blank" href="/filemanager/{$ web.masterDomain $}" title="Open File Manager">
+                                --
+                                File Manager</a>
+                        </div>
+                        <div class="col-md-2 content-box-header" style="text-transform: none;">
+                            <a href="/websites/{$ web.masterDomain $}/{$ web.domain $}" target="_blank"
+                               title="Manage Website">
+                                <i class="p fa fa-external-link btn-icon">&emsp;</i>
+                                <span>Manage</span>
+                            </a>
+                        </div>
                     </div>
-                    <div class="col-lg-9" style="text-transform: none">
-                        <div style="border-bottom: 1px solid #888888" class="col-md-12">
-                            <div class="col-lg-10 content-box-header" style="text-transform: none;">
-                                <a href="http://{$ web.domain $}" target="_blank" title="Visit Site">
-                                    <h2 style="display: inline; color: #414C59;" ng-bind="web.domain"></h2>
-                                </a>
-                                <a target="_blank" href="/filemanager/{$ web.masterDomain $}" title="Open File Manager">
-                                    --
-                                    File Manager</a>
-                            </div>
-                            <div class="col-md-2 content-box-header" style="text-transform: none;">
-                                <a href="/websites/{$ web.masterDomain $}/{$ web.domain $}" target="_blank"
-                                   title="Manage Website">
-                                    <i class="p fa fa-external-link btn-icon">&emsp;</i>
-                                    <span>Manage</span>
-                                </a>
-                            </div>
-                        </div>
-                        <div class="col-md-12">
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-trash-o btn-icon text-muted" data-toggle="tooltip"
-                                   data-placement="right"
-                                   title="Delete Child Domain">&emsp;</i>
-                                <span><a ng-click='deleteDomainInit(web.domain)' data-toggle="modal" data-target="#DeleteChild" href=""
-                                         style="text-transform: none">Delete</a></span>
-                                <div id="DeleteChild" class="modal fade" role="dialog">
-                                    <div class="modal-dialog">
-                                        <!-- Modal content-->
-                                        <div class="modal-content">
-                                            <div class="modal-header">
-                                                <button type="button" class="close" data-dismiss="modal">&times;
-                                                </button>
-                                                <h4 class="modal-title">Delete Child Domain
-                                                    <img ng-hide="$parent.cyberPanelLoading"
-                                                         src="/static/images/loading.gif"
-                                                         style="display: none;">
-                                                </h4>
-                                            </div>
-                                            <div class="modal-body">
-                                                <form name="DeleteDocumentRootForm" action="/" class="form-horizontal">
 
-                                                    <div ng-hide="installationDetailsForm" class="form-group">
-                                                        <label class="col-sm-2 control-label">{% trans "" %}</label>
-                                                        <div class="col-sm-8">
-                                                            <input ng-model="$parent.DeleteDocRoot" type="checkbox" value="">
-                                                            Delete Document Root
-                                                        </div>
+                    <div class="col-md-12">
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-trash-o btn-icon text-muted" data-toggle="tooltip"
+                               data-placement="right"
+                               title="Delete Child Domain">&emsp;</i>
+                            <span><a ng-click='deleteDomainInit(web.domain)' data-toggle="modal" data-target="#DeleteChild" href=""
+                                     style="text-transform: none">Delete</a></span>
+                            <div id="DeleteChild" class="modal fade" role="dialog">
+                                <div class="modal-dialog">
+                                    <!-- Modal content-->
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <button type="button" class="close" data-dismiss="modal">&times;
+                                            </button>
+                                            <h4 class="modal-title">Delete Child Domain
+                                                <img ng-hide="$parent.cyberPanelLoading"
+                                                     src="/static/images/loading.gif"
+                                                     style="display: none;">
+                                            </h4>
+                                        </div>
+                                        <div class="modal-body">
+                                            <form name="DeleteDocumentRootForm" action="/" class="form-horizontal">
+
+                                                <div ng-hide="installationDetailsForm" class="form-group">
+                                                    <label class="col-sm-2 control-label">{% trans "" %}</label>
+                                                    <div class="col-sm-8">
+                                                        <input ng-model="$parent.DeleteDocRoot" type="checkbox" value="">
+                                                        Delete Document Root
                                                     </div>
-                                                </form>
-                                            </div>
-                                            <div class="modal-footer">
-                                                <button type="button" class="btn btn-primary"
-                                                        ng-click="deleteChildDomain()">Delete Now
-                                                </button>
-                                                <button type="button" ng-disabled="savingSettings"
-                                                        class="btn btn-default" data-dismiss="modal">
-                                                    Close
-                                                </button>
-                                            </div>
+                                                </div>
+                                            </form>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-primary"
+                                                    ng-click="deleteChildDomain()">Delete Now
+                                            </button>
+                                            <button type="button" ng-disabled="savingSettings"
+                                                    class="btn btn-default" data-dismiss="modal">
+                                                Close
+                                            </button>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-map-marker btn-icon text-muted" data-toggle="tooltip"
-                                   data-placement="right" title="IP Address">&emsp;</i>
-                                <span ng-bind="web.ipAddress"></span>
-                            </div>
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-lock btn-icon text-muted" data-toggle="tooltip" data-placement="right"
-                                   title="SSL">&emsp;</i>
-                                <span><a ng-click="issueSSL(web.domain)" href=""
-                                         style="text-transform: none">Issue SSL</a></span>
-                            </div>
                         </div>
-                        <div class="col-md-12">
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-map-marker btn-icon text-muted" data-toggle="tooltip"
+                               data-placement="right" title="IP Address">&emsp;</i>
+                            <span ng-bind="web.ipAddress"></span>
+                        </div>
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-lock btn-icon text-muted" data-toggle="tooltip" data-placement="right"
+                               title="SSL">&emsp;</i>
+                            <span><a ng-click="issueSSL(web.domain)" href=""
+                                     style="text-transform: none">Issue SSL</a></span>
+                        </div>
+                    </div>
 
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-cubes btn-icon text-muted" data-toggle="tooltip"
-                                   data-placement="right"
-                                   title="Packages">&emsp;</i>
-                                <span ng-bind="web.package" style="text-transform: none"></span>
-                            </div>
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-user btn-icon text-muted" data-toggle="tooltip" data-placement="right"
-                                   title="Owner">&emsp;</i>
-                                <span ng-bind="web.admin" style="text-transform: none"></span>
-                            </div>
+                    <div class="col-md-12">
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-cubes btn-icon text-muted" data-toggle="tooltip"
+                               data-placement="right"
+                               title="Packages">&emsp;</i>
+                            <span ng-bind="web.package" style="text-transform: none"></span>
+                        </div>
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-user btn-icon text-muted" data-toggle="tooltip" data-placement="right"
+                               title="Owner">&emsp;</i>
+                            <span ng-bind="web.admin" style="text-transform: none"></span>
+                        </div>
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-arrows-h btn-icon text-muted" data-toggle="tooltip"
+                               data-placement="right"
+                               title="Convert to Website">&emsp;</i>
+                            <span><a data-toggle="modal" data-target="#settings" href=""
+                                     style="text-transform: none" ng-click="initConvert(web.domain)">Convert to Website</a></span>
+                            <div id="settings" class="modal fade" role="dialog">
+                                <div class="modal-dialog">
 
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-arrows-h btn-icon text-muted" data-toggle="tooltip"
-                                   data-placement="right"
-                                   title="Convert to Website">&emsp;</i>
-                                <span><a data-toggle="modal" data-target="#settings" href=""
-                                         style="text-transform: none" ng-click="initConvert(web.domain)">Convert to Website</a></span>
-                                <div id="settings" class="modal fade" role="dialog">
-                                    <div class="modal-dialog">
+                                    <!-- Modal content-->
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <button type="button" class="close" data-dismiss="modal">&times;
+                                            </button>
+                                            <h4 class="modal-title">Convert Child Domain to normal Website
+                                                <img ng-hide="$parent.cyberPanelLoading"
+                                                     src="/static/images/loading.gif"
+                                                     style="display: none;">
+                                            </h4>
+                                        </div>
+                                        <div class="modal-body">
 
-                                        <!-- Modal content-->
-                                        <div class="modal-content">
-                                            <div class="modal-header">
-                                                <button type="button" class="close" data-dismiss="modal">&times;
-                                                </button>
-                                                <h4 class="modal-title">Convert Child Domain to normal Website
-                                                    <img ng-hide="$parent.cyberPanelLoading"
-                                                         src="/static/images/loading.gif"
-                                                         style="display: none;">
-                                                </h4>
-                                            </div>
-                                            <div class="modal-body">
+                                            <form name="containerSettingsForm" action="/" class="form-horizontal">
 
-                                                <form name="containerSettingsForm" action="/" class="form-horizontal">
-
-                                                    <div ng-hide="installationDetailsForm" class="form-group">
-                                                        <label class="col-sm-3 control-label">{% trans "Domain Name" %}</label>
-                                                        <div class="col-sm-6">
-                                                            <input name="dom" type="text" class="form-control"
-                                                                   ng-model="domainName"
-                                                                   placeholder="{% trans "Do not enter WWW, it will be auto created!" %}"
-                                                                   readonly>
-                                                        </div>
+                                                <div ng-hide="installationDetailsForm" class="form-group">
+                                                    <label class="col-sm-3 control-label">{% trans "Domain Name" %}</label>
+                                                    <div class="col-sm-6">
+                                                        <input name="dom" type="text" class="form-control"
+                                                               ng-model="domainName"
+                                                               placeholder="{% trans "Do not enter WWW, it will be auto created!" %}"
+                                                               readonly>
                                                     </div>
+                                                </div>
 
-                                                    <div ng-hide="installationDetailsForm" class="form-group">
-                                                        <label class="col-sm-3 control-label">{% trans "Select Owner" %}</label>
-                                                        <div class="col-sm-6">
-                                                            <select ng-model="$parent.websiteOwner"
-                                                                    class="form-control">
-                                                                {% for items in owernList %}
-                                                                    <option>{{ items }}</option>
-                                                                {% endfor %}
-                                                            </select>
-                                                        </div>
+                                                <div ng-hide="installationDetailsForm" class="form-group">
+                                                    <label class="col-sm-3 control-label">{% trans "Select Owner" %}</label>
+                                                    <div class="col-sm-6">
+                                                        <select ng-model="$parent.websiteOwner"
+                                                                class="form-control">
+                                                            {% for items in owernList %}
+                                                                <option>{{ items }}</option>
+                                                            {% endfor %}
+                                                        </select>
                                                     </div>
+                                                </div>
 
-                                                    <hr ng-hide="installationDetailsForm">
+                                                <hr ng-hide="installationDetailsForm">
 
-                                                    <div ng-hide="installationDetailsForm" class="form-group">
-                                                        <label class="col-sm-3 control-label">{% trans "Select Package" %}</label>
-                                                        <div class="col-sm-6">
-                                                            <select ng-model="$parent.packageForWebsite"
-                                                                    class="form-control">
-                                                                {% for items in packageList %}
-                                                                    <option>{{ items }}</option>
-                                                                {% endfor %}
-                                                            </select>
-                                                        </div>
+                                                <div ng-hide="installationDetailsForm" class="form-group">
+                                                    <label class="col-sm-3 control-label">{% trans "Select Package" %}</label>
+                                                    <div class="col-sm-6">
+                                                        <select ng-model="$parent.packageForWebsite"
+                                                                class="form-control">
+                                                            {% for items in packageList %}
+                                                                <option>{{ items }}</option>
+                                                            {% endfor %}
+                                                        </select>
                                                     </div>
+                                                </div>
 
-                                                    <hr ng-hide="installationDetailsForm">
-                                                    <div ng-hide="installationDetailsForm" class="form-group">
-                                                        <label class="col-sm-3 control-label">{% trans "Email" %}</label>
-                                                        <div class="col-sm-6">
-                                                            <input type="email" name="email" class="form-control"
-                                                                   ng-model="$parent.adminEmail" required>
-                                                        </div>
+                                                <hr ng-hide="installationDetailsForm">
+                                                <div ng-hide="installationDetailsForm" class="form-group">
+                                                    <label class="col-sm-3 control-label">{% trans "Email" %}</label>
+                                                    <div class="col-sm-6">
+                                                        <input type="email" name="email" class="form-control"
+                                                               ng-model="$parent.adminEmail" required>
                                                     </div>
+                                                </div>
 
-                                                    <hr ng-hide="installationDetailsForm">
-                                                    <div ng-hide="installationDetailsForm" class="form-group">
-                                                        <label class="col-sm-3 control-label">{% trans "Select PHP" %}</label>
-                                                        <div class="col-sm-6">
-                                                            <select ng-model="$parent.phpSelection"
-                                                                    class="form-control">
-                                                                {% for php in phps %}
-                                                                    <option>{{ php }}</option>
-                                                                {% endfor %}
-                                                            </select>
-                                                        </div>
+                                                <hr ng-hide="installationDetailsForm">
+                                                <div ng-hide="installationDetailsForm" class="form-group">
+                                                    <label class="col-sm-3 control-label">{% trans "Select PHP" %}</label>
+                                                    <div class="col-sm-6">
+                                                        <select ng-model="$parent.phpSelection"
+                                                                class="form-control">
+                                                            {% for php in phps %}
+                                                                <option>{{ php }}</option>
+                                                            {% endfor %}
+                                                        </select>
                                                     </div>
+                                                </div>
 
-                                                    <div ng-hide="installationProgress" class="form-group">
-                                                        <label class="col-sm-1 control-label"></label>
-                                                        <div class="col-sm-10">
+                                                <div ng-hide="installationProgress" class="form-group">
+                                                    <label class="col-sm-1 control-label"></label>
+                                                    <div class="col-sm-10">
 
-                                                            <div class="alert alert-success text-center">
-                                                                <h2>{$ currentStatus $}</h2>
+                                                        <div class="alert alert-success text-center">
+                                                            <h2>{$ currentStatus $}</h2>
+                                                        </div>
+
+                                                        <div class="progress">
+                                                            <div id="installProgress" class="progress-bar"
+                                                                 role="progressbar" aria-valuenow="70"
+                                                                 aria-valuemin="0" aria-valuemax="100"
+                                                                 style="width:0%">
+                                                                <span class="sr-only">70% Complete</span>
                                                             </div>
-
-                                                            <div class="progress">
-                                                                <div id="installProgress" class="progress-bar"
-                                                                     role="progressbar" aria-valuenow="70"
-                                                                     aria-valuemin="0" aria-valuemax="100"
-                                                                     style="width:0%">
-                                                                    <span class="sr-only">70% Complete</span>
-                                                                </div>
-                                                            </div>
-
-
                                                         </div>
+
+
                                                     </div>
+                                                </div>
 
-                                                    <div ng-hide="installationProgress" class="form-group">
-                                                        <label class="col-sm-3 control-label"></label>
-                                                        <div class="col-sm-4">
-                                                            <button type="button" ng-disabled="goBackDisable"
-                                                                    ng-click="goBack()"
-                                                                    class="btn btn-primary btn-lg">{% trans "Go Back" %}</button>
-                                                        </div>
+                                                <div ng-hide="installationProgress" class="form-group">
+                                                    <label class="col-sm-3 control-label"></label>
+                                                    <div class="col-sm-4">
+                                                        <button type="button" ng-disabled="goBackDisable"
+                                                                ng-click="goBack()"
+                                                                class="btn btn-primary btn-lg">{% trans "Go Back" %}</button>
                                                     </div>
+                                                </div>
 
-                                                </form>
+                                            </form>
 
-                                            </div>
-                                            <div class="modal-footer">
-                                                <button type="button" class="btn btn-primary"
-                                                        ng-click="convert()">Convert
-                                                </button>
-                                                <button type="button" ng-disabled="savingSettings"
-                                                        class="btn btn-default" data-dismiss="modal">
-                                                    Close
-                                                </button>
-                                            </div>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-primary"
+                                                    ng-click="convert()">Convert
+                                            </button>
+                                            <button type="button" ng-disabled="savingSettings"
+                                                    class="btn btn-default" data-dismiss="modal">
+                                                Close
+                                            </button>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-
                         </div>
-
                     </div>
 
                     <div id="listFail" class="alert alert-danger">

--- a/websiteFunctions/templates/websiteFunctions/listWebsites.html
+++ b/websiteFunctions/templates/websiteFunctions/listWebsites.html
@@ -43,71 +43,62 @@
              style="padding: 0px; box-shadow: 0px 0px 1px 0px #888888;">
             <div class="">
                 <div class="table-responsive no-gutter text-nowrap" style="overflow-x: hidden;">
-                    <div style="background-image: url('https://cdn.statically.io/screenshot/{$ web.domain $}?fullPage=true');
-                                    height: 160px;
-                                    width: 200px;
-                                    background-position: top;
-                                    background-repeat: no-repeat;
-                                    background-size: cover;
-                                    position: relative;"
-                         class="col-lg-3 col-md-12">
+
+                    <div style="border-bottom: 1px solid #888888" class="col-md-12">
+                        <div class="col-lg-10 content-box-header" style="text-transform: none;">
+                            <a href="http://{$ web.domain $}" target="_blank" title="Visit Site">
+                                <h2 style="display: inline; color: #414C59;" ng-bind="web.domain"></h2>
+                            </a>
+                            <a target="_self" href="/filemanager/{$ web.domain $}" title="Open File Manager"> --
+                                {% trans "File Manager" %}</a>
+                        </div>
+                        <div class="col-md-2 content-box-header" style="text-transform: none;">
+                            <a href="/websites/{$ web.domain $}" target="_self" title="Manage Website">
+                                <i class="p fa fa-external-link btn-icon">&emsp;</i>
+                                <span>{% trans "Manage" %}</span>
+                            </a>
+                        </div>
                     </div>
-                    <div class="col-lg-9" style="text-transform: none">
-                        <div style="border-bottom: 1px solid #888888" class="col-md-12">
-                            <div class="col-lg-10 content-box-header" style="text-transform: none;">
-                                <a href="http://{$ web.domain $}" target="_blank" title="Visit Site">
-                                    <h2 style="display: inline; color: #414C59;" ng-bind="web.domain"></h2>
-                                </a>
-                                <a target="_self" href="/filemanager/{$ web.domain $}" title="Open File Manager"> --
-                                    {% trans "File Manager" %}</a>
-                            </div>
-                            <div class="col-md-2 content-box-header" style="text-transform: none;">
-                                <a href="/websites/{$ web.domain $}" target="_self" title="Manage Website">
-                                    <i class="p fa fa-external-link btn-icon">&emsp;</i>
-                                    <span>{% trans "Manage" %}</span>
-                                </a>
-                            </div>
-                        </div>
-                        <div class="col-md-12">
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-sticky-note btn-icon text-muted" data-toggle="tooltip"
-                                   data-placement="right" title="State">&emsp;</i>
-                                <span ng-bind="web.state" style="text-transform: none"></span>
-                            </div>
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-map-marker btn-icon text-muted" data-toggle="tooltip"
-                                   data-placement="right" title="IP Address">&emsp;</i>
-                                <span ng-bind="web.ipAddress"></span>
-                            </div>
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-lock btn-icon text-muted" data-toggle="tooltip" data-placement="right"
-                                   title="SSL">&emsp;</i>
-                                <span><a ng-click="issueSSL(web.domain)" href=""
-                                         style="text-transform: none">{% trans "Issue SSL" %}</a></span>
-                            </div>
-                        </div>
-                        <div class="col-md-12">
 
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-hdd-o btn-icon text-muted" data-toggle="tooltip"
-                                   data-placement="right"
-                                   title="Disk Usage">&emsp;</i>
-                                <span ng-bind="web.diskUsed" style="text-transform: none"></span>
-                            </div>
-
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-cubes btn-icon text-muted" data-toggle="tooltip"
-                                   data-placement="right"
-                                   title="Packages">&emsp;</i>
-                                <span ng-bind="web.package" style="text-transform: none"></span>
-                            </div>
-                            <div class="col-md-4 content-box-header">
-                                <i class="p fa fa-user btn-icon text-muted" data-toggle="tooltip" data-placement="right"
-                                   title="Owner">&emsp;</i>
-                                <span ng-bind="web.admin" style="text-transform: none"></span>
-                            </div>
-
+                    <div class="col-md-12">
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-sticky-note btn-icon text-muted" data-toggle="tooltip"
+                               data-placement="right" title="State">&emsp;</i>
+                            <span ng-bind="web.state" style="text-transform: none"></span>
                         </div>
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-map-marker btn-icon text-muted" data-toggle="tooltip"
+                               data-placement="right" title="IP Address">&emsp;</i>
+                            <span ng-bind="web.ipAddress"></span>
+                        </div>
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-lock btn-icon text-muted" data-toggle="tooltip" data-placement="right"
+                               title="SSL">&emsp;</i>
+                            <span><a ng-click="issueSSL(web.domain)" href=""
+                                     style="text-transform: none">{% trans "Issue SSL" %}</a></span>
+                        </div>
+                    </div>
+
+                    <div class="col-md-12">
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-hdd-o btn-icon text-muted" data-toggle="tooltip"
+                               data-placement="right"
+                               title="Disk Usage">&emsp;</i>
+                            <span ng-bind="web.diskUsed" style="text-transform: none"></span>
+                        </div>
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-cubes btn-icon text-muted" data-toggle="tooltip"
+                               data-placement="right"
+                               title="Packages">&emsp;</i>
+                            <span ng-bind="web.package" style="text-transform: none"></span>
+                        </div>
+                        <div class="col-md-4 content-box-header">
+                            <i class="p fa fa-user btn-icon text-muted" data-toggle="tooltip" data-placement="right"
+                               title="Owner">&emsp;</i>
+                            <span ng-bind="web.admin" style="text-transform: none"></span>
+                        </div>
+                    </div>
+
                         <!--table cellpadding="0" cellspacing="0" border="0" class="table" style="margin:0px 0px; id="datatable-example">
                     <thead>
                     <tr>
@@ -129,8 +120,6 @@
 
                     </tbody>
                     </table-->
-
-                    </div>
 
                     <div id="listFail" class="alert alert-danger">
                         <p>{% trans "Cannot list websites. Error message:" %} {$ errorMessage $}</p>


### PR DESCRIPTION
The screenshots shown on the Websites and Child Domains pages has been broken for a long time. I propose to remove these screenshots.

Reasons to take this action:

1. Statically's own demo page ([link](https://statically.io/docs/using-screenshot/)) is also broken.
2. [I've notified them](https://twitter.com/Brugman/status/1514393858796408834) of this 2 weeks ago and got no response.
3. I've spent an hour trying to find an alternative screenshot service that we could use, but none seem to offer it at no cost, or without creating an account. Creating an account is not worth the effort, and sharing an account with all CyberPanel users would put us over the free tier limit, and be a privacy concern.
4. The creation of issue #158 indicated that the feature has been problematic since Nov 1st 2019. A very long time.

![2022-05-01-21-14-46](https://user-images.githubusercontent.com/2203813/166161464-c2da911c-044d-48ca-b42e-f3cd25a0db2e.jpg)

The PR is very simple. I've only deleted a couple of lines. The reason you're seeing _lots_ of code removed and added is because I fixed the indentation.

I tested this change thoroughly but manually by performing it in Dev Tools. I could not find `listWebsites.html` on my CyberPanel install so I wasn't enable to upload it and test it fully. Please perform this final test before merging.

Thank you.