### PR TITLE
Refactor: replace url() with path() for Django routes in plugin Insta…

### DIFF
--- a/pluginHolder/urls.py
+++ b/pluginHolder/urls.py
@@ -3,4 +3,8 @@ from . import views
 
 urlpatterns = [
     path('installed', views.installed, name='installed'),
+    path('api/install/<str:plugin_name>/', views.install_plugin, name='install_plugin'),
+    path('api/uninstall/<str:plugin_name>/', views.uninstall_plugin, name='uninstall_plugin'),
+    path('api/enable/<str:plugin_name>/', views.enable_plugin, name='enable_plugin'),
+    path('api/disable/<str:plugin_name>/', views.disable_plugin, name='disable_plugin'),
 ]


### PR DESCRIPTION
…ller

- Updated pluginHolder/urls.py to use path() instead of url()
- Added new API routes for plugin installation, uninstallation, enable, and disable
- Compatible with Django 4.x (url() was removed in Django 4.0)

Ref: PR [1644](https://github.com/usmannasir/cyberpanel/pull/1644)