### PR TITLE
make sure TTL is 0-86400 inclusive when add or update

### DIFF
--- a/dns/dnsManager.py
+++ b/dns/dnsManager.py
@@ -257,6 +257,10 @@ class DNSManager:
             recordType = data['recordType']
             recordName = data['recordName']
             ttl = int(data['ttl'])
+            if ttl < 0:
+                raise ValueError("TTL: The item must be greater than 0")
+            elif ttl > 86400:
+                raise ValueError("TTL: The item must be lesser than 86401")
 
             admin = Administrator.objects.get(pk=userID)
             if ACLManager.checkOwnershipZone(zoneDomain, admin, currentACL) == 1:
@@ -444,6 +448,10 @@ class DNSManager:
 
             if data['ttlNow'] != None:
                 record.ttl = int(data['ttlNow'])
+                if record.ttl < 0:
+                    raise ValueError("TTL: The item must be greater than 0")
+                elif record.ttl > 86400:
+                    raise ValueError("TTL: The item must be lesser than 86401")
 
             if data['priorityNow'] != None:
                 record.prio = int(data['priorityNow'])
@@ -826,6 +834,10 @@ class DNSManager:
             recordType = data['recordType']
             recordName = data['recordName']
             ttl = int(data['ttl'])
+            if ttl < 0:
+                raise ValueError("TTL: The item must be greater than 0")
+            elif ttl > 86400:
+                raise ValueError("TTL: The item must be lesser than 86401")
 
             admin = Administrator.objects.get(pk=userID)
             self.admin = admin

--- a/dns/templates/dns/addDeleteDNSRecords.html
+++ b/dns/templates/dns/addDeleteDNSRecords.html
@@ -88,7 +88,7 @@
                                 </div>
 
                                 <div class="col-sm-3 aRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -114,7 +114,7 @@
                                 </div>
 
                                 <div class="col-sm-3 aaaaRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -141,7 +141,7 @@
                                 </div>
 
                                 <div class="col-sm-3 cNameRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -167,7 +167,7 @@
                                 </div>
 
                                 <div class="col-sm-2 mxRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -199,7 +199,7 @@
                                 </div>
 
                                 <div class="col-sm-3 spfRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -226,7 +226,7 @@
                                 </div>
 
                                 <div class="col-sm-3 txtRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -253,7 +253,7 @@
                                 </div>
 
                                 <div class="col-sm-3 soaRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -280,7 +280,7 @@
                                 </div>
 
                                 <div class="col-sm-3 nsRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -307,7 +307,7 @@
                                 </div>
 
                                 <div class="col-sm-2 srvRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
 
@@ -337,7 +337,7 @@
                                            ng-model="recordName">
                                 </div>
                                 <div class="col-sm-3 caaRecord">
-                                    <input placeholder="{% trans 'TTL' %}" type="number" class="form-control"
+                                    <input placeholder="{% trans 'TTL' %}" type="number" min="0" max="86400" class="form-control"
                                            ng-model="ttl" required>
                                 </div>
                                 <div class="col-sm-3 caaRecord">


### PR DESCRIPTION
This PR ensures that user can't pass a negative or out-of-bounds TTL value. ~User can still enter a negative value through CyberPanel but this makes sure that the value is not saved.~

EDIT: added a commit so input field has ```min=0``` and ```max=86400```.

NOTE TO REVIEWERS:
There is room for improvement in cloudAPI - are there any major plans to overhaul cloudAPI? I would be willing to provide a PR with a proof of concept on how we can improve it somewhat without breaking the existing endpoints.