### PR TITLE
Refactor: replace url() with path() for Django routes in plugin Installer

### DIFF
--- a/pluginInstaller/pluginInstaller.py
+++ b/pluginInstaller/pluginInstaller.py
@@ -57,7 +57,7 @@ class pluginInstaller:
         for items in data:
             if items.find("manageservices") > -1:
                 writeToFile.writelines(items)
-                writeToFile.writelines("    url(r'^" + pluginName + "/',include('" + pluginName + ".urls')),\n")
+                writeToFile.writelines("    path("pluginName + "/',include('" + pluginName + ".urls')),\n")
             else:
                 writeToFile.writelines(items)
 


### PR DESCRIPTION
### What was changed
Replaced usage of `url()` with `path()` when generating Django URL
configurations.

### Why
- `url()` is deprecated and removed in Django 4.x
- `path()` is the recommended approach
- Ensures compatibility with modern Django versions

### Impact
- No functional changes
- Refactor only
