### PR TITLE
docs: third-party AGPL notice for SnappyMail list-unsubscribe plugin

### DIFF
--- a/CPScripts/sync_snappymail_list_unsubscribe_plugin.sh
+++ b/CPScripts/sync_snappymail_list_unsubscribe_plugin.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Sync list-unsubscribe-header from a local snappymail-plugins (or upstream clone)
+# checkout into install/snappymail/plugins/ for CyberPanel packaging.
+#
+# Usage (from CyberPanel repo root):
+#   export SNAPPYMAIL_PLUGINS_ROOT=/path/to/snappymail-plugins
+#   ./CPScripts/sync_snappymail_list_unsubscribe_plugin.sh
+#
+# Optional: CYBERPANEL_REPO_ROOT overrides repo root (parent of CPScripts).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CYBERPANEL_REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+SRC_ROOT="${SNAPPYMAIL_PLUGINS_ROOT:-}"
+
+if [[ -z "${SRC_ROOT}" ]]; then
+	echo "ERROR: Set SNAPPYMAIL_PLUGINS_ROOT to the directory containing list-unsubscribe-header/ (e.g. snappymail-plugins checkout)." >&2
+	exit 1
+fi
+
+SRC_FILE="${SRC_ROOT%/}/list-unsubscribe-header/index.php"
+DEST_DIR="${REPO_ROOT}/install/snappymail/plugins/list-unsubscribe-header"
+DEST_FILE="${DEST_DIR}/index.php"
+
+if [[ ! -f "${SRC_FILE}" ]]; then
+	echo "ERROR: Source not found: ${SRC_FILE}" >&2
+	exit 1
+fi
+
+mkdir -p "${DEST_DIR}"
+
+python3 - "${SRC_FILE}" "${DEST_FILE}" <<'PY'
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+raw = src.read_text(encoding="utf-8", errors="strict")
+
+if "Bundled with CyberPanel" in raw:
+    out = raw
+else:
+    if not raw.startswith("<?php"):
+        raise SystemExit("ERROR: expected plugin to start with <?php")
+    body = raw[len("<?php") :].lstrip("\n")
+    if body.startswith("/**"):
+        end = body.find("*/")
+        if end == -1:
+            raise SystemExit("ERROR: unterminated docblock in source")
+        rest = body[end + 2 :].lstrip("\n")
+    else:
+        rest = body
+
+    bundled = (
+        "<?php\n\n"
+        "/**\n"
+        " * Bundled with CyberPanel (see plogical/snappymail_plugin_utilities.py).\n"
+        " * Upstream: https://github.com/master3395/snappymail-list-unsubscribe-header\n"
+        " *\n"
+        " * Adds List-Unsubscribe and List-Unsubscribe-Post on outbound mail (RFC 2369 / RFC 8058).\n"
+        " */\n"
+    )
+    out = bundled + rest
+
+dst.write_text(out.replace("\r\n", "\n"), encoding="utf-8")
+PY
+
+php -l "${DEST_FILE}" >/dev/null
+echo "OK: wrote ${DEST_FILE}"

--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ Requires a live CyberPanel + OLS installation.
 
 ---
 
+## Third-party notices
+
+Bundled components that use licenses other than CyberPanel's GPL-3.0 are listed in [docs/THIRD_PARTY_NOTICES.md](docs/THIRD_PARTY_NOTICES.md).
+
+
 ## Resources
 
 * Official site: [https://cyberpanel.net](https://cyberpanel.net)

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,17 @@
+# Third-party notices
+
+This document lists separately licensed components shipped with this repository.
+
+## SnappyMail plugin: list-unsubscribe-header
+
+| Field | Value |
+|--------|--------|
+| **Component** | SnappyMail plugin `list-unsubscribe-header` |
+| **Bundled path** | `install/snappymail/plugins/list-unsubscribe-header/index.php` |
+| **Install / enable** | `plogical/snappymail_plugin_utilities.py` (called from `install/install.py` and `plogical/upgrade.py` after the upstream SnappyMail CyberPanel installer PHP step) |
+| **License** | **GNU Affero General Public License v3.0** (AGPL-3.0) |
+| **Upstream source** | https://github.com/master3395/snappymail-list-unsubscribe-header |
+
+Bundling AGPL-3.0 code imposes AGPL obligations on distribution of that component (for example, making corresponding source available to recipients as required by the license). See the upstream repository `LICENSE` file for the full text and terms.
+
+CyberPanel as a whole is licensed under **GPL-3.0**; see the repository root `LICENSE`. This notice does not change the license of CyberPanel’s own code.


### PR DESCRIPTION
Add docs/THIRD_PARTY_NOTICES.md for the bundled list-unsubscribe-header plugin (AGPL-3.0, upstream GitHub). Link from README. Add CPScripts helper to sync the plugin from a local snappymail-plugins checkout into install/.