### PR TITLE
Update cyberpanel.sh - fix install failure with python error 'unexpected keyword argument: "strip_trailing_zero"'

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -1110,6 +1110,13 @@ export LC_CTYPE=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 #need to set lang to address some pip module installation issue.
 
+### @micfogas - code added to force updating of python3 package 'packaging' to version 22 or higher to avoid fatal error
+###
+Debug_Log2 "Force updating pip package 'packaging' to \>\=22...,40"
+pip install packaging>=22 --root-user-action=ignore --break-system-packages -U --force-reinstall -I
+###
+### @micfogas end code addition
+
 Retry_Command "pip install --default-timeout=3600 virtualenv"
 
 Download_Requirement


### PR DESCRIPTION
Added code prior to the script's python virtualenv install that upgrades python's 'packaging' package. Recent changes by the pypi team to pip will cause an error of "strip-trailing-zero" in versions of "packaging" that are lower than 22.
- code executes pip command to install/reinstall the "packaging" package, even if the package was installed by your distro package manager.  *** AlmaLinux 9 (and likely other yum/dnf distros) uses version 20.9 of "packaging" in the rpm repos. Other distros may be affected. ***