### PR TITLE
fix: auto-elevate installer/upgrade

### DIFF
--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -14,6 +14,20 @@
 Sudo_Test=$(set)
 #for SUDO check
 
+# Re-exec with elevation if not running as root
+if [[ $(id -u) != 0 ]]; then
+  SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+  for elevate in sudo doas run0 pkexec; do
+    if command -v "$elevate" >/dev/null 2>&1; then
+      echo "Elevating with $elevate"
+      "$elevate" env "XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-}" "SUDO_USER=$(whoami)" "$SCRIPT_PATH" "$@"
+      exit $?
+    fi
+  done
+  echo "Please install sudo, doas, run0 (systemd), or pkexec (polkit) to continue."
+  exit 1
+fi
+
 Set_Default_Variables() {
 
 # Clear old log files
@@ -91,12 +105,6 @@ echo -e "\n${1}" >> /var/log/upgradeLogs.txt
 
 Check_Root() {
 echo -e "\nChecking root privileges..."
-  if echo "$Sudo_Test" | grep SUDO >/dev/null; then
-    echo -e "\nYou are using SUDO, please run as root user...\n"
-    echo -e "\nIf you don't have direct access to root user, please run \e[31msudo su -\e[39m command (do NOT miss the \e[31m-\e[39m at end or it will fail) and then run installation command again."
-    exit
-  fi
-
   if [[ $(id -u) != 0 ]] >/dev/null; then
     echo -e "\nYou must run as root user to install CyberPanel...\n"
     echo -e "or run the following command: (do NOT miss the quotes)"
@@ -149,10 +157,10 @@ elif grep -q -E "CloudLinux 7|CloudLinux 8|CloudLinux 9" /etc/os-release ; then
   Server_OS="CloudLinux"
 elif grep -q -E "Rocky Linux" /etc/os-release ; then
   Server_OS="RockyLinux"
-elif grep -q -E "AlmaLinux-8|AlmaLinux-9|AlmaLinux-10" /etc/os-release ; then
+elif grep -q -E "AlmaLinux( |-)?8|AlmaLinux( |-)?9|AlmaLinux( |-)?10" /etc/os-release ; then
   Server_OS="AlmaLinux"
   # Set specific version for AlmaLinux 9+ to use dnf instead of yum
-  if grep -q -E "AlmaLinux-9|AlmaLinux-10" /etc/os-release ; then
+  if grep -q -E "AlmaLinux( |-)?9|AlmaLinux( |-)?10" /etc/os-release ; then
     Server_OS="AlmaLinux9"
   fi
 elif grep -q -E "Ubuntu 18.04|Ubuntu 20.04|Ubuntu 20.10|Ubuntu 22.04|Ubuntu 24.04|Ubuntu 24.04.3" /etc/os-release ; then
@@ -527,7 +535,7 @@ elif [[ "$Server_OS" = "Ubuntu" ]] ; then
     groupadd nobody
   fi
 
-  apt update -y
+  apt-get update -y
   export DEBIAN_FRONTEND=noninteractive ; apt-get -o Dpkg::Options::="--force-confold" upgrade -y
 
   if [[ "$Server_OS_Version" = "22" ]] || [[ "$Server_OS_Version" = "24" ]] ; then
@@ -577,7 +585,7 @@ elif [[ "$Server_OS" = "Ubuntu" ]] ; then
     #fix ubuntu 20 webmail login issue
 
     rm -f /etc/apt/sources.list.d/dovecot.list
-    apt update
+    apt-get update -y
     DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical apt -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade -y
   fi
 #all pre-upgrade operation for Ubuntu 20
@@ -858,22 +866,6 @@ if [[ "$Server_Country" = "CN" ]] ; then
   sed -i 's|https://cyberpanel.sh/composer.sh|https://gitee.com/qtwrk/cyberpanel/raw/stable/install/composer_cn.sh|g' upgrade.py
 fi
 
-}
-
-Pre_Upgrade_Setup_Git_URL() {
-if [[ $Server_Country != "CN" ]] ; then
-  Git_User="usmannasir"
-  Git_Content_URL="https://raw.githubusercontent.com/${Git_User}/cyberpanel"
-  Git_Clone_URL="https://github.com/${Git_User}/cyberpanel.git"
-else
-  Git_User="qtwrk"
-  Git_Content_URL="https://gitee.com/${Git_User}/cyberpanel/raw"
-  Git_Clone_URL="https://gitee.com/${Git_User}/cyberpanel.git"
-fi
-
-if [[ "$Debug" = "On" ]] ; then
-  Debug_Log "Git_URL" "$Git_Content_URL"
-fi
 }
 
 Pre_Upgrade_Branch_Input() {

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,38 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # CyberPanel v2.5.5-dev Installer
 # Simplified approach similar to stable branch
 
+# Re-exec with elevation if not running as root
+if [ "$(id -u)" -ne 0 ]; then
+    SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+    for elevate in sudo doas run0 pkexec; do
+        if command -v "$elevate" >/dev/null 2>&1; then
+            echo "Elevating with $elevate"
+            "$elevate" env "XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-}" "SUDO_USER=$(whoami)" "$SCRIPT_PATH" "$@"
+            exit $?
+        fi
+    done
+
+    echo "Please install sudo, doas, run0 (systemd), or pkexec (polkit) to continue."
+    exit 1
+fi
+
 # Determine branch from arguments or use default
 BRANCH_NAME="v2.5.5-dev"
-for arg in "$@"; do
-    case "$arg" in
+while [ "$#" -gt 0 ]; do
+    case "$1" in
         -b|--branch)
-            BRANCH_NAME="$2"
-            shift 2
+            if [ -n "${2:-}" ]; then
+                BRANCH_NAME="$2"
+                shift 2
+            else
+                echo "❌ Missing value for $1"
+                exit 1
+            fi
+            ;;
+        *)
+            shift
             ;;
     esac
 done


### PR DESCRIPTION
Fix: ensure install/upgrade scripts re-exec with sudo/doas/run0/pkexec when not root, and avoid blocking in upgrade root checks. Also includes earlier install/upgrade robustness fixes already on this branch.