### PR TITLE
Change trial urls to 30 day trial instead of 15 day trial (Litespeed Enterprise)

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -1698,9 +1698,9 @@ Retry_Command "wget https://cyberpanel.sh/www.litespeedtech.com/packages/${LSWS_
 tar xzvf "lsws-$LSWS_Stable_Version-ent-x86_64-linux.tar.gz" >/dev/null
 cd "/root/cyberpanel-tmp/lsws-$LSWS_Stable_Version/conf"  || exit
 if [[ "$License_Key" = "Trial" ]]; then
-  Retry_Command "wget -q https://cyberpanel.sh/license.litespeedtech.com/reseller/trial.key"
+  Retry_Command "wget -q https://license.litespeedtech.com/reseller/trial.key.cwp -O trial.key"
   # Update the serial number handling to use trial key
-  sed -i "s|writeSerial = open('lsws-[0-9.]\+/serial.no', 'w')|command = 'wget -q --output-document=./lsws-$LSWS_Stable_Version/trial.key https://cyberpanel.sh/license.litespeedtech.com/reseller/trial.key'|g" "$Current_Dir/installCyberPanel.py"
+  sed -i "s|writeSerial = open('lsws-[0-9.]\+/serial.no', 'w')|command = 'wget -q --output-document=./lsws-$LSWS_Stable_Version/trial.key https://cyberpanel.sh/license.litespeedtech.com/reseller/trial.key.cwp'|g" "$Current_Dir/installCyberPanel.py"
   sed -i 's|writeSerial.writelines(self.serial)|subprocess.call(command, shell=True)|g' "$Current_Dir/installCyberPanel.py"
   sed -i 's|writeSerial.close()||g' "$Current_Dir/installCyberPanel.py"
 else

--- a/install/installCyberPanel.py
+++ b/install/installCyberPanel.py
@@ -552,9 +552,9 @@ module cyberpanel_ols {
                 install_utils.call(command, self.distro, command, command, 1, 1, os.EX_OSERR)
 
                 if str.lower(self.serial) == 'trial':
-                    command = f'wget -q --output-document=lsws-{lsws_version}/trial.key http://license.litespeedtech.com/reseller/trial.key'
+                    command = f'wget -q --output-document=lsws-{lsws_version}/trial.key http://license.litespeedtech.com/reseller/trial.key.cwp'
                 if self.serial == '1111-2222-3333-4444':
-                    command = f'wget -q --output-document=/root/cyberpanel/install/lsws-{lsws_version}/trial.key http://license.litespeedtech.com/reseller/trial.key'
+                    command = f'wget -q --output-document=/root/cyberpanel/install/lsws-{lsws_version}/trial.key http://license.litespeedtech.com/reseller/trial.key.cwp'
                     install_utils.call(command, self.distro, command, command, 1, 1, os.EX_OSERR)
                 else:
                     writeSerial = open(f'lsws-{lsws_version}/serial.no', 'w')

--- a/install/venvsetup.sh
+++ b/install/venvsetup.sh
@@ -34,8 +34,8 @@ wget -q https://$DOWNLOAD_SERVER/litespeed/lsws-$LSWS_STABLE_VER-ent-x86_64-linu
 tar xzvf lsws-$LSWS_STABLE_VER-ent-x86_64-linux.tar.gz > /dev/null
 cd  /root/cyberpanel-tmp/lsws-$LSWS_STABLE_VER/conf
 if [[ $LICENSE_KEY == "TRIAL" ]] ; then
-wget -q http://license.litespeedtech.com/reseller/trial.key
-sed -i "s|writeSerial = open('lsws-5.4.2/serial.no', 'w')|command = 'wget -q --output-document=./lsws-$LSWS_STABLE_VER/trial.key http://license.litespeedtech.com/reseller/trial.key'|g" $CURRENT_DIR/installCyberPanel.py
+wget -q https://license.litespeedtech.com/reseller/trial.key.cwp -O trial.key
+sed -i "s|writeSerial = open('lsws-5.4.2/serial.no', 'w')|command = 'wget -q --output-document=./lsws-$LSWS_STABLE_VER/trial.key https://license.litespeedtech.com/reseller/trial.key.cwp'|g" $CURRENT_DIR/installCyberPanel.py
 sed -i 's|writeSerial.writelines(self.serial)|subprocess.call(command, shell=True)|g' $CURRENT_DIR/installCyberPanel.py
 sed -i 's|writeSerial.close()||g' $CURRENT_DIR/installCyberPanel.py
 else

--- a/serverStatus/serverStatusUtil.py
+++ b/serverStatus/serverStatusUtil.py
@@ -133,7 +133,7 @@ class ServerStatusUtil(multi.Thread):
                 return 0
 
             if licenseKey == 'trial':
-                command = f'wget -q --output-document=/usr/local/CyberCP/lsws-{lsws_version}/trial.key http://license.litespeedtech.com/reseller/trial.key'
+                command = f'wget -q --output-document=/usr/local/CyberCP/lsws-{lsws_version}/trial.key http://license.litespeedtech.com/reseller/trial.key.cwp'
                 if ServerStatusUtil.executioner(command, statusFile) == 0:
                     return 0
             else:


### PR DESCRIPTION
Changes all references to trial.key.cwp, but save it as trial.key

It gives 30 day trial instead of usual 15 day trial.