### PR TITLE
Add "Disable Wordpress XMLRPC & Trackback" option to Rewrite Rules menu

### DIFF
--- a/static/websiteFunctions/websiteFunctions.js
+++ b/static/websiteFunctions/websiteFunctions.js
@@ -2750,6 +2750,15 @@ RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 `;
 
+    const WordpressProtect = `### Rewrite Rules Added by CyberPanel Rewrite Rule Generator
+
+RewriteEngine On
+RewriteRule ^/(xmlrpc|wp-trackback)\.php - [F,L,NC]
+
+### End CyberPanel Generated Rules.
+
+`;
+
     $scope.applyRewriteTemplate = function () {
 
         if ($scope.rewriteTemplate === "Force HTTP -> HTTPS") {
@@ -2759,6 +2768,9 @@ RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
         }
         else if ($scope.rewriteTemplate === "Force WWW -> NON-WWW") {
             $scope.rewriteRules = WWWToNonWWW + $scope.rewriteRules;
+        }
+        else if ($scope.rewriteTemplate === "Disable Wordpress XMLRPC & Trackback") {
+            $scope.rewriteRules = WordpressProtect + $scope.rewriteRules;
         }
     };
 

--- a/websiteFunctions/static/websiteFunctions/websiteFunctions.js
+++ b/websiteFunctions/static/websiteFunctions/websiteFunctions.js
@@ -5008,6 +5008,15 @@ RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 `;
 
+    const WordpressProtect = `### Rewrite Rules Added by CyberPanel Rewrite Rule Generator
+
+RewriteEngine On
+RewriteRule ^/(xmlrpc|wp-trackback)\.php - [F,L,NC]
+
+### End CyberPanel Generated Rules.
+
+`;
+
     $scope.applyRewriteTemplate = function () {
 
         if ($scope.rewriteTemplate === "Force HTTP -> HTTPS") {
@@ -5016,6 +5025,8 @@ RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
             $scope.rewriteRules = nonWWWToWWW + $scope.rewriteRules;
         } else if ($scope.rewriteTemplate === "Force WWW -> NON-WWW") {
             $scope.rewriteRules = WWWToNonWWW + $scope.rewriteRules;
+        }  else if ($scope.rewriteTemplate === "Disable Wordpress XMLRPC & Trackback") {
+            $scope.rewriteRules = WordpressProtect + $scope.rewriteRules;
         }
     };
 

--- a/websiteFunctions/templates/websiteFunctions/website.html
+++ b/websiteFunctions/templates/websiteFunctions/website.html
@@ -692,6 +692,7 @@
                                                     <option>Force HTTP -> HTTPS</option>
                                                     <option>Force WWW -> NON-WWW</option>
                                                     <option>Force NON-WWW -> WWW</option>
+                                                    <option>Disable Wordpress XMLRPC & Trackback</option>
                                                 </select>
                                             </div>
                                         </div>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/14070303/181510271-e4544903-8cc6-40be-a232-d01c9299dd80.png)

Issues regarding XMLRPC file : 
- https://www.facebook.com/groups/cyberpanel/permalink/3105585583086402/
- https://forum.openlitespeed.org/threads/how-to-block-access-to-xmlrpc-php-file.2570/
- https://wpbeaches.com/block-xmlrpc-php-wordpress-running-on-openlitespeed-using-htaccess/