### PR TITLE
Fix "Session reuse detected, IPAddress logged."

### DIFF
--- a/CyberCP/secMiddleware.py
+++ b/CyberCP/secMiddleware.py
@@ -13,7 +13,7 @@ class secMiddleware:
     LOW = 1
 
     def get_client_ip(request):
-        ip = request.META.get('HTTP_CF_CONNECTING_IP')
+        ip = request.META.get('HTTP_CF_CONNECTING_IP') | request.META.get('True-Client-IP')
         if ip is None:
             ip = request.META.get('REMOTE_ADDR')
         return ip


### PR DESCRIPTION
After updating Cyberpanel, when the app is served behind Cloudflare, it is common to encounter the following logging message:
"Session reuse detected, IPAddress logged."

The solution is to retrieve the 'True-Client-IP' from the request headers and use it if present.