### PR TITLE
Fix for CentOS 7 installation DNF error

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -60,7 +60,7 @@ def get_distro():
             return cent8
         if data.find('Rocky Linux release 8') > -1 or data.find('Rocky Linux 8') > -1 or data.find('rocky:8') > -1:
             return cent8
-        if data.find('CloudLinux 8') or data.find('cloudlinux 8'):
+        if data.find('CloudLinux 8') > -1 or data.find('cloudlinux 8') > -1:
             return cent8
 
     else:

--- a/install/installCyberPanel.py
+++ b/install/installCyberPanel.py
@@ -360,7 +360,7 @@ gpgcheck=1
             WriteToFile.write(RepoContent)
             WriteToFile.close()
 
-            command = 'dnf install mariadb-server -y'
+            command = 'yum install mariadb-server -y'
         elif self.distro == cent8 or self.distro == openeuler:
 
             clAPVersion = FetchCloudLinuxAlmaVersionVersion()

--- a/install/installCyberPanel.py
+++ b/install/installCyberPanel.py
@@ -347,20 +347,7 @@ Signed-By: /etc/apt/keyrings/mariadb-keyring.pgp
             command = "DEBIAN_FRONTEND=noninteractive apt-get install mariadb-server -y"
         elif self.distro == centos:
 
-            RepoPath = '/etc/yum.repos.d/mariadb.repo'
-            RepoContent = f"""
-[mariadb]
-name = MariaDB
-baseurl = http://yum.mariadb.org/10.11/rhel8-amd64
-module_hotfixes=1
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1            
-"""
-            WriteToFile = open(RepoPath, 'w')
-            WriteToFile.write(RepoContent)
-            WriteToFile.close()
-
-            command = 'yum install mariadb-server -y'
+            command = 'yum --enablerepo=mariadb -y install MariaDB-server MariaDB-client'
         elif self.distro == cent8 or self.distro == openeuler:
 
             clAPVersion = FetchCloudLinuxAlmaVersionVersion()


### PR DESCRIPTION
When installing on CentOS 7, since the operating system is detected as CentOS 8, services are tried to be installed with dnf instead of yum, so an error is received.

Example error : FileNotFoundError: [Errno 2] No such file or directory: 'dnf': 'dnf'