### PR TITLE
Fix menu ids

### DIFF
--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -334,7 +334,7 @@
                                        data-original-title=".icon-cloud-upload" aria-describedby="tooltip896208"></i>
                                     <span>{% trans "Connect" %}</span>
                                 </a>
-                                <a target="_blank" href="https://go.cyberpanel.net/community"
+                                <a id="sidebar-menu-item-community" target="_blank" href="https://go.cyberpanel.net/community"
                                    title="{% trans 'Connect' %}">
                                     <i class="glyph-icon tooltip-button icon-comments-o" title="{% trans 'Community' %}"
                                        data-original-title=".icon-comments-alt" aria-describedby="tooltip896208"></i>
@@ -396,10 +396,8 @@
                             </div><!-- .sidebar-submenu -->
                         </li>
 
-                        <li id="sidebar-menu-item-websites">
-
                             <!-------------WordPress--------------------------->
-                        <li>
+                        <li id="sidebar-menu-item-wordpress">
                             <a href="{% url 'loadWebsitesHome' %}" title="{% trans 'WordPress' %}">
                                 <div class="glyph-icon icon-wordpress" title="{% trans 'WordPress' %}"></div>
                                 <span>{% trans "WordPress" %}</span>
@@ -430,7 +428,7 @@
                         </li>
 
 
-                        <li>
+                        <li id="sidebar-menu-item-websites">
                             <a href="{% url 'loadWebsitesHome' %}" title="{% trans 'Websites' %}">
                                 <div class="glyph-icon icon-globe" title="{% trans 'Websites' %}"></div>
                                 <span>{% trans "Websites" %}</span>
@@ -782,7 +780,7 @@
                         {% if admin %}
 
                             <li class="header"><span>{% trans "Server" %}</span></li>
-                            <li>
+                            <li id="sidebar-menu-item-root-file-manager">
                                 <a href="{% url 'Filemanager' %}"
                                    title="{% trans 'Root File Manager' %}">
                                     <i class="glyph-icon tooltip-button icon-link"
@@ -945,7 +943,7 @@
                                 </div><!-- .sidebar-submenu -->
                             </li>
 
-                            <li id="sidebar-menu-item-server-status">
+                            <li id="sidebar-menu-item-logs">
                                 <a href="{% url 'logsHome' %}" title="{% trans 'Server Status' %}">
                                     <i class="glyph-icon icon-file"></i>
                                     <span>{% trans "Logs" %}</span>


### PR DESCRIPTION
Since you merged my PR with menu ids it seems there was some sloppy updating without them. The server status id was used twice, and there was a single `li` for websites that was never closed. That's all fixed now.