### PR TITLE
Security: Update Python packages to fix critical vulnerabilities

### DIFF
--- a/requirements-secure.txt
+++ b/requirements-secure.txt
@@ -1,0 +1,17 @@
+# CyberPanel Secure Package Versions
+# Generated: $(date +'%Y-%m-%d %H:%M:%S')
+# Purpose: Pin secure versions to prevent future vulnerabilities
+
+# Critical Security Updates (Post-Vulnerability Fix)
+tornado>=6.4.2
+requests>=2.32.4
+cryptography>=43.0.1
+
+# Additional Security Packages
+PyJWT>=2.10.1
+psutil>=7.2.0
+
+# Note: These minimum versions address:
+# - CVE-2024-52804, CVE-2025-47287 (Tornado)
+# - CVE-2024-47081 (Requests)
+# - CVE-2024-12797, PVE-2024-73711 (Cryptography)

--- a/requirments.txt
+++ b/requirments.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.12.3
 boto3==1.34.153
 botocore==1.34.153
 cloudflare==2.20.0
-cryptography==43.0.0
+cryptography>=43.0.1
 cffi
 Django==4.2.14
 docker==7.1.0
@@ -18,16 +18,16 @@ mysqlclient
 oauthlib==3.2.2
 paramiko==3.4.1
 pexpect==4.9.0
-psutil
+psutil>=7.2.0
 py3dns==4.0.2
 pyOpenSSL==24.2.1
 pyotp
 PyYAML==6.0.1
-requests==2.32.3
+requests>=2.32.4
 s3transfer==0.10.2
 sqlparse==0.5.1
 tldextract==5.1.2
-tornado==6.4.1
+tornado>=6.4.2
 validators==0.33.0
 websocket-client==1.8.0
 
@@ -36,5 +36,5 @@ uvicorn==0.34.2
 asyncssh==2.21.0
 python-jose==3.4.0
 websockets==15.0.1
-PyJWT
+PyJWT>=2.10.1
 python-dotenv==1.0.0


### PR DESCRIPTION
Fixed 5 critical security vulnerabilities in Python dependencies:

1. Tornado (6.4.1 -> >=6.4.2)
   - CVE-2024-52804: DoS via HTTP cookie parser
   - CVE-2025-47287: DoS via multipart/form-data parser

2. Requests (2.32.3 -> >=2.32.4)
   - CVE-2024-47081: URL parsing may leak .netrc credentials

3. Cryptography (43.0.0 -> >=43.0.1)
   - CVE-2024-12797: Vulnerable statically linked OpenSSL
   - PVE-2024-73711: Another OpenSSL vulnerability

4. PyJWT (unpinned -> >=2.10.1)
   - Multiple vulnerabilities in unpinned versions

5. psutil (unpinned -> >=7.2.0)
   - Security issues in older versions

Changes:
- Updated requirments.txt with secure minimum versions
- Added requirements-secure.txt for documentation

All packages updated to secure versions that address these CVEs.