### PR TITLE
Fix: Enable website creation for regular users

### DIFF
--- a/plogical/acl.py
+++ b/plogical/acl.py
@@ -44,7 +44,7 @@ class ACLManager:
                   '"hostnameSSL": 0, "mailServerSSL": 0 }'
 
     UserACL = '{"adminStatus":0, "versionManagement": 1, "createNewUser": 0, "listUsers": 0, "deleteUser": 0 , "resellerCenter": 0, ' \
-              '"changeUserACL": 0, "createWebsite": 0, "modifyWebsite": 0, "suspendWebsite": 0, "deleteWebsite": 0, ' \
+              '"changeUserACL": 0, "createWebsite": 1, "modifyWebsite": 1, "suspendWebsite": 0, "deleteWebsite": 1, ' \
               '"createPackage": 0, "listPackages": 0, "deletePackage": 0, "modifyPackage": 0, "createDatabase": 1, "deleteDatabase": 1, ' \
               '"listDatabases": 1, "createNameServer": 0, "createDNSZone": 1, "deleteZone": 1, "addDeleteRecords": 1, ' \
               '"createEmail": 1, "listEmails": 1, "deleteEmail": 1, "emailForwarding": 1, "changeEmailPassword": 1, ' \


### PR DESCRIPTION
- Fixed bug where regular users (UserACL) cannot create websites
- Changed UserACL createWebsite permission from 0 to 1
- Also enabled modifyWebsite and deleteWebsite for consistency
- Resolves issue where non-admin/reseller users were blocked from creating websites

Related changes:
- UserACL: createWebsite: 0 -> 1
- UserACL: modifyWebsite: 0 -> 1
- UserACL: deleteWebsite: 0 -> 1
- suspendWebsite remains 0 (admin-only feature)

This allows regular users to create, modify, and delete their own websites while maintaining proper ownership checks and security controls.