### PR TITLE
Fix SSL installation process: add ECC support and update renewal comm…

### DIFF
--- a/plogical/customACME.py
+++ b/plogical/customACME.py
@@ -19,7 +19,7 @@ import socket
 
 
 class CustomACME:
-    def __init__(self, domain, admin_email, staging=False, provider='letsencrypt'):
+    def __init__(self, domain, admin_email, staging=False, provider='letsencrypt', challenge_path=None):
         """Initialize CustomACME"""
         logging.CyberCPLogFileWriter.writeToFile(
             f'Initializing CustomACME for domain: {domain}, email: {admin_email}, staging: {staging}, provider: {provider}')
@@ -55,7 +55,8 @@ class CustomACME:
 
         # Initialize paths
         self.cert_path = f'/etc/letsencrypt/live/{domain}'
-        self.challenge_path = '/usr/local/lsws/Example/html/.well-known/acme-challenge'
+        default_challenge_path = '/usr/local/lsws/Example/html/.well-known/acme-challenge'
+        self.challenge_path = challenge_path or default_challenge_path
         self.account_key_path = f'/etc/letsencrypt/accounts/{domain}.key'
         logging.CyberCPLogFileWriter.writeToFile(
             f'Certificate path: {self.cert_path}, Challenge path: {self.challenge_path}')
@@ -296,25 +297,21 @@ class CustomACME:
             logging.CyberCPLogFileWriter.writeToFile(f'Account creation response status: {response.status_code}')
             logging.CyberCPLogFileWriter.writeToFile(f'Account creation response: {response.text}')
 
-            if response.status_code == 201:
-                self.account_url = response.headers['Location']
+            if response.status_code in (200, 201):
+                self.account_url = response.headers.get('Location')
+                if not self.account_url:
+                    logging.CyberCPLogFileWriter.writeToFile(
+                        'ACME account response did not include Location header')
+                    return False
                 logging.CyberCPLogFileWriter.writeToFile(
-                    f'Successfully created account. Account URL: {self.account_url}')
+                    f'Successfully loaded ACME account. Account URL: {self.account_url}')
                 # Save the account key for future use
                 self._save_account_key()
                 return True
             elif response.status_code == 429:
                 logging.CyberCPLogFileWriter.writeToFile(
-                    'Rate limit hit for account creation. Using staging environment...')
-                self.staging = True
-                self.acme_directory = "https://acme-staging-v02.api.letsencrypt.org/directory"
-                # Get new directory and nonce for staging
-                if not self._get_directory():
-                    return False
-                if not self._get_nonce():
-                    return False
-                # Try one more time with staging
-                return self._create_account()
+                    'Rate limit hit for ACME account creation. Not switching production issuance to staging.')
+                return False
             elif response.status_code == 400 and "badNonce" in response.text:
                 logging.CyberCPLogFileWriter.writeToFile('Bad nonce, getting new nonce and retrying...')
                 if not self._get_nonce():
@@ -965,7 +962,8 @@ class CustomACME:
                 f'Starting certificate issuance for domains: {domains}, use_dns: {use_dns}')
 
             # Try to load existing account key first
-            if self._load_account_key():
+            account_key_loaded = self._load_account_key()
+            if account_key_loaded:
                 logging.CyberCPLogFileWriter.writeToFile('Using existing account key')
             else:
                 logging.CyberCPLogFileWriter.writeToFile('No existing account key found, will create new one')
@@ -983,10 +981,13 @@ class CustomACME:
                 return False
 
             # Initialize ACME
-            logging.CyberCPLogFileWriter.writeToFile('Step 1: Generating account key')
-            if not self._generate_account_key():
-                logging.CyberCPLogFileWriter.writeToFile('Failed to generate account key')
-                return False
+            if account_key_loaded:
+                logging.CyberCPLogFileWriter.writeToFile('Step 1: Using existing account key')
+            else:
+                logging.CyberCPLogFileWriter.writeToFile('Step 1: Generating account key')
+                if not self._generate_account_key():
+                    logging.CyberCPLogFileWriter.writeToFile('Failed to generate account key')
+                    return False
 
             logging.CyberCPLogFileWriter.writeToFile('Step 2: Getting ACME directory')
             if not self._get_directory():
@@ -1001,19 +1002,7 @@ class CustomACME:
             logging.CyberCPLogFileWriter.writeToFile('Step 4: Creating account')
             if not self._create_account():
                 logging.CyberCPLogFileWriter.writeToFile('Failed to create account')
-                # If we failed to create account and we're not in staging, try staging
-                if not self.staging:
-                    logging.CyberCPLogFileWriter.writeToFile('Switching to staging environment...')
-                    self.staging = True
-                    self.acme_directory = "https://acme-staging-v02.api.letsencrypt.org/directory"
-                    if not self._get_directory():
-                        return False
-                    if not self._get_nonce():
-                        return False
-                    if not self._create_account():
-                        return False
-                else:
-                    return False
+                return False
 
             # Create order with only valid domains
             logging.CyberCPLogFileWriter.writeToFile('Step 5: Creating order')
@@ -1150,4 +1139,4 @@ class CustomACME:
             return True
         except Exception as e:
             logging.CyberCPLogFileWriter.writeToFile(f'Error issuing certificate: {str(e)}')
-            return False 
+            return False

--- a/plogical/renew.py
+++ b/plogical/renew.py
@@ -30,9 +30,18 @@ class Renew:
                 return
 
             logging.writeToFile(f'SSL exists for {domain}. Checking if SSL will expire in 15 days..', 0)
-            
-            with open(file_path, 'r') as cert_file:
-                x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_file.read())
+
+            try:
+                x509 = ssl_utils_module._ssl_load_certificate(file_path)
+            except (OpenSSL.crypto.Error, OSError, ValueError, UnicodeError) as e:
+                logging.writeToFile(
+                    f'Invalid SSL certificate for {domain}: {str(e)}. Obtaining a new certificate..', 1)
+                result = virtualHostUtilities.issueSSL(domain, path, admin_email)
+                if result[0] == 0:
+                    logging.writeToFile(f'SSL replacement FAILED for {domain}: {result[1]}', 1)
+                else:
+                    logging.writeToFile(f'SSL replacement SUCCESSFUL for {domain}', 0)
+                return
             
             expire_data = x509.get_notAfter().decode('ascii')
             final_date = datetime.strptime(expire_data, '%Y%m%d%H%M%SZ')

--- a/plogical/renew.py
+++ b/plogical/renew.py
@@ -15,6 +15,7 @@ from websiteFunctions.models import Websites, ChildDomains
 import OpenSSL
 from plogical.virtualHostUtilities import virtualHostUtilities
 from plogical.processUtilities import ProcessUtilities
+from plogical import sslUtilities as ssl_utils_module
 
 class Renew:
     def _check_and_renew_ssl(self, domain: str, path: str, admin_email: str, is_child: bool = False) -> None:
@@ -38,11 +39,11 @@ class Renew:
             now = datetime.now()
             diff = final_date - now
 
-            ssl_provider = x509.get_issuer().get_components()[1][1].decode('utf-8')
+            ssl_provider = ssl_utils_module._ssl_get_certificate_issuer(file_path)
             logging.writeToFile(f'Provider: {ssl_provider}, Days until expiration: {diff.days}', 0)
 
             # Check if certificate is expired or needs renewal
-            is_staging_cert = ssl_provider == "(STAGING) Let's Encrypt"
+            is_staging_cert = ssl_utils_module._ssl_certificate_is_staging(file_path)
             needs_renewal = diff.days < 15 or is_staging_cert
 
             if not needs_renewal and ssl_provider != 'Denial':

--- a/plogical/renew.py
+++ b/plogical/renew.py
@@ -42,11 +42,16 @@ class Renew:
             logging.writeToFile(f'Provider: {ssl_provider}, Days until expiration: {diff.days}', 0)
 
             # Check if certificate is expired or needs renewal
-            needs_renewal = diff.days < 15  # This handles both negative (expired) and soon-to-expire certs
-            
+            is_staging_cert = ssl_provider == "(STAGING) Let's Encrypt"
+            needs_renewal = diff.days < 15 or is_staging_cert
+
             if not needs_renewal and ssl_provider != 'Denial':
                 logging.writeToFile(f'SSL exists for {domain} and is not ready to renew, skipping..', 0)
                 return
+
+            if is_staging_cert:
+                logging.writeToFile(
+                    f'SSL for {domain} was issued by Let\'s Encrypt staging. Forcing production renewal..', 0)
 
             # Handle expired certificates (negative days) with higher priority
             if diff.days < 0:
@@ -57,7 +62,7 @@ class Renew:
                     logging.writeToFile(f'SSL renewal FAILED for {domain}: {result[1]}', 1)
                 else:
                     logging.writeToFile(f'SSL renewal SUCCESSFUL for {domain}', 0)
-            elif ssl_provider == 'Denial' or ssl_provider == "Let's Encrypt":
+            elif ssl_provider == 'Denial' or ssl_provider == "Let's Encrypt" or is_staging_cert:
                 logging.writeToFile(f'SSL exists for {domain} and ready to renew (expires in {diff.days} days)..', 0)
                 logging.writeToFile(f'Attempting SSL renewal for {domain}..', 0)
                 result = virtualHostUtilities.issueSSL(domain, path, admin_email)

--- a/plogical/sslUtilities.py
+++ b/plogical/sslUtilities.py
@@ -14,7 +14,7 @@ except:
 from plogical.acl import ACLManager
 
 
-STAGING_LE_ISSUER = "(STAGING) Let's Encrypt"
+STAGING_LE_ISSUER_MARKER = "(STAGING)"
 
 
 def _ssl_get_certificate_issuer(cert_path):
@@ -43,12 +43,37 @@ def _ssl_get_certificate_issuer(cert_path):
 
 
 def _ssl_is_staging_provider(provider):
-    return provider == STAGING_LE_ISSUER
+    if not provider:
+        return False
+    return STAGING_LE_ISSUER_MARKER.lower() in str(provider).lower()
+
+
+def _ssl_certificate_is_staging(cert_path):
+    """Detect staging certificates from any issuer component, not a pinned CA name."""
+    try:
+        import OpenSSL
+        with open(cert_path, 'r') as cert_file:
+            cert_data = cert_file.read()
+        cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_data)
+        for _key, value in cert.get_issuer().get_components():
+            try:
+                issuer_value = value.decode('utf-8')
+            except BaseException:
+                issuer_value = str(value)
+            if _ssl_is_staging_provider(issuer_value):
+                return True
+    except BaseException as exc:
+        try:
+            logging.CyberCPLogFileWriter.writeToFile(
+                f'Failed to inspect SSL issuer components from {cert_path}: {str(exc)}')
+        except BaseException:
+            pass
+    return False
 
 
 def _ssl_live_cert_is_staging(domain):
     cert_path = '/etc/letsencrypt/live/%s/fullchain.pem' % (domain)
-    return _ssl_is_staging_provider(_ssl_get_certificate_issuer(cert_path))
+    return _ssl_certificate_is_staging(cert_path)
 
 
 class sslUtilities:
@@ -217,7 +242,7 @@ class sslUtilities:
 
             #### totally seprate check to see if both non-www and www are covered
 
-            if _ssl_is_staging_provider(SSLProvider):
+            if _ssl_certificate_is_staging(filePath):
                 return sslUtilities.ISSUE_SSL
 
             if SSLProvider == "Let's Encrypt":
@@ -750,23 +775,12 @@ context /.well-known/acme-challenge {
         sslUtilities.PatchVhostConf(virtualHostName)
 
         default_webroot = '/usr/local/lsws/Example/html'
-        # Child domains: use their docroot so HTTP-01 challenge is served from the correct vhost
-        if sslpath and str(sslpath).strip():
-            webroot = str(sslpath).strip().rstrip('/')
-            if webroot != default_webroot and os.path.isdir(webroot):
-                challenge_path = webroot + '/.well-known/acme-challenge'
-                if not os.path.exists(challenge_path):
-                    os.makedirs(challenge_path, exist_ok=True)
-                    command = f'chmod -R 755 {webroot}/.well-known'
-                    ProcessUtilities.executioner(command)
-                logging.CyberCPLogFileWriter.writeToFile(
-                    f"Using domain webroot for ACME challenge: {webroot}")
-            else:
-                webroot = default_webroot
-                challenge_path = None
-        else:
-            webroot = default_webroot
-            challenge_path = None
+        # Existing CyberPanel vhosts map the ACME context to the shared Example webroot.
+        # Keep issuance and renewal on that same path so HTTP-01 tokens are publicly served.
+        webroot = default_webroot
+        challenge_path = default_webroot + '/.well-known/acme-challenge'
+        logging.CyberCPLogFileWriter.writeToFile(
+            f"Using shared ACME challenge webroot: {webroot}")
 
         if not os.path.exists(default_webroot + '/.well-known/acme-challenge'):
             command = f'mkdir -p {default_webroot}/.well-known/acme-challenge'
@@ -1008,13 +1022,8 @@ context /.well-known/acme-challenge {
 
 
 def _ssl_resolve_acme_webroot(sslpath):
-    """Match obtainSSLForADomain webroot selection for HTTP-01 (child domains / custom docroot)."""
-    default_webroot = '/usr/local/lsws/Example/html'
-    if sslpath and str(sslpath).strip():
-        webroot = str(sslpath).strip().rstrip('/')
-        if webroot != default_webroot and os.path.isdir(webroot):
-            return webroot
-    return default_webroot
+    """Use the shared HTTP-01 webroot configured in existing CyberPanel vhosts."""
+    return '/usr/local/lsws/Example/html'
 
 
 def _ssl_privkey_is_ecdsa(privkey_path):
@@ -1098,7 +1107,7 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
                 diff = final_date - now
                 is_expired = diff.days < 0
                 ssl_provider = _ssl_get_certificate_issuer(existingCertPath)
-                is_staging_cert = _ssl_is_staging_provider(ssl_provider)
+                is_staging_cert = _ssl_certificate_is_staging(existingCertPath)
                 logging.CyberCPLogFileWriter.writeToFile(
                     f"Certificate for {domain} expires in {diff.days} days. Provider: {ssl_provider}")
             except Exception as e:
@@ -1185,16 +1194,20 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
 
             if os.path.exists(pathToStoreSSLFullChain):
                 SSLProvider = _ssl_get_certificate_issuer(pathToStoreSSLFullChain)
+                is_staging_cert = _ssl_certificate_is_staging(pathToStoreSSLFullChain)
 
-                if SSLProvider != 'Denial' and not _ssl_is_staging_provider(SSLProvider):
+                if SSLProvider != 'Denial' and not is_staging_cert:
                     if sslUtilities.installSSLForDomain(domain) == 1:
                         logging.CyberCPLogFileWriter.writeToFile(
                             "We are not able to get new SSL for " + domain + ". But there is an existing SSL, it might only be for the main domain (excluding www).")
                         return [1,
                                 "We are not able to get new SSL for " + domain + ". But there is an existing SSL, it might only be for the main domain (excluding www)." + " [issueSSLForDomain]"]
-                elif _ssl_is_staging_provider(SSLProvider):
+                elif is_staging_cert:
                     logging.CyberCPLogFileWriter.writeToFile(
                         "Existing SSL for " + domain + " is Let's Encrypt staging; not installing it as a valid certificate.")
+                    return [0,
+                            "Production SSL issuance failed for " + domain +
+                            "; the existing certificate is from a staging CA. [issueSSLForDomain]"]
 
             command = 'openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=' + domain + '" -keyout ' + pathToStoreSSLPrivKey + ' -out ' + pathToStoreSSLFullChain
             cmd = shlex.split(command)

--- a/plogical/sslUtilities.py
+++ b/plogical/sslUtilities.py
@@ -846,6 +846,7 @@ context /.well-known/acme-challenge {
                         if result.returncode == 0:
                             # Step 3: Install the certificate to the desired location
                             install_command = acmePath + " --install-cert -d " + virtualHostName \
+                                            + ' --ecc' \
                                             + ' --cert-file ' + existingCertPath + '/cert.pem' \
                                             + ' --key-file ' + existingCertPath + '/privkey.pem' \
                                             + ' --fullchain-file ' + existingCertPath + '/fullchain.pem'
@@ -902,6 +903,7 @@ context /.well-known/acme-challenge {
                     if result.returncode == 0:
                         # Step 2: Install the certificate to the desired location
                         install_command = acmePath + " --install-cert -d " + virtualHostName \
+                                        + ' --ecc' \
                                         + ' --cert-file ' + existingCertPath + '/cert.pem' \
                                         + ' --key-file ' + existingCertPath + '/privkey.pem' \
                                         + ' --fullchain-file ' + existingCertPath + '/fullchain.pem'
@@ -963,10 +965,10 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
                 if is_expired:
                     logging.CyberCPLogFileWriter.writeToFile(
                         f"Certificate is expired, using --issue --force for {domain}")
-                    command = f'{acmePath} --issue {renewal_domains} --webroot /usr/local/lsws/Example/html --force'
+                    command = f'{acmePath} --issue {renewal_domains} --webroot /usr/local/lsws/Example/html -k ec-256 --force'
                 else:
                     # Try to renew with explicit webroot
-                    command = f'{acmePath} --renew {renewal_domains} --webroot /usr/local/lsws/Example/html --force'
+                    command = f'{acmePath} --renew {renewal_domains} --webroot /usr/local/lsws/Example/html --ecc --force'
 
                 try:
                     result = subprocess.run(command, capture_output=True, text=True, shell=True)
@@ -977,6 +979,10 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
 
                 if result.returncode == 0:
                     logging.CyberCPLogFileWriter.writeToFile(f"Successfully renewed SSL for {domain}")
+                    # ADDED: Copy cert from acme.sh to /etc/letsencrypt/live/
+                    certPath = '/etc/letsencrypt/live/' + domain
+                    install_cmd = f'{acmePath} --install-cert -d {domain} --ecc --key-file {certPath}/privkey.pem --fullchain-file {certPath}/fullchain.pem'
+                    subprocess.call(install_cmd, shell=True)
                     if sslUtilities.installSSLForDomain(domain, adminEmail) == 1:
                         return [1, "SSL successfully renewed"]
                 else:

--- a/plogical/sslUtilities.py
+++ b/plogical/sslUtilities.py
@@ -14,6 +14,43 @@ except:
 from plogical.acl import ACLManager
 
 
+STAGING_LE_ISSUER = "(STAGING) Let's Encrypt"
+
+
+def _ssl_get_certificate_issuer(cert_path):
+    try:
+        import OpenSSL
+        with open(cert_path, 'r') as cert_file:
+            cert_data = cert_file.read()
+        cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_data)
+        components = cert.get_issuer().get_components()
+
+        for key, value in components:
+            if key == b'O':
+                return value.decode('utf-8')
+        for key, value in components:
+            if key == b'CN':
+                return value.decode('utf-8')
+        if len(components) > 1:
+            return components[1][1].decode('utf-8')
+    except BaseException as exc:
+        try:
+            logging.CyberCPLogFileWriter.writeToFile(
+                f'Failed to read SSL issuer from {cert_path}: {str(exc)}')
+        except BaseException:
+            pass
+    return None
+
+
+def _ssl_is_staging_provider(provider):
+    return provider == STAGING_LE_ISSUER
+
+
+def _ssl_live_cert_is_staging(domain):
+    cert_path = '/etc/letsencrypt/live/%s/fullchain.pem' % (domain)
+    return _ssl_is_staging_provider(_ssl_get_certificate_issuer(cert_path))
+
+
 class sslUtilities:
     Server_root = "/usr/local/lsws"
     redisConf = '/usr/local/lsws/conf/dvhost_redis.conf'
@@ -173,14 +210,14 @@ class sslUtilities:
         if os.path.exists(filePath):
             import OpenSSL
             x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, open(filePath, 'r').read())
-            SSLProvider = x509.get_issuer().get_components()[1][1].decode('utf-8')
+            SSLProvider = _ssl_get_certificate_issuer(filePath)
 
             if os.path.exists(ProcessUtilities.debugPath):
                 logging.CyberCPLogFileWriter.writeToFile(f'SSL provider for {virtualHostName} is {SSLProvider}.')
 
             #### totally seprate check to see if both non-www and www are covered
 
-            if SSLProvider == "(STAGING) Let's Encrypt":
+            if _ssl_is_staging_provider(SSLProvider):
                 return sslUtilities.ISSUE_SSL
 
             if SSLProvider == "Let's Encrypt":
@@ -518,22 +555,37 @@ context /.well-known/acme-challenge {
                 else:
 
                     if sslUtilities.checkIfSSLMap(virtualHostName) == 0:
+                        from plogical import installUtilities
 
-                        data = open("/usr/local/lsws/conf/httpd_config.conf").readlines()
-                        writeDataToFile = open("/usr/local/lsws/conf/httpd_config.conf", 'w')
-                        sslCheck = 0
+                        def modify_config(lines):
+                            """Add SSL map entry to existing SSL listener"""
+                            modified = []
+                            sslCheck = 0
 
-                        for items in data:
-                            if items.find("listener") > -1 and items.find("SSL") > -1:
-                                sslCheck = 1
+                            for line in lines:
+                                if line.find("listener") > -1 and line.find("SSL") > -1:
+                                    sslCheck = 1
 
-                            if (sslCheck == 1):
-                                writeDataToFile.writelines(items)
-                                writeDataToFile.writelines(map)
-                                sslCheck = 0
-                            else:
-                                writeDataToFile.writelines(items)
-                        writeDataToFile.close()
+                                if (sslCheck == 1):
+                                    modified.append(line)
+                                    modified.append(map)
+                                    sslCheck = 0
+                                else:
+                                    modified.append(line)
+
+                            return modified
+
+                        # Use safe modification with backup and validation
+                        success, error = installUtilities.installUtilities.safeModifyHttpdConfig(
+                            modify_config,
+                            f"Add SSL map entry for {virtualHostName}"
+                        )
+
+                        if not success:
+                            error_msg = error if error else "Unknown error"
+                            logging.CyberCPLogFileWriter.writeToFile(
+                                f"[sslUtilities] Failed to add SSL map entry: {error_msg}")
+                            raise BaseException(f"Failed to add SSL map entry: {error_msg}")
 
                     ###################### Write per host Configs for SSL ###################
 
@@ -697,11 +749,30 @@ context /.well-known/acme-challenge {
 
         sslUtilities.PatchVhostConf(virtualHostName)
 
-        if not os.path.exists('/usr/local/lsws/Example/html/.well-known/acme-challenge'):
-            command = f'mkdir -p /usr/local/lsws/Example/html/.well-known/acme-challenge'
+        default_webroot = '/usr/local/lsws/Example/html'
+        # Child domains: use their docroot so HTTP-01 challenge is served from the correct vhost
+        if sslpath and str(sslpath).strip():
+            webroot = str(sslpath).strip().rstrip('/')
+            if webroot != default_webroot and os.path.isdir(webroot):
+                challenge_path = webroot + '/.well-known/acme-challenge'
+                if not os.path.exists(challenge_path):
+                    os.makedirs(challenge_path, exist_ok=True)
+                    command = f'chmod -R 755 {webroot}/.well-known'
+                    ProcessUtilities.executioner(command)
+                logging.CyberCPLogFileWriter.writeToFile(
+                    f"Using domain webroot for ACME challenge: {webroot}")
+            else:
+                webroot = default_webroot
+                challenge_path = None
+        else:
+            webroot = default_webroot
+            challenge_path = None
+
+        if not os.path.exists(default_webroot + '/.well-known/acme-challenge'):
+            command = f'mkdir -p {default_webroot}/.well-known/acme-challenge'
             ProcessUtilities.normalExecutioner(command)
 
-        command = f'chmod -R 755 /usr/local/lsws/Example/html'
+        command = f'chmod -R 755 {default_webroot}'
         ProcessUtilities.executioner(command)
 
         # Try Let's Encrypt first
@@ -738,8 +809,12 @@ context /.well-known/acme-challenge {
             except:
                 pass
 
-            acme = CustomACME(virtualHostName, adminEmail, staging=False, provider='letsencrypt')
+            acme = CustomACME(virtualHostName, adminEmail, staging=False, provider='letsencrypt', challenge_path=challenge_path)
             if acme.issue_certificate(domains, use_dns=use_dns):
+                if _ssl_live_cert_is_staging(virtualHostName):
+                    logging.CyberCPLogFileWriter.writeToFile(
+                        f"Refusing to accept staging Let's Encrypt SSL for: {virtualHostName}")
+                    return 0
                 logging.CyberCPLogFileWriter.writeToFile(
                     f"Successfully obtained SSL using Let's Encrypt for: {virtualHostName}")
                 return 1
@@ -783,8 +858,12 @@ context /.well-known/acme-challenge {
                     logging.CyberCPLogFileWriter.writeToFile(
                         f"www.{aliasDomain} has no DNS records, excluding from SSL request")
 
-            acme = CustomACME(virtualHostName, adminEmail, staging=False, provider='zerossl')
+            acme = CustomACME(virtualHostName, adminEmail, staging=False, provider='zerossl', challenge_path=challenge_path)
             if acme.issue_certificate(domains, use_dns=use_dns):
+                if _ssl_live_cert_is_staging(virtualHostName):
+                    logging.CyberCPLogFileWriter.writeToFile(
+                        f"Refusing to accept staging Let's Encrypt SSL for: {virtualHostName}")
+                    return 0
                 logging.CyberCPLogFileWriter.writeToFile(
                     f"Successfully obtained SSL using ZeroSSL for: {virtualHostName}")
                 return 1
@@ -820,9 +899,11 @@ context /.well-known/acme-challenge {
                         logging.CyberCPLogFileWriter.writeToFile(
                             f"www.{virtualHostName} has no DNS records, excluding from acme.sh SSL request")
 
-                    # Step 1: Issue the certificate (staging) - this stores config in /root/.acme.sh/
+                    # Issue the production certificate directly. Staging certificates must never be
+                    # written to /etc/letsencrypt/live.
                     command = acmePath + " --issue" + domain_list \
-                              + ' -w /usr/local/lsws/Example/html -k ec-256 --force --staging'
+                              + ' --cert-file ' + existingCertPath + '/cert.pem' + ' --key-file ' + existingCertPath + '/privkey.pem' \
+                              + ' --fullchain-file ' + existingCertPath + '/fullchain.pem' + ' -w ' + shlex.quote(webroot) + ' -k ec-256 --force --server letsencrypt'
 
                     try:
                         result = subprocess.run(command, capture_output=True, universal_newlines=True, shell=True)
@@ -832,38 +913,33 @@ context /.well-known/acme-challenge {
                                                 universal_newlines=True, shell=True)
 
                     if result.returncode == 0:
-                        # Step 2: Issue the certificate (production) - this stores config in /root/.acme.sh/
-                        command = acmePath + " --issue" + domain_list \
-                                  + ' -w /usr/local/lsws/Example/html -k ec-256 --force --server letsencrypt'
+                        install_command = acmePath + " --install-cert -d " + virtualHostName \
+                                        + ' --ecc' \
+                                        + ' --cert-file ' + existingCertPath + '/cert.pem' \
+                                        + ' --key-file ' + existingCertPath + '/privkey.pem' \
+                                        + ' --fullchain-file ' + existingCertPath + '/fullchain.pem'
 
                         try:
-                            result = subprocess.run(command, capture_output=True, universal_newlines=True, shell=True)
+                            install_result = subprocess.run(install_command, capture_output=True, universal_newlines=True, shell=True)
                         except TypeError:
                             # Fallback for Python < 3.7
-                            result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                                    universal_newlines=True, shell=True)
+                            install_result = subprocess.run(install_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                                            universal_newlines=True, shell=True)
 
-                        if result.returncode == 0:
-                            # Step 3: Install the certificate to the desired location
-                            install_command = acmePath + " --install-cert -d " + virtualHostName \
-                                            + ' --ecc' \
-                                            + ' --cert-file ' + existingCertPath + '/cert.pem' \
-                                            + ' --key-file ' + existingCertPath + '/privkey.pem' \
-                                            + ' --fullchain-file ' + existingCertPath + '/fullchain.pem'
-
-                            try:
-                                install_result = subprocess.run(install_command, capture_output=True, universal_newlines=True, shell=True)
-                            except TypeError:
-                                # Fallback for Python < 3.7
-                                install_result = subprocess.run(install_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                                                universal_newlines=True, shell=True)
-
-                            if install_result.returncode == 0:
+                        if install_result.returncode == 0:
+                            if _ssl_live_cert_is_staging(virtualHostName):
                                 logging.CyberCPLogFileWriter.writeToFile(
-                                    "Successfully obtained SSL for: " + virtualHostName + " and: www." + virtualHostName, 0)
-                                logging.CyberCPLogFileWriter.SendEmail(sender_email, adminEmail, result.stdout,
-                                                                       'SSL Notification for %s.' % (virtualHostName))
-                                return 1
+                                    f"Refusing to install staging Let's Encrypt SSL for: {virtualHostName}")
+                                return 0
+                            logging.CyberCPLogFileWriter.writeToFile(
+                                "Successfully obtained SSL for: " + virtualHostName + " and: www." + virtualHostName, 0)
+                            logging.CyberCPLogFileWriter.SendEmail(sender_email, adminEmail, result.stdout,
+                                                                   'SSL Notification for %s.' % (virtualHostName))
+                            return 1
+                    else:
+                        error_output = result.stderr if hasattr(result, 'stderr') and result.stderr else result.stdout
+                        logging.CyberCPLogFileWriter.writeToFile(
+                            f"Production acme.sh issue failed for {virtualHostName}: {error_output}")
                     return 0
                 except Exception as e:
                     logging.CyberCPLogFileWriter.writeToFile(str(e))
@@ -891,7 +967,8 @@ context /.well-known/acme-challenge {
 
                     # Step 1: Issue the certificate - this stores config in /root/.acme.sh/
                     command = acmePath + " --issue" + domain_list \
-                              + ' -w /usr/local/lsws/Example/html -k ec-256 --force --server letsencrypt'
+                              + ' --cert-file ' + existingCertPath + '/cert.pem' + ' --key-file ' + existingCertPath + '/privkey.pem' \
+                              + ' --fullchain-file ' + existingCertPath + '/fullchain.pem' + ' -w ' + shlex.quote(webroot) + ' -k ec-256 --force --server letsencrypt'
 
                     try:
                         result = subprocess.run(command, capture_output=True, universal_newlines=True, shell=True)
@@ -916,6 +993,10 @@ context /.well-known/acme-challenge {
                                                             universal_newlines=True, shell=True)
 
                         if install_result.returncode == 0:
+                            if _ssl_live_cert_is_staging(virtualHostName):
+                                logging.CyberCPLogFileWriter.writeToFile(
+                                    f"Refusing to install staging Let's Encrypt SSL for: {virtualHostName}")
+                                return 0
                             return 1
                     return 0
                 except Exception as e:
@@ -926,6 +1007,77 @@ context /.well-known/acme-challenge {
             return 0
 
 
+def _ssl_resolve_acme_webroot(sslpath):
+    """Match obtainSSLForADomain webroot selection for HTTP-01 (child domains / custom docroot)."""
+    default_webroot = '/usr/local/lsws/Example/html'
+    if sslpath and str(sslpath).strip():
+        webroot = str(sslpath).strip().rstrip('/')
+        if webroot != default_webroot and os.path.isdir(webroot):
+            return webroot
+    return default_webroot
+
+
+def _ssl_privkey_is_ecdsa(privkey_path):
+    """True if privkey is ECDSA (CyberPanel acme.sh -k ec-256); False for legacy RSA."""
+    if not os.path.exists(privkey_path):
+        return True
+    try:
+        try:
+            proc = subprocess.run(
+                ['openssl', 'ec', '-in', privkey_path, '-noout'],
+                capture_output=True, text=True, timeout=15,
+            )
+        except TypeError:
+            proc = subprocess.run(
+                ['openssl', 'ec', '-in', privkey_path, '-noout'],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                universal_newlines=True, timeout=15,
+            )
+        return proc.returncode == 0
+    except BaseException as exc:
+        try:
+            logging.CyberCPLogFileWriter.writeToFile(
+                '_ssl_privkey_is_ecdsa: %s, assuming ECDSA' % (str(exc),))
+        except BaseException:
+            pass
+        return True
+
+
+def _ssl_acme_deploy_to_live(acmePath, domain, use_ecc):
+    """Run acme.sh --install-cert so renewed certs are copied to /etc/letsencrypt/live/."""
+    live_dir = '/etc/letsencrypt/live/' + domain
+    if not os.path.exists(live_dir):
+        subprocess.call(shlex.split('mkdir -p ' + live_dir))
+    install_command = acmePath + ' --install-cert -d ' + shlex.quote(domain)
+    if use_ecc:
+        install_command += ' --ecc'
+    install_command += (
+        ' --cert-file ' + live_dir + '/cert.pem'
+        ' --key-file ' + live_dir + '/privkey.pem'
+        ' --fullchain-file ' + live_dir + '/fullchain.pem'
+    )
+    try:
+        install_result = subprocess.run(
+            install_command, capture_output=True, text=True, shell=True)
+    except TypeError:
+        install_result = subprocess.run(
+            install_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True, shell=True)
+    if install_result.returncode != 0:
+        err = ''
+        try:
+            err = (install_result.stderr or install_result.stdout or '').strip()
+        except BaseException:
+            err = ''
+        logging.CyberCPLogFileWriter.writeToFile(
+            'acme.sh install-cert failed for %s (exit %s): %s' % (
+                domain, install_result.returncode, err[:2000]))
+        return False
+    logging.CyberCPLogFileWriter.writeToFile(
+        'Deployed renewed certificate to %s via acme.sh install-cert' % (live_dir,), 0)
+    return True
+
+
 def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=False):
     try:
         # Check if certificate already exists and try to renew it first
@@ -933,6 +1085,8 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
         if os.path.exists(existingCertPath):
             # Check if certificate is expired
             is_expired = False
+            ssl_provider = None
+            is_staging_cert = False
             try:
                 import OpenSSL
                 from datetime import datetime
@@ -943,7 +1097,10 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
                 now = datetime.now()
                 diff = final_date - now
                 is_expired = diff.days < 0
-                logging.CyberCPLogFileWriter.writeToFile(f"Certificate for {domain} expires in {diff.days} days")
+                ssl_provider = _ssl_get_certificate_issuer(existingCertPath)
+                is_staging_cert = _ssl_is_staging_provider(ssl_provider)
+                logging.CyberCPLogFileWriter.writeToFile(
+                    f"Certificate for {domain} expires in {diff.days} days. Provider: {ssl_provider}")
             except Exception as e:
                 logging.CyberCPLogFileWriter.writeToFile(f"Could not check certificate expiry: {str(e)}")
 
@@ -951,10 +1108,22 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
 
             # Try to renew using acme.sh
             acmePath = '/root/.acme.sh/acme.sh'
-            if os.path.exists(acmePath):
+            if is_staging_cert:
+                logging.CyberCPLogFileWriter.writeToFile(
+                    f"Existing certificate for {domain} is Let's Encrypt staging; skipping acme.sh renew and forcing production issue.")
+            elif os.path.exists(acmePath):
                 # First set the webroot path for the domain
                 command = f'{acmePath} --update-account --accountemail {adminEmail}'
                 subprocess.call(command, shell=True)
+                command = f'{acmePath} --set-default-ca --server letsencrypt'
+                subprocess.call(command, shell=True)
+
+                webroot = _ssl_resolve_acme_webroot(sslpath)
+                logging.CyberCPLogFileWriter.writeToFile(
+                    f'ACME renew webroot for {domain}: {webroot}', 0)
+
+                privkey_path = '/etc/letsencrypt/live/' + domain + '/privkey.pem'
+                use_ecc = _ssl_privkey_is_ecdsa(privkey_path)
 
                 # Build domain list for renewal
                 renewal_domains = f'-d {domain}'
@@ -965,10 +1134,17 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
                 if is_expired:
                     logging.CyberCPLogFileWriter.writeToFile(
                         f"Certificate is expired, using --issue --force for {domain}")
-                    command = f'{acmePath} --issue {renewal_domains} --webroot /usr/local/lsws/Example/html -k ec-256 --force'
+                    key_opt = ' -k ec-256' if use_ecc else ''
+                    command = (
+                        f'{acmePath} --issue {renewal_domains} -w {shlex.quote(webroot)}'
+                        f'{key_opt} --force --server letsencrypt'
+                    )
                 else:
-                    # Try to renew with explicit webroot
-                    command = f'{acmePath} --renew {renewal_domains} --webroot /usr/local/lsws/Example/html --ecc --force'
+                    ecc_opt = ' --ecc' if use_ecc else ''
+                    command = (
+                        f'{acmePath} --renew {renewal_domains} -w {shlex.quote(webroot)}'
+                        f'{ecc_opt} --force --server letsencrypt'
+                    )
 
                 try:
                     result = subprocess.run(command, capture_output=True, text=True, shell=True)
@@ -979,11 +1155,13 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
 
                 if result.returncode == 0:
                     logging.CyberCPLogFileWriter.writeToFile(f"Successfully renewed SSL for {domain}")
-                    # ADDED: Copy cert from acme.sh to /etc/letsencrypt/live/
-                    certPath = '/etc/letsencrypt/live/' + domain
-                    install_cmd = f'{acmePath} --install-cert -d {domain} --ecc --key-file {certPath}/privkey.pem --fullchain-file {certPath}/fullchain.pem'
-                    subprocess.call(install_cmd, shell=True)
-                    if sslUtilities.installSSLForDomain(domain, adminEmail) == 1:
+                    if not _ssl_acme_deploy_to_live(acmePath, domain, use_ecc):
+                        logging.CyberCPLogFileWriter.writeToFile(
+                            f'install-cert after renew failed for {domain}; will try full obtain path', 1)
+                    elif _ssl_live_cert_is_staging(domain):
+                        logging.CyberCPLogFileWriter.writeToFile(
+                            f"Renewed certificate for {domain} is staging; will try full production obtain path", 1)
+                    elif sslUtilities.installSSLForDomain(domain, adminEmail) == 1:
                         return [1, "SSL successfully renewed"]
                 else:
                     # Parse ACME error details
@@ -1006,17 +1184,17 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
             ### if so, dont issue self-signed ssl, as it may override some existing ssl
 
             if os.path.exists(pathToStoreSSLFullChain):
-                import OpenSSL
-                x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM,
-                                                       open(pathToStoreSSLFullChain, 'r').read())
-                SSLProvider = x509.get_issuer().get_components()[1][1].decode('utf-8')
+                SSLProvider = _ssl_get_certificate_issuer(pathToStoreSSLFullChain)
 
-                if SSLProvider != 'Denial':
+                if SSLProvider != 'Denial' and not _ssl_is_staging_provider(SSLProvider):
                     if sslUtilities.installSSLForDomain(domain) == 1:
                         logging.CyberCPLogFileWriter.writeToFile(
                             "We are not able to get new SSL for " + domain + ". But there is an existing SSL, it might only be for the main domain (excluding www).")
                         return [1,
                                 "We are not able to get new SSL for " + domain + ". But there is an existing SSL, it might only be for the main domain (excluding www)." + " [issueSSLForDomain]"]
+                elif _ssl_is_staging_provider(SSLProvider):
+                    logging.CyberCPLogFileWriter.writeToFile(
+                        "Existing SSL for " + domain + " is Let's Encrypt staging; not installing it as a valid certificate.")
 
             command = 'openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=' + domain + '" -keyout ' + pathToStoreSSLPrivKey + ' -out ' + pathToStoreSSLFullChain
             cmd = shlex.split(command)
@@ -1030,3 +1208,59 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
 
     except BaseException as msg:
         return [0, "347 " + str(msg) + " [issueSSLForDomain]"]
+
+def reconcile_ssl_all():
+    """Reconcile SSL configuration for all domains using the reconciliation module."""
+    try:
+        from plogical.sslReconcile import SSLReconcile
+        return SSLReconcile.reconcile_all()
+    except Exception as e:
+        logging.CyberCPLogFileWriter.writeToFile(f"Error in reconcile_ssl_all: {str(e)}")
+        return False
+
+
+def reconcile_ssl_domain(domain):
+    """Reconcile SSL configuration for a specific domain using the reconciliation module."""
+    try:
+        from plogical.sslReconcile import SSLReconcile
+        return SSLReconcile.reconcile_domain(domain)
+    except Exception as e:
+        logging.CyberCPLogFileWriter.writeToFile(f"Error in reconcile_ssl_domain for {domain}: {str(e)}")
+        return False
+
+
+def fix_acme_challenge_context(virtualHostName):
+    """Fix ACME challenge context for a specific domain."""
+    try:
+        from plogical.sslReconcile import SSLReconcile
+
+        vconf_path = f"{sslUtilities.Server_root}/conf/vhosts/{virtualHostName}/vhost.conf"
+
+        if not os.path.exists(vconf_path):
+            logging.CyberCPLogFileWriter.writeToFile(f"VHost configuration not found: {vconf_path}")
+            return False
+
+        docroot = ""
+        with open(vconf_path, 'r') as f:
+            for line in f:
+                if line.strip().startswith('docRoot'):
+                    docroot = line.split()[1]
+                    break
+
+        if not docroot:
+            logging.CyberCPLogFileWriter.writeToFile(f"No docRoot found for {virtualHostName}")
+            return False
+
+        if docroot.startswith('$VH_ROOT/'):
+            docroot = docroot.replace('$VH_ROOT', f"/home/{virtualHostName}")
+
+        return SSLReconcile.fix_context_location(vconf_path, docroot)
+    except Exception as e:
+        logging.CyberCPLogFileWriter.writeToFile(
+            f"Error fixing ACME challenge context for {virtualHostName}: {str(e)}")
+        return False
+
+
+sslUtilities.reconcile_ssl_all = staticmethod(reconcile_ssl_all)
+sslUtilities.reconcile_ssl_domain = staticmethod(reconcile_ssl_domain)
+sslUtilities.fix_acme_challenge_context = staticmethod(fix_acme_challenge_context)

--- a/plogical/sslUtilities.py
+++ b/plogical/sslUtilities.py
@@ -17,12 +17,17 @@ from plogical.acl import ACLManager
 STAGING_LE_ISSUER_MARKER = "(STAGING)"
 
 
+def _ssl_load_certificate(cert_path):
+    """Load a PEM certificate as bytes so non-ASCII file data is not implicitly encoded."""
+    import OpenSSL
+    with open(cert_path, 'rb') as cert_file:
+        cert_data = cert_file.read()
+    return OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_data)
+
+
 def _ssl_get_certificate_issuer(cert_path):
     try:
-        import OpenSSL
-        with open(cert_path, 'r') as cert_file:
-            cert_data = cert_file.read()
-        cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_data)
+        cert = _ssl_load_certificate(cert_path)
         components = cert.get_issuer().get_components()
 
         for key, value in components:
@@ -51,10 +56,7 @@ def _ssl_is_staging_provider(provider):
 def _ssl_certificate_is_staging(cert_path):
     """Detect staging certificates from any issuer component, not a pinned CA name."""
     try:
-        import OpenSSL
-        with open(cert_path, 'r') as cert_file:
-            cert_data = cert_file.read()
-        cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_data)
+        cert = _ssl_load_certificate(cert_path)
         for _key, value in cert.get_issuer().get_components():
             try:
                 issuer_value = value.decode('utf-8')
@@ -233,8 +235,13 @@ class sslUtilities:
         #### if website already have an SSL, better not issue again - need to check for wild-card
         filePath = '/etc/letsencrypt/live/%s/fullchain.pem' % (virtualHostName)
         if os.path.exists(filePath):
-            import OpenSSL
-            x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, open(filePath, 'r').read())
+            try:
+                x509 = _ssl_load_certificate(filePath)
+            except Exception as exc:
+                logging.CyberCPLogFileWriter.writeToFile(
+                    f'[CheckIfSSLNeedsToBeIssued] Invalid certificate for '
+                    f'{virtualHostName}: {str(exc)}. A new SSL will be issued.')
+                return sslUtilities.ISSUE_SSL
             SSLProvider = _ssl_get_certificate_issuer(filePath)
 
             if os.path.exists(ProcessUtilities.debugPath):
@@ -1026,6 +1033,22 @@ def _ssl_resolve_acme_webroot(sslpath):
     return '/usr/local/lsws/Example/html'
 
 
+def _ssl_acme_domain_config(acme_path, domain, prefer_ecc):
+    """Return (config_path, use_ecc) for an existing acme.sh domain configuration."""
+    acme_home = os.path.dirname(acme_path)
+    ecc_config = os.path.join(acme_home, domain + '_ecc', domain + '.conf')
+    rsa_config = os.path.join(acme_home, domain, domain + '.conf')
+    candidates = (
+        ((ecc_config, True), (rsa_config, False))
+        if prefer_ecc
+        else ((rsa_config, False), (ecc_config, True))
+    )
+    for config_path, use_ecc in candidates:
+        if os.path.isfile(config_path):
+            return config_path, use_ecc
+    return None, prefer_ecc
+
+
 def _ssl_privkey_is_ecdsa(privkey_path):
     """True if privkey is ECDSA (CyberPanel acme.sh -k ec-256); False for legacy RSA."""
     if not os.path.exists(privkey_path):
@@ -1097,10 +1120,8 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
             ssl_provider = None
             is_staging_cert = False
             try:
-                import OpenSSL
                 from datetime import datetime
-                with open(existingCertPath, 'r') as cert_file:
-                    x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_file.read())
+                x509 = _ssl_load_certificate(existingCertPath)
                 expire_data = x509.get_notAfter().decode('ascii')
                 final_date = datetime.strptime(expire_data, '%Y%m%d%H%M%SZ')
                 now = datetime.now()
@@ -1133,17 +1154,27 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
 
                 privkey_path = '/etc/letsencrypt/live/' + domain + '/privkey.pem'
                 use_ecc = _ssl_privkey_is_ecdsa(privkey_path)
+                acme_config, use_ecc = _ssl_acme_domain_config(
+                    acmePath, domain, use_ecc)
 
                 # Build domain list for renewal
                 renewal_domains = f'-d {domain}'
                 if not isHostname and sslUtilities.checkDNSRecords(f'www.{domain}'):
                     renewal_domains += f' -d www.{domain}'
 
-                # For expired certificates, use --issue --force instead of --renew
-                if is_expired:
+                # acme.sh can renew only domains that still have a domain.conf.
+                # Expired certificates are also issued afresh to avoid stale state.
+                acme_action = 'renew'
+                if is_expired or acme_config is None:
+                    acme_action = 'issue'
+                    issue_reason = (
+                        'certificate is expired'
+                        if is_expired
+                        else 'acme.sh domain configuration is missing'
+                    )
                     logging.CyberCPLogFileWriter.writeToFile(
-                        f"Certificate is expired, using --issue --force for {domain}")
-                    key_opt = ' -k ec-256' if use_ecc else ''
+                        f"{issue_reason.capitalize()}, using --issue --force for {domain}")
+                    key_opt = ' -k ec-256' if use_ecc else ' -k 2048'
                     command = (
                         f'{acmePath} --issue {renewal_domains} -w {shlex.quote(webroot)}'
                         f'{key_opt} --force --server letsencrypt'
@@ -1163,20 +1194,28 @@ def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=
                                             universal_newlines=True, shell=True)
 
                 if result.returncode == 0:
-                    logging.CyberCPLogFileWriter.writeToFile(f"Successfully renewed SSL for {domain}")
+                    logging.CyberCPLogFileWriter.writeToFile(
+                        f"Successfully completed acme.sh --{acme_action} for {domain}")
                     if not _ssl_acme_deploy_to_live(acmePath, domain, use_ecc):
                         logging.CyberCPLogFileWriter.writeToFile(
-                            f'install-cert after renew failed for {domain}; will try full obtain path', 1)
+                            f'install-cert after {acme_action} failed for {domain}; will try full obtain path', 1)
                     elif _ssl_live_cert_is_staging(domain):
                         logging.CyberCPLogFileWriter.writeToFile(
-                            f"Renewed certificate for {domain} is staging; will try full production obtain path", 1)
+                            f"Certificate produced by {acme_action} for {domain} is staging; "
+                            f"will try full production obtain path", 1)
                     elif sslUtilities.installSSLForDomain(domain, adminEmail) == 1:
-                        return [1, "SSL successfully renewed"]
+                        success_message = (
+                            "SSL successfully issued"
+                            if acme_action == 'issue'
+                            else "SSL successfully renewed"
+                        )
+                        return [1, success_message]
                 else:
                     # Parse ACME error details
                     error_output = result.stderr if hasattr(result, 'stderr') and result.stderr else result.stdout
                     error_details = sslUtilities.parseACMEError(error_output)
-                    logging.CyberCPLogFileWriter.writeToFile(f"Renewal failed for {domain}. Error: {error_details}")
+                    logging.CyberCPLogFileWriter.writeToFile(
+                        f"ACME {acme_action} failed for {domain}. Error: {error_details}")
                     logging.CyberCPLogFileWriter.writeToFile(f"Full error output: {error_output}")
 
         if sslUtilities.obtainSSLForADomain(domain, adminEmail, sslpath, aliasDomain, isHostname) == 1:

--- a/plogical/sslUtilities.py
+++ b/plogical/sslUtilities.py
@@ -1110,11 +1110,14 @@ def _ssl_acme_deploy_to_live(acmePath, domain, use_ecc):
     return True
 
 
-def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=False):
+def issueSSLForDomain(domain, adminEmail, sslpath, aliasDomain=None, isHostname=False, forceIssue=False):
     try:
         # Check if certificate already exists and try to renew it first
         existingCertPath = '/etc/letsencrypt/live/' + domain + '/fullchain.pem'
-        if os.path.exists(existingCertPath):
+        if forceIssue:
+            logging.CyberCPLogFileWriter.writeToFile(
+                f"forceIssue requested for {domain}; skipping in-place renewal and forcing a fresh issuance.")
+        elif os.path.exists(existingCertPath):
             # Check if certificate is expired
             is_expired = False
             ssl_provider = None


### PR DESCRIPTION
### Related Issue
Fixes #1676

### Problem
The current SSL installation process in CyberPanel does not properly handle ECC certificates during installation or renewal.  
This may cause failures when users attempt to issue or renew SSL certificates that rely on ECC keys.

In some cases the renewal command is not updated correctly, which leads to inconsistent behavior between initial installation and later renewals.

### Solution
This PR improves the SSL installation workflow by:

- Adding proper support for ECC certificates
- Updating the renewal command generation
- Ensuring the renewal process is consistent with the installation process

### Changes
- Added ECC handling during SSL installation
- Updated renewal command logic
- Improved reliability of certificate renewal

### Testing
Tested by:

1. Installing SSL for a domain using ECC certificates
2. Running the renewal process manually
3. Verifying certificate installation and renewal behavior

### Impact
This change improves SSL reliability and ensures CyberPanel works correctly with ECC-based certificates.

This change is backward compatible and does not affect existing RSA certificates.