### PR TITLE
Use correct arguments ordering in CloudLinuxDomains

### DIFF
--- a/CLScript/CloudLinuxDomains.py
+++ b/CLScript/CloudLinuxDomains.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    pi = CloudLinuxDomains(args.owner, args.name)
+    pi = CloudLinuxDomains(args.name, args.owner)
     try:
         pi.listAll()
     except:


### PR DESCRIPTION
CloudLinuxDomains is constructed with name and owner arguments, but they are swapped and some CloudLinux features do not work properly.

Correct order was restored.