### PR TITLE
Update elasticsearch to v8.x

### DIFF
--- a/manageServices/serviceManager.py
+++ b/manageServices/serviceManager.py
@@ -154,8 +154,8 @@ superslave=yes
 
             content = '''
 [elasticsearch]
-name=Elasticsearch repository for 7.x packages
-baseurl=https://artifacts.elastic.co/packages/7.x/yum
+name=Elasticsearch repository for 8.x packages
+baseurl=https://artifacts.elastic.co/packages/8.x/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=0
@@ -176,7 +176,7 @@ type=rpm-md
             command = 'apt-get install apt-transport-https -y'
             ServerStatusUtil.executioner(command, statusFile)
 
-            command = 'echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-7.x.list'
+            command = 'echo "deb https://artifacts.elastic.co/packages/8.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-8.x.list'
             subprocess.call(command, shell=True)
 
             command = 'apt-get update -y'
@@ -236,6 +236,7 @@ type=rpm-md
 
             try:
                 os.remove('/etc/apt/sources.list.d/elastic-7.x.list')
+                os.remove('/etc/apt/sources.list.d/elastic-8.x.list')
             except:
                 pass
 

--- a/manageServices/serviceManager.py
+++ b/manageServices/serviceManager.py
@@ -182,7 +182,7 @@ type=rpm-md
             command = 'apt-get update -y'
             ServerStatusUtil.executioner(command, statusFile)
 
-            command = 'apt-get install elasticsearch -y'
+            command = 'apt-get install elasticsearch kibana -y'
             ServerStatusUtil.executioner(command, statusFile)
 
         ### Tmp folder configurations
@@ -241,7 +241,7 @@ type=rpm-md
                 pass
 
 
-            command = 'apt-get remove elasticsearch -y'
+            command = 'apt-get remove elasticsearch kibana -y'
             ServerStatusUtil.executioner(command, statusFile)
 
         ### Tmp folder configurations


### PR DESCRIPTION
Elasticsearch is now running on v8.3. This PR should work to install that. I've added a line to remove both 7.x and 8.x for legacy purposes. Though perhaps that can be replaced with a wildcard?

I've also included Kibana (which is completely essential to use) in the install, but i dont know how to configure the centos commands