### PR TITLE
Improve CyberPanel CLI Usability and Version Handling

### DIFF
--- a/cli/cliParser.py
+++ b/cli/cliParser.py
@@ -3,10 +3,13 @@ import re
 
 class cliParser:
 
+    def __init__(self):
+        self.parser = argparse.ArgumentParser(description='CyberPanel Command Line Interface!')
+
     def prepareArguments(self):
         ## Website creation Arguments
 
-        parser = argparse.ArgumentParser(description='CyberPanel Command Line Interface!')
+        parser = self.parser
         parser.add_argument('function', help='Specific a operation to perform!')
 
         parser.add_argument('--package', help='Select a package for website.')
@@ -76,3 +79,23 @@ class cliParser:
 
 
         return parser.parse_args()
+
+    def print_help(self):
+        self.parser.print_help()
+
+    def getAllowedFunctions(self):
+        allowed_functions = {
+            "Website management": ["createWebsite", "deleteWebsite", "createChild", "deleteChild", "listWebsitesJson", "listWebsitesPretty", "changePHP", "changePackage"],
+            "DNS management": ["listDNSJson", "listDNSPretty", "listDNSZonesJson", "listDNSZonesPretty", "createDNSZone", "deleteDNSZone", "createDNSRecord", "deleteDNSRecord"],
+            "Backup management": ["createBackup", "restoreBackup"],
+            "Package management": ["createPackage", "deletePackage", "listPackagesJson", "listPackagesPretty"],
+            "Database management": ["createDatabase", "deleteDatabase", "listDatabasesJson", "listDatabasesPretty"],
+            "Email management": ["createEmail", "deleteEmail", "changeEmailPassword", "listEmailsJson", "listEmailsPretty"],
+            "FTP management": ["createFTPAccount", "deleteFTPAccount", "changeFTPPassword", "listFTPJson", "listFTPPretty"],
+            "SSL management": ["issueSSL", "hostNameSSL", "mailServerSSL", "issueSelfSignedSSL"],
+            "User management": ["createUser", "deleteUser", "listUsers", "suspendUser", "editUser" ],
+            "Application installers": ["installWordPress", "installJoomla"],
+            "Others": ["help", "version", "utility", "[upgrade|update]", "switchTOLSWS" ]
+        }
+
+        return allowed_functions

--- a/cli/cyberPanel.py
+++ b/cli/cyberPanel.py
@@ -1603,6 +1603,18 @@ def main():
 
         ServerStatusUtil.switchTOLSWSCLI(args.licenseKey)
 
+    else:
+        parser.print_help()
+        print(f"\nUnknown function: {args.function}\n")
+        print("Available functions:\n")
+
+        allowed_functions = parser.getAllowedFunctions()
+
+        for category, funcs in allowed_functions.items():
+            print(f"{category}:")
+            for function in funcs:
+                print(f"\t{function}")
+            print()
 
 if __name__ == "__main__":
     main()

--- a/cli/cyberPanel.py
+++ b/cli/cyberPanel.py
@@ -30,10 +30,15 @@ from plogical.backupSchedule import backupSchedule
 # All that we see or seem is but a dream within a dream.
 
 def get_cyberpanel_version():
-    with open('/usr/local/CyberCP/version.txt') as version:
-        version_file = version.read()
-        version = json.loads(str(version_file))
-    return f"{version['version']}.{version['build']}"
+    with open('/usr/local/CyberCP/version.txt') as file:
+        content = file.read()
+        try:
+            data = json.loads(content)
+            version = data['version']
+            build = data['build']
+        except json.JSONDecodeError:
+            version, build = content.split()           
+    return f"{version}.{build}"
 
 
 class cyberPanel:


### PR DESCRIPTION
While orchestrating CyberPanel with Ansible, I decided to leverage the cyberpanel-cli. While I have the programming knowledge to understand the functionalities of the cli and how to invoke them, the user-friendliness of the CLI was lacking in certain areas (for example, no info was provided about which functions the user could call). The code changes in this pull request have therefore focused on improving user-friendliness in the following areas:

1. Added a new method `getAllowedFunctions()` to the cliParser class that maintains a static list of available functions. These functions are grouped into categories such as "Website Management", "DNS Management", "Backup Management" and more. This list is used to validate the function argument provided by the user and to print the list of available functions if an unknown function is provided.
Improved the error handling when an unknown function is provided as argument to the cli. Now it not only prints the help message from ArgumentParser, but also indicates that the function is unknown and prints a neatly formatted list of available functions.

2. Additionally, I've corrected the version output, as it was not working correctly:
I've updated the `get_cyberpanel_version` function to handle non-JSON data. Previously, it could only interpret JSON formatted data from version.txt and would fail if the data was provided as plain text lines (which is the case after a new installation). The function now attempts to interpret the data as JSON first and if that fails, it tries to interpret the data as plain text lines. This allows for greater flexibility in the format of the data in version.txt, making the function more robust to changes in the way version information is stored.

The proposed changes aim to make the CyberPanel CLI more user-friendly, especially for users who aren't familiar with the underlying code or Python programming. I hope these changes are helpful and I welcome any feedback.