### PR TITLE
Remove wrong "manage" directory from essential directories list

### DIFF
--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -593,7 +593,6 @@ CYBERCP_ESSENTIAL_DIRS=(
     "/usr/local/CyberCP/CyberCP"
     "/usr/local/CyberCP/plogical"
     "/usr/local/CyberCP/websiteFunctions"
-    "/usr/local/CyberCP/manage"
 )
 
 CYBERCP_MISSING=0


### PR DESCRIPTION
Removed '/usr/local/CyberCP/manage' from essential directories. This directory does not exist. This line caused problem by triggering Recovery which could not solve the "problem" either.