### PR TITLE
Keep nav open

### DIFF
--- a/baseTemplate/static/baseTemplate/assets/finalJS/final.js
+++ b/baseTemplate/static/baseTemplate/assets/finalJS/final.js
@@ -60,14 +60,6 @@ $(function(){
 				anchorClass: 'sf-with-ul',
 				menuArrowClass: 'sf-arrows'
 			},
-			outerClick = (function() {
-				$(window).load(function() {
-					$('body').children().on('click.superclick', function() {
-						var $allMenus = $('.sf-js-enabled');
-						$allMenus.superclick('reset');
-					});
-				});
-			})(),
 			toggleMenuClasses = function($menu, o) {
 				var classes = c.menuClass;
 				if (o.cssArrows) {

--- a/baseTemplate/static/baseTemplate/assets/widgets/superclick/superclick.js
+++ b/baseTemplate/static/baseTemplate/assets/widgets/superclick/superclick.js
@@ -17,14 +17,6 @@
 				anchorClass: 'sf-with-ul',
 				menuArrowClass: 'sf-arrows'
 			},
-			outerClick = (function() {
-				$(window).load(function() {
-					$('body').children().on('click.superclick', function() {
-						var $allMenus = $('.sf-js-enabled');
-						$allMenus.superclick('reset');
-					});
-				});
-			})(),
 			toggleMenuClasses = function($menu, o) {
 				var classes = c.menuClass;
 				if (o.cssArrows) {

--- a/static/baseTemplate/assets/finalJS/final.js
+++ b/static/baseTemplate/assets/finalJS/final.js
@@ -60,14 +60,6 @@ $(function(){
 				anchorClass: 'sf-with-ul',
 				menuArrowClass: 'sf-arrows'
 			},
-			outerClick = (function() {
-				$(window).load(function() {
-					$('body').children().on('click.superclick', function() {
-						var $allMenus = $('.sf-js-enabled');
-						$allMenus.superclick('reset');
-					});
-				});
-			})(),
 			toggleMenuClasses = function($menu, o) {
 				var classes = c.menuClass;
 				if (o.cssArrows) {

--- a/static/baseTemplate/assets/widgets/superclick/superclick.js
+++ b/static/baseTemplate/assets/widgets/superclick/superclick.js
@@ -17,14 +17,6 @@
 				anchorClass: 'sf-with-ul',
 				menuArrowClass: 'sf-arrows'
 			},
-			outerClick = (function() {
-				$(window).load(function() {
-					$('body').children().on('click.superclick', function() {
-						var $allMenus = $('.sf-js-enabled');
-						$allMenus.superclick('reset');
-					});
-				});
-			})(),
 			toggleMenuClasses = function($menu, o) {
 				var classes = c.menuClass;
 				if (o.cssArrows) {


### PR DESCRIPTION
This is a PR to keep the main nav open when you're clicking around on a page.
I've removed the `outerClick` function.

**Why**

Argument 1

Let's say you click Users, and then List Users.
You scroll (and click) around on the List Users page, but you decide this was the wrong page.
Let's go back to the menu and look for the page you wanted instead... Oh. It's closed.

Now you have to find Users in the list again, click it, wait for the animation, and then you're ready to continue.

Argument 2

If you are multitasking, you constantly click into different windows to give them focus. Clicking on the empty parts of a website should never _do_ something.