### PR TITLE
Enhance MySQL/MariaDB development headers installation in upgrade scr…

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -1805,7 +1805,123 @@ fi
 
 Debug_Log2 "Installing requirments..,3"
 
-Retry_Command "pip install --default-timeout=3600 -r /usr/local/requirments.txt"
+# Install MySQL/MariaDB development headers for mysqlclient Python package
+echo "Installing MySQL/MariaDB development headers for Python packages..."
+
+# Ensure MariaDB repository is available for development packages
+if [[ "$Server_OS" =~ ^(CentOS|RHEL|AlmaLinux|RockyLinux|CloudLinux) ]]; then
+  echo "Setting up MariaDB repository for development packages..."
+  if command -v dnf >/dev/null 2>&1; then
+    # Try to add MariaDB repository if not present
+    if ! dnf repolist | grep -q "mariadb"; then
+      curl -sS "https://downloads.mariadb.com/MariaDB/mariadb_repo_setup" | bash -s -- --mariadb-server-version="10.11" --skip-maxscale --skip-tools
+    fi
+  fi
+fi
+if [[ "$Server_OS" = "Ubuntu" ]] || [[ "$Server_OS" = "Debian" ]]; then
+  # Ubuntu/Debian - comprehensive development packages
+  apt-get update -y
+  apt-get install -y \
+    libmariadb-dev \
+    libmariadb-dev-compat \
+    libmysqlclient-dev \
+    pkg-config \
+    build-essential \
+    python3-dev \
+    python3-pip \
+    libssl-dev \
+    libffi-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libffi-dev \
+    liblzma-dev
+elif [[ "$Server_OS" =~ ^(CentOS|RHEL|AlmaLinux|RockyLinux|CloudLinux) ]]; then
+  # RHEL-based systems - comprehensive development packages
+  if command -v dnf >/dev/null 2>&1; then
+    dnf install -y \
+      mariadb-devel \
+      mysql-devel \
+      pkgconfig \
+      gcc \
+      gcc-c++ \
+      python3-devel \
+      openssl-devel \
+      libffi-devel \
+      zlib-devel \
+      bzip2-devel \
+      readline-devel \
+      sqlite-devel \
+      ncurses-devel \
+      xz-devel \
+      tk-devel \
+      libxml2-devel \
+      libxmlsec1-devel \
+      lzma-devel
+  else
+    yum install -y \
+      mariadb-devel \
+      mysql-devel \
+      pkgconfig \
+      gcc \
+      gcc-c++ \
+      python3-devel \
+      openssl-devel \
+      libffi-devel \
+      zlib-devel \
+      bzip2-devel \
+      readline-devel \
+      sqlite-devel \
+      ncurses-devel \
+      xz-devel \
+      tk-devel \
+      libxml2-devel \
+      libxmlsec1-devel \
+      lzma-devel
+  fi
+fi
+
+# Verify pkg-config can find MySQL libraries
+echo "Verifying MySQL development headers installation..."
+if pkg-config --exists mysqlclient; then
+  echo "mysqlclient found via pkg-config"
+elif pkg-config --exists mariadb; then
+  echo "mariadb found via pkg-config"
+else
+  echo "WARNING: MySQL development headers not found via pkg-config"
+  # Try to set environment variables manually
+  export MYSQLCLIENT_CFLAGS="-I/usr/include/mysql"
+  export MYSQLCLIENT_LDFLAGS="-L/usr/lib64/mysql -lmysqlclient"
+  echo "Set MYSQLCLIENT environment variables as fallback"
+fi
+
+# Try pip install with enhanced error handling
+echo "Installing Python requirements with enhanced MySQL support..."
+if ! Retry_Command "pip install --default-timeout=3600 -r /usr/local/requirments.txt"; then
+  echo "Standard pip install failed, trying alternative mysqlclient installation..."
+  
+  # Try installing mysqlclient separately with specific flags
+  echo "Attempting alternative MySQL client installations..."
+  
+  # Try pre-compiled wheels first
+  pip install --no-cache-dir --only-binary=all mysqlclient==2.2.7 || \
+  pip install --no-cache-dir --only-binary=all mysqlclient || \
+  pip install --no-cache-dir --force-reinstall mysqlclient==2.2.7 || \
+  pip install --no-cache-dir --force-reinstall PyMySQL || \
+  pip install --no-cache-dir --force-reinstall mysql-connector-python || \
+  pip install --no-cache-dir --force-reinstall pymysql
+  
+  echo "Alternative MySQL client installation completed"
+  
+  # Then try the requirements again
+  Retry_Command "pip install --default-timeout=3600 -r /usr/local/requirments.txt"
+fi
   Check_Return "requirments" "no_exit"
 
 # Change to /usr/local directory to clone CyberPanel

--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -1069,6 +1069,21 @@ if ! /usr/local/CyberCP/bin/python -c "import django" 2>/dev/null; then
   # Re-activate virtual environment
   source /usr/local/CyberCP/bin/activate
   
+  # Install MySQL/MariaDB development headers for mysqlclient Python package
+  echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Installing MySQL/MariaDB development headers..." | tee -a /var/log/cyberpanel_upgrade_debug.log
+  if [[ "$Server_OS" = "Ubuntu" ]] || [[ "$Server_OS" = "Debian" ]]; then
+    # Ubuntu/Debian
+    apt-get update -y
+    apt-get install -y libmariadb-dev libmariadb-dev-compat pkg-config build-essential
+  elif [[ "$Server_OS" =~ ^(CentOS|RHEL|AlmaLinux|RockyLinux|CloudLinux) ]]; then
+    # RHEL-based systems
+    if command -v dnf >/dev/null 2>&1; then
+      dnf install -y mariadb-devel pkgconfig gcc python3-devel
+    else
+      yum install -y mariadb-devel pkgconfig gcc python3-devel
+    fi
+  fi
+  
   # Re-install requirements
   echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Re-installing Python requirements..." | tee -a /var/log/cyberpanel_upgrade_debug.log
   pip install --default-timeout=3600 --ignore-installed -r /usr/local/requirments.txt 2>&1 | tee -a /var/log/cyberpanel_upgrade_debug.log


### PR DESCRIPTION
…ipts

- Added installation steps for MySQL/MariaDB development headers in both cyberpanel.sh and cyberpanel_upgrade.sh to support the mysqlclient Python package.
- Implemented checks for different operating systems (Ubuntu, Debian, CentOS, RHEL, etc.) to ensure the correct packages are installed.
- Enhanced error handling during Python requirements installation with fallback options for mysqlclient.
- Verified the installation of MySQL development headers using pkg-config.