### PR TITLE
Solved file removing bugs when user directory is locked.

### DIFF
--- a/filemanager/filemanager.py
+++ b/filemanager/filemanager.py
@@ -384,17 +384,18 @@ class FileManager:
 
                 RemoveOK = 1
 
-                command = 'touch %s/hello.txt' % (self.homePath)
+                command = 'touch %s/public_html/hello.txt' % (self.homePath)
                 result = ProcessUtilities.outputExecutioner(command)
 
-                if result.find('No such file or directory') > -1:
+
+                if result.find('cannot touch') > -1:
                     RemoveOK = 0
 
                     command = 'chattr -R -i %s' % (self.homePath)
                     ProcessUtilities.executioner(command)
 
                 else:
-                    command = 'rm -f %s/hello.txt' % (self.homePath)
+                    command = 'rm -f %s/public_html/hello.txt' % (self.homePath)
                     ProcessUtilities.executioner(command)
 
 
@@ -422,6 +423,24 @@ class FileManager:
                 if RemoveOK == 0:
                     command = 'chattr -R +i %s' % (self.homePath)
                     ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/logs/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/.trash/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/backup/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/incbackup/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/lscache/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/.cagefs/'
+                    ProcessUtilities.executioner(command)
             except:
                 try:
                     skipTrash = self.data['skipTrash']
@@ -433,17 +452,17 @@ class FileManager:
 
                 RemoveOK = 1
 
-                command = 'touch %s/hello.txt' % (self.homePath)
+                command = 'touch %s/public_html/hello.txt' % (self.homePath)
                 result = ProcessUtilities.outputExecutioner(command)
 
-                if result.find('No such file or directory') > -1:
+                if result.find('cannot touch') > -1:
                     RemoveOK = 0
 
                     command = 'chattr -R -i %s' % (self.homePath)
                     ProcessUtilities.executioner(command)
 
                 else:
-                    command = 'rm -f %s/hello.txt' % (self.homePath)
+                    command = 'rm -f %s/public_html/hello.txt' % (self.homePath)
                     ProcessUtilities.executioner(command)
 
                 for item in self.data['fileAndFolders']:
@@ -459,6 +478,24 @@ class FileManager:
 
                 if RemoveOK == 0:
                     command = 'chattr -R +i %s' % (self.homePath)
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/logs/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/.trash/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/backup/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/incbackup/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/lscache/'
+                    ProcessUtilities.executioner(command)
+                    
+                    command = 'chattr -R -i %s' % (self.homePath) + '/.cagefs/'
                     ProcessUtilities.executioner(command)
 
             json_data = json.dumps(finalData)

--- a/filemanager/filemanager.py
+++ b/filemanager/filemanager.py
@@ -386,9 +386,9 @@ class FileManager:
 
                 command = 'touch %s/public_html/hello.txt' % (self.homePath)
                 result = ProcessUtilities.outputExecutioner(command)
+                result_lower = result.lower()
 
-
-                if result.find('cannot touch') > -1:
+                if 'cannot touch' in result_lower or 'no such file or directory' in result_lower:
                     RemoveOK = 0
 
                     command = 'chattr -R -i %s' % (self.homePath)
@@ -454,8 +454,9 @@ class FileManager:
 
                 command = 'touch %s/public_html/hello.txt' % (self.homePath)
                 result = ProcessUtilities.outputExecutioner(command)
+                result_lower = result.lower()
 
-                if result.find('cannot touch') > -1:
+                if 'cannot touch' in result_lower or 'no such file or directory' in result_lower:
                     RemoveOK = 0
 
                     command = 'chattr -R -i %s' % (self.homePath)


### PR DESCRIPTION
When user exceed disk quota exceeded cyberpanel lock his/her directory for further editing/renaming/creating new files. But unfortunately user cant delete file because the text used here "No such file or directory" to determine whether user directory is locked or not is wrong cause if any user directory is locked hello.txt file will not be able to create thus it will generate "Can not touch" output not "No such file or directory" output. Moreover previous code lock all directory which will break openlitespeed. So, i have corrected everything and tested it. it will work perfectly.