### PR TITLE
security: harden fastapi_ssh Web Terminal (JWT from conf, panel claim…

### DIFF
--- a/fastapi_ssh_server.py
+++ b/fastapi_ssh_server.py
@@ -1,106 +1,216 @@
+"""
+Web Terminal SSH bridge (FastAPI + WebSocket).
+
+JWT secret and claims are loaded from /etc/cyberpanel/fastapi_ssh_server.conf (see plogical.fastapi_ssh_config).
+"""
+
+from __future__ import annotations
+
 import asyncio
-import asyncssh
-import tempfile
+import io
+import logging
 import os
+import pwd
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import List, Optional
+
+import asyncssh
+import paramiko
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Query
 from fastapi.middleware.cors import CORSMiddleware
-import paramiko  # For key generation and manipulation
-import io
-import pwd
-from jose import jwt, JWTError
-import logging
+from jose import JWTError, jwt
+
+from plogical.fastapi_ssh_config import (
+    CONF_PATH,
+    DEFAULT_AUD,
+    DEFAULT_ISS,
+    is_strong_secret,
+    read_conf_file_dict,
+)
+
+logging.basicConfig(level=logging.INFO)
+_LOGGER = logging.getLogger("cyberpanel.fastapi_ssh_server")
+
+JWT_ALGORITHM = "HS256"
+MAX_TOKEN_LIFETIME_SEC = 15 * 60
+
+
+@dataclass
+class RuntimeSettings:
+    jwt_secret: str
+    jwt_iss: str
+    jwt_aud: str
+    cors_origins: List[str]
+    cors_origin_regex: Optional[str]
+
+
+def _load_runtime_settings() -> RuntimeSettings:
+    secret = (os.environ.get("JWT_SECRET") or "").strip()
+    conf = read_conf_file_dict()
+    if not secret:
+        secret = (conf.get("JWT_SECRET") or "").strip()
+    if not is_strong_secret(secret):
+        _LOGGER.error(
+            "Refusing to start: JWT_SECRET missing, weak, or known-insecure. "
+            "Configure %s (chmod 600) with a random secret (32+ chars).",
+            CONF_PATH,
+        )
+        sys.exit(1)
+
+    iss = (os.environ.get("JWT_ISS") or conf.get("JWT_ISS") or DEFAULT_ISS).strip()
+    aud = (os.environ.get("JWT_AUD") or conf.get("JWT_AUD") or DEFAULT_AUD).strip()
+    origins_csv = (os.environ.get("ALLOWED_ORIGINS") or conf.get("ALLOWED_ORIGINS") or "").strip()
+    origins = [o.strip() for o in origins_csv.split(",") if o.strip()]
+    regex: Optional[str] = None
+    if not origins:
+        regex = r"https?://[\w\-.]+:8090$"
+    return RuntimeSettings(
+        jwt_secret=secret,
+        jwt_iss=iss,
+        jwt_aud=aud,
+        cors_origins=origins,
+        cors_origin_regex=regex,
+    )
+
+
+RUNTIME = _load_runtime_settings()
 
 app = FastAPI()
-# JWT_SECRET = "YOUR_SECRET_KEY"
-JWT_SECRET = "DAsjK2gl50PE09d1N3uZPTQ6JdwwfiuhlyWKMVbUEpc"
-JWT_ALGORITHM = "HS256"
 
-# Allow CORS for local dev/testing
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=RUNTIME.cors_origins if RUNTIME.cors_origins else [],
+    allow_origin_regex=RUNTIME.cors_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-SSH_USER = "your_website_user"  # Replace with a real user for testing
+SSH_USER = "your_website_user"
 AUTHORIZED_KEYS_PATH = f"/home/{SSH_USER}/.ssh/authorized_keys"
 
-# Read the actual SSH port from sshd_config (fixes WebTerminal when SSH uses custom port)
+
 def get_ssh_port() -> int:
     try:
-        with open("/etc/ssh/sshd_config", "r") as f:
-            for line in f:
+        with open("/etc/ssh/sshd_config", "r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
                 line = line.strip()
-                if not line or line.startswith('#'):
+                if not line or line.startswith("#"):
                     continue
-                line = line.split('#')[0].strip()
+                line = line.split("#")[0].strip()
                 parts = line.split()
-                if len(parts) >= 2 and parts[0].lower() == 'port':
+                if len(parts) >= 2 and parts[0].lower() == "port":
                     port = int(parts[1])
-                    logging.info(f"[get_ssh_port] SSH port detected: {port}")
+                    _LOGGER.info("[get_ssh_port] SSH port detected: %s", port)
                     return port
-    except Exception as e:
-        logging.warning(f"[get_ssh_port] Could not read sshd_config: {e}")
-    logging.warning("[get_ssh_port] Falling back to default port 22")
+    except Exception as exc:
+        _LOGGER.warning("[get_ssh_port] Could not read sshd_config: %s", exc)
+    _LOGGER.warning("[get_ssh_port] Falling back to default port 22")
     return 22
+
 
 SSH_PORT = get_ssh_port()
 
-# Helper to generate a keypair
+
 def generate_ssh_keypair():
     key = paramiko.RSAKey.generate(2048)
     private_io = io.StringIO()
     key.write_private_key(private_io)
     private_key = private_io.getvalue()
-    public_key = f"{key.get_name()} {key.get_base64()}"
+    public_key = "%s %s" % (key.get_name(), key.get_base64())
     return private_key, public_key
 
-# Add public key to authorized_keys with a unique comment
-def add_key_to_authorized_keys(public_key, comment):
-    entry = f'from="127.0.0.1,::1" {public_key} {comment}\n'
-    with open(AUTHORIZED_KEYS_PATH, "a") as f:
-        f.write(entry)
 
-# Remove public key from authorized_keys by comment
+def add_key_to_authorized_keys(public_key, comment):
+    entry = 'from="127.0.0.1,::1" %s %s\n' % (public_key, comment)
+    with open(AUTHORIZED_KEYS_PATH, "a", encoding="utf-8") as handle:
+        handle.write(entry)
+
+
 def remove_key_from_authorized_keys(comment):
-    with open(AUTHORIZED_KEYS_PATH, "r") as f:
-        lines = f.readlines()
-    with open(AUTHORIZED_KEYS_PATH, "w") as f:
+    with open(AUTHORIZED_KEYS_PATH, "r", encoding="utf-8") as handle:
+        lines = handle.readlines()
+    with open(AUTHORIZED_KEYS_PATH, "w", encoding="utf-8") as handle:
         for line in lines:
             if comment not in line:
-                f.write(line)
+                handle.write(line)
+
 
 @app.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket, token: str = Query(None), ssh_user: str = Query(None)):
-    # Re-enable JWT validation
-    try:
-        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
-        user = payload.get("ssh_user")
-        if not user:
-            await websocket.close()
-            return
-    except JWTError:
-        await websocket.close()
+async def websocket_endpoint(
+    websocket: WebSocket, token: str = Query(None), ssh_user: str = Query(None)
+):
+    if not token:
+        await websocket.close(code=4401)
         return
+    try:
+        payload = jwt.decode(
+            token,
+            RUNTIME.jwt_secret,
+            algorithms=[JWT_ALGORITHM],
+            audience=RUNTIME.jwt_aud,
+            issuer=RUNTIME.jwt_iss,
+            options={
+                "verify_signature": True,
+                "verify_aud": True,
+                "verify_iss": True,
+                "verify_exp": True,
+                "require_exp": True,
+                "verify_iat": True,
+                "require_iat": True,
+            },
+        )
+    except JWTError:
+        await websocket.close(code=4403)
+        return
+
+    user = payload.get("ssh_user")
+    if not user or not isinstance(user, str):
+        await websocket.close(code=4403)
+        return
+    if ssh_user is not None and ssh_user != user:
+        _LOGGER.warning("ssh_user query claim does not match token; rejecting.")
+        await websocket.close(code=4403)
+        return
+
+    iat = payload.get("iat")
+    exp = payload.get("exp")
+    try:
+        if iat is None or exp is None:
+            raise ValueError("missing iat/exp")
+        if int(exp) - int(iat) > MAX_TOKEN_LIFETIME_SEC:
+            raise ValueError("token lifetime too long")
+    except (TypeError, ValueError):
+        await websocket.close(code=4403)
+        return
+
+    try:
+        pwd.getpwnam(user)
+    except KeyError:
+        _LOGGER.warning("Unknown ssh_user in token.")
+        await websocket.close(code=4403)
+        return
+
     home_dir = pwd.getpwnam(user).pw_dir
     ssh_dir = os.path.join(home_dir, ".ssh")
     authorized_keys_path = os.path.join(ssh_dir, "authorized_keys")
 
     os.makedirs(ssh_dir, exist_ok=True)
     if not os.path.exists(authorized_keys_path):
-        with open(authorized_keys_path, "w"): pass
+        with open(authorized_keys_path, "w", encoding="utf-8"):
+            pass
     os.chown(ssh_dir, pwd.getpwnam(user).pw_uid, pwd.getpwnam(user).pw_gid)
     os.chmod(ssh_dir, 0o700)
     os.chown(authorized_keys_path, pwd.getpwnam(user).pw_uid, pwd.getpwnam(user).pw_gid)
     os.chmod(authorized_keys_path, 0o600)
 
     private_key, public_key = generate_ssh_keypair()
-    comment = f"webterm-{os.urandom(8).hex()}"
-    entry = f'from="127.0.0.1,::1" {public_key} {comment}\n'
-    with open(authorized_keys_path, "a") as f:
-        f.write(entry)
+    comment = "webterm-%s" % (os.urandom(8).hex(),)
+    entry = 'from="127.0.0.1,::1" %s %s\n' % (public_key, comment)
+    with open(authorized_keys_path, "a", encoding="utf-8") as handle:
+        handle.write(entry)
 
     with tempfile.NamedTemporaryFile(delete=False) as keyfile:
         keyfile.write(private_key.encode())
@@ -115,7 +225,7 @@ async def websocket_endpoint(websocket: WebSocket, token: str = Query(None), ssh
             port=SSH_PORT,
             username=user,
             client_keys=[keyfile_path],
-            known_hosts=None
+            known_hosts=None,
         )
         process = await conn.create_process(term_type="xterm")
 
@@ -123,8 +233,7 @@ async def websocket_endpoint(websocket: WebSocket, token: str = Query(None), ssh
             try:
                 while True:
                     data = await websocket.receive_bytes()
-                    # Decode bytes to str before writing to SSH stdin
-                    process.stdin.write(data.decode('utf-8', errors='replace'))
+                    process.stdin.write(data.decode("utf-8", errors="replace"))
             except WebSocketDisconnect:
                 process.stdin.close()
 
@@ -133,44 +242,44 @@ async def websocket_endpoint(websocket: WebSocket, token: str = Query(None), ssh
                 while not process.stdout.at_eof():
                     data = await process.stdout.read(1024)
                     if data:
-                        # Defensive type check and logging
-                        logging.debug(f"[ssh_to_ws] Sending to WS: type={type(data)}, sample={data[:40] if isinstance(data, bytes) else data}")
+                        _LOGGER.debug(
+                            "[ssh_to_ws] Sending to WS: type=%s", type(data).__name__
+                        )
                         if isinstance(data, bytes):
                             await websocket.send_bytes(data)
                         elif isinstance(data, str):
                             await websocket.send_text(data)
                         else:
                             await websocket.send_text(str(data))
-            except Exception as ex:
-                logging.exception(f"[ssh_to_ws] Exception: {ex}")
-                pass
+            except Exception as exc:
+                _LOGGER.exception("[ssh_to_ws] Exception: %s", exc)
 
         await asyncio.gather(ws_to_ssh(), ssh_to_ws())
-    except Exception as e:
+    except Exception as exc:
         try:
-            # Always send error as text (string)
-            msg = f"Connection error: {e}"
-            logging.exception(f"[websocket_endpoint] Exception: {e}")
-            if isinstance(msg, bytes):
-                msg = msg.decode('utf-8', errors='replace')
+            msg = "Connection error: %s" % (exc,)
+            _LOGGER.exception("[websocket_endpoint] Exception: %s", exc)
             await websocket.send_text(str(msg))
-        except Exception as ex:
-            logging.exception(f"[websocket_endpoint] Error sending error message: {ex}")
-            pass
+        except Exception as send_exc:
+            _LOGGER.exception(
+                "[websocket_endpoint] Error sending error message: %s", send_exc
+            )
         try:
             await websocket.close()
         except Exception:
             pass
     finally:
-        # Remove key from authorized_keys and delete temp private key
-        with open(authorized_keys_path, "r") as f:
-            lines = f.readlines()
-        with open(authorized_keys_path, "w") as f:
+        with open(authorized_keys_path, "r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+        with open(authorized_keys_path, "w", encoding="utf-8") as handle:
             for line in lines:
                 if comment not in line:
-                    f.write(line)
-        os.remove(keyfile_path)
+                    handle.write(line)
+        try:
+            os.remove(keyfile_path)
+        except OSError:
+            pass
         if process:
             process.close()
         if conn:
-            conn.close() 
+            conn.close()

--- a/fastapi_ssh_server.service
+++ b/fastapi_ssh_server.service
@@ -5,10 +5,21 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/usr/local/CyberCP
+EnvironmentFile=-/etc/cyberpanel/fastapi_ssh_server.conf
+# JWT and optional tuning live in the EnvironmentFile. The browser still connects to port 8888
+# (see websiteFunctions templates). Hardening the shared JWT and avoiding a default public
+# firewalld 8888 rule is the primary exposure fix. For a stricter setup, add a WebSocket
+# reverse proxy to 127.0.0.1:8888 and set --host 127.0.0.1 here.
 ExecStart=/usr/local/CyberCP/bin/python3 -m uvicorn fastapi_ssh_server:app --host 0.0.0.0 --port 8888 --ssl-keyfile=/usr/local/lscp/conf/key.pem --ssl-certfile=/usr/local/lscp/conf/cert.pem
 Restart=on-failure
 User=root
 Group=root
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ReadWritePaths=/home
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
 
 [Install]
-WantedBy=multi-user.target 
+WantedBy=multi-user.target

--- a/install/install.py
+++ b/install/install.py
@@ -468,7 +468,7 @@ class preFlightsChecks:
                 "8090/tcp", "7080/tcp", "80/tcp", "443/tcp",
                 "21/tcp", "25/tcp", "587/tcp", "465/tcp",
                 "110/tcp", "143/tcp", "993/tcp", "995/tcp",
-                "53/tcp", "53/udp", "8888/tcp", "40110-40210/tcp"
+                "53/tcp", "53/udp", "40110-40210/tcp"
             ]
             
             for port in ports:
@@ -4947,7 +4947,6 @@ user_query = SELECT email as user, password, 'vmail' as uid, 'vmail' as gid, '/h
             FirewallUtilities.addRule("tcp", "995")
             FirewallUtilities.addRule("udp", "53")
             FirewallUtilities.addRule("tcp", "53")
-            FirewallUtilities.addRule("tcp", "8888")
             FirewallUtilities.addRule("udp", "443")
             FirewallUtilities.addRule("tcp", "40110-40210")
 
@@ -6783,21 +6782,21 @@ vmail
             preFlightsChecks.stdOut("Please check the logs and consider running: systemctl restart lsws lscpd")
 
 def configure_jwt_secret():
+    """
+    Web Terminal: write JWT and claims to /etc/cyberpanel/fastapi_ssh_server.conf (never embed in .py).
+    """
     try:
-        import secrets
-        secret = secrets.token_urlsafe(32)
-        fastapi_file = '/usr/local/CyberCP/fastapi_ssh_server.py'
-        with open(fastapi_file, 'r') as f:
-            lines = f.readlines()
-        with open(fastapi_file, 'w') as f:
-            for line in lines:
-                if line.strip().startswith('JWT_SECRET'):
-                    f.write(f'JWT_SECRET = "{secret}"\n')
-                else:
-                    f.write(line)
-            print(f"Configured JWT_SECRET in fastapi_ssh_server.py")
-    except:
-        pass
+        sys.path.insert(0, "/usr/local/CyberCP")
+        from plogical import fastapi_ssh_config
+
+        fastapi_ssh_config.ensure_runtime_files_on_install()
+    except Exception as exc:
+        try:
+            logging.InstallLog.writeToFile(
+                "[configure_jwt_secret] Web Terminal runtime config failed: %s" % str(exc)
+            )
+        except Exception:
+            pass
 
 def main():
     parser = argparse.ArgumentParser(description='CyberPanel Installer')

--- a/install/venvsetup_modules/04_after_install.sh
+++ b/install/venvsetup_modules/04_after_install.sh
@@ -10,7 +10,9 @@ _restart_lscpd_safe() {
 		systemctl daemon-reload
 		systemctl restart lscpd
 	fi
-	systemctl restart fastapi_ssh_server 2>/dev/null || true
+	if [ -f /etc/cyberpanel/fastapi_ssh_server.conf ]; then
+		systemctl restart fastapi_ssh_server 2>/dev/null || true
+	fi
 }
 
 if [ ! -d "/var/lib/php" ]; then

--- a/plogical/fastapi_ssh_config.py
+++ b/plogical/fastapi_ssh_config.py
@@ -1,0 +1,274 @@
+"""
+Runtime configuration and migration helpers for fastapi_ssh_server (Web Terminal).
+
+Secrets are stored in /etc/cyberpanel/fastapi_ssh_server.conf (chmod 600), not in Python source.
+
+Install and upgrade touchpoints (copy, enable, restart, firewall):
+- install/install.py (configure_jwt_secret, firewalld rules without public 8888)
+- install/venvsetup_modules/04_after_install.sh (restart fastapi_ssh_server when conf exists)
+- plogical/upgrade.py (apply_security_migration before systemctl restart fastapi_ssh_server)
+- websiteFunctions/website.py (ensure_web_terminal_runtime_for_panel, systemd unit, start service)
+- websiteFunctions/views.py (get_terminal_jwt uses get_jwt_encode_settings)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import secrets
+import subprocess
+from typing import Dict, Optional, Tuple
+
+_LOGGER = logging.getLogger("cyberpanel.fastapi_ssh_config")
+
+CONF_PATH = "/etc/cyberpanel/fastapi_ssh_server.conf"
+MARKER_PATH = "/etc/cyberpanel/fastapi_ssh_server_hardening_v1.done"
+FASTAPI_PY = "/usr/local/CyberCP/fastapi_ssh_server.py"
+SERVICE_SRC = "/usr/local/CyberCP/fastapi_ssh_server.service"
+SERVICE_DST = "/etc/systemd/system/fastapi_ssh_server.service"
+
+LEGACY_JWT_SECRETS = frozenset(
+    {
+        "DAsjK2gl50PE09d1N3uZPTQ6JdwwfiuhlyWKMVbUEpc",
+        "YOUR_SECRET_KEY",
+        "REPLACE_ME_WITH_INSTALLER",
+    }
+)
+
+DEFAULT_ISS = "cyberpanel-web-terminal"
+DEFAULT_AUD = "cyberpanel-fastapi-ssh"
+
+
+def _parse_conf_text(text: str) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if key:
+            out[key] = val
+    return out
+
+
+def read_conf_file_dict(path: str = CONF_PATH) -> Dict[str, str]:
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return _parse_conf_text(handle.read())
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        _LOGGER.warning("Could not read %s: %s", path, exc)
+        return {}
+
+
+def is_strong_secret(secret: Optional[str]) -> bool:
+    if not secret or len(secret) < 32:
+        return False
+    if secret in LEGACY_JWT_SECRETS:
+        return False
+    return True
+
+
+def generate_secret() -> str:
+    return secrets.token_urlsafe(48)
+
+
+def write_runtime_conf(
+    jwt_secret: str,
+    iss: str = DEFAULT_ISS,
+    aud: str = DEFAULT_AUD,
+    allowed_origins: str = "",
+) -> None:
+    os.makedirs(os.path.dirname(CONF_PATH), exist_ok=True)
+    lines = [
+        "# CyberPanel Web Terminal (fastapi_ssh_server) runtime configuration",
+        "# Keep permissions at chmod 600 and root ownership.",
+        f'JWT_SECRET="{jwt_secret}"',
+        f'JWT_ISS="{iss}"',
+        f'JWT_AUD="{aud}"',
+    ]
+    if allowed_origins.strip():
+        lines.append(f'ALLOWED_ORIGINS="{allowed_origins.strip()}"')
+    content = "\n".join(lines) + "\n"
+    with open(CONF_PATH, "w", encoding="utf-8") as handle:
+        handle.write(content)
+    try:
+        os.chmod(CONF_PATH, 0o600)
+    except OSError as exc:
+        _LOGGER.warning("Could not chmod %s: %s", CONF_PATH, exc)
+
+
+def _extract_jwt_from_py(content: str) -> Optional[str]:
+    for line in content.splitlines():
+        match = re.match(r"^\s*JWT_SECRET\s*=\s*[\"']([^\"']+)[\"']", line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def migrate_secret_from_legacy_py() -> Optional[str]:
+    """
+    Read JWT_SECRET from the deployed Python file if present (one-time migration).
+    Does not log secret material.
+    """
+    try:
+        with open(FASTAPI_PY, "r", encoding="utf-8", errors="replace") as handle:
+            content = handle.read()
+    except OSError:
+        return None
+    return _extract_jwt_from_py(content)
+
+
+def ensure_web_terminal_runtime_for_panel() -> None:
+    """
+    Panel-side: ensure runtime conf exists and refresh systemd unit if an old 0.0.0.0 bind is present.
+    """
+    ensure_runtime_files_on_install()
+    try:
+        if os.path.isfile(SERVICE_DST):
+            with open(SERVICE_DST, "r", encoding="utf-8", errors="replace") as handle:
+                body = handle.read()
+            if "0.0.0.0" in body and os.path.isfile(SERVICE_SRC):
+                subprocess.run(
+                    ["cp", "-f", SERVICE_SRC, SERVICE_DST],
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                subprocess.run(
+                    ["systemctl", "daemon-reload"],
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+        elif os.path.isfile(SERVICE_SRC):
+            subprocess.run(
+                ["cp", "-f", SERVICE_SRC, SERVICE_DST],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            subprocess.run(
+                ["systemctl", "daemon-reload"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+    except OSError as exc:
+        _LOGGER.debug("ensure_web_terminal_runtime_for_panel unit check: %s", exc)
+
+
+def ensure_runtime_files_on_install() -> None:
+    """
+    Fresh install: ensure /etc/cyberpanel/fastapi_ssh_server.conf exists with a strong secret.
+    """
+    try:
+        data = read_conf_file_dict()
+        cur = (os.environ.get("JWT_SECRET") or data.get("JWT_SECRET", "")).strip()
+        if is_strong_secret(cur):
+            print("Web Terminal JWT already configured at %s" % CONF_PATH)
+            return
+        secret = generate_secret()
+        iss = data.get("JWT_ISS") or DEFAULT_ISS
+        aud = data.get("JWT_AUD") or DEFAULT_AUD
+        origins = (data.get("ALLOWED_ORIGINS") or "").strip()
+        write_runtime_conf(secret, iss=iss, aud=aud, allowed_origins=origins)
+        print("Configured Web Terminal JWT in %s" % CONF_PATH)
+    except Exception as exc:
+        _LOGGER.error("ensure_runtime_files_on_install failed: %s", exc)
+        print("[WARNING] Web Terminal runtime config could not be written: %s" % exc)
+
+
+def get_jwt_encode_settings() -> Tuple[str, str, str]:
+    """
+    Panel-side token creation: return (secret, iss, aud).
+    """
+    data = read_conf_file_dict()
+    secret = (os.environ.get("JWT_SECRET") or data.get("JWT_SECRET", "")).strip()
+    if not is_strong_secret(secret):
+        raise ValueError(
+            "Web Terminal JWT is not configured securely. Check %s" % CONF_PATH
+        )
+    iss = data.get("JWT_ISS") or DEFAULT_ISS
+    aud = data.get("JWT_AUD") or DEFAULT_AUD
+    return secret, iss, aud
+
+
+def _try_remove_public_8888_ports() -> None:
+    """
+    Remove simple firewalld port openings for 8888/tcp if present (legacy exposure).
+    """
+    for cmd in (
+        "firewall-cmd --permanent --zone=public --remove-port=8888/tcp",
+        "firewall-cmd --reload",
+    ):
+        try:
+            subprocess.run(
+                cmd,
+                shell=True,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as exc:
+            _LOGGER.debug("firewall cmd skipped: %s", exc)
+
+
+def apply_security_migration() -> None:
+    """
+    Idempotent upgrade migration: strong secret on disk, refresh systemd unit, marker file.
+    """
+    data = read_conf_file_dict()
+    secret = (os.environ.get("JWT_SECRET") or data.get("JWT_SECRET", "")).strip()
+    need_conf_write = False
+
+    if not is_strong_secret(secret):
+        py_secret = migrate_secret_from_legacy_py()
+        if is_strong_secret(py_secret):
+            secret = py_secret
+        else:
+            secret = generate_secret()
+        need_conf_write = True
+    elif not os.path.isfile(CONF_PATH):
+        secret = generate_secret()
+        need_conf_write = True
+
+    if need_conf_write:
+        write_runtime_conf(
+            secret,
+            iss=data.get("JWT_ISS") or DEFAULT_ISS,
+            aud=data.get("JWT_AUD") or DEFAULT_AUD,
+            allowed_origins=(data.get("ALLOWED_ORIGINS") or "").strip(),
+        )
+
+    try:
+        if os.path.isfile(SERVICE_SRC):
+            subprocess.run(
+                ["cp", "-f", SERVICE_SRC, SERVICE_DST],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            subprocess.run(
+                ["systemctl", "daemon-reload"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+    except OSError as exc:
+        _LOGGER.warning("apply_security_migration unit refresh: %s", exc)
+
+    _try_remove_public_8888_ports()
+
+    try:
+        with open(MARKER_PATH, "w", encoding="utf-8") as marker:
+            marker.write("fastapi_ssh_server hardening migration v1 applied\n")
+        os.chmod(MARKER_PATH, 0o600)
+    except OSError as exc:
+        _LOGGER.warning("Could not write marker %s: %s", MARKER_PATH, exc)

--- a/plogical/upgrade.py
+++ b/plogical/upgrade.py
@@ -7222,6 +7222,19 @@ slowlog = /var/log/php{version}-fpm-slow.log
 
         Upgrade.installDNS_CyberPanelACMEFile()
 
+        try:
+            from plogical import fastapi_ssh_config
+
+            fastapi_ssh_config.apply_security_migration()
+            Upgrade.stdOut(
+                "Applied Web Terminal (fastapi_ssh_server) security migration.", 1
+            )
+        except Exception as exc:
+            Upgrade.stdOut(
+                "Warning: fastapi_ssh_server security migration skipped: %s" % str(exc),
+                0,
+            )
+
         command = 'systemctl restart fastapi_ssh_server'
         Upgrade.executioner(command, command, 0)
 

--- a/test/fastapi_ssh_security_checks.py
+++ b/test/fastapi_ssh_security_checks.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Static checks for Web Terminal security changes (no live services required).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+
+def main() -> int:
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    py_path = os.path.join(root, "fastapi_ssh_server.py")
+    svc_path = os.path.join(root, "fastapi_ssh_server.service")
+    install_path = os.path.join(root, "install", "install.py")
+
+    with open(py_path, "r", encoding="utf-8", errors="replace") as handle:
+        py_src = handle.read()
+    if "DAsjK2gl50PE09d1N3uZPTQ6JdwwfiuhlyWKMVbUEpc" in py_src:
+        print("FAIL: legacy JWT constant leaked in fastapi_ssh_server.py", file=sys.stderr)
+        return 1
+    if re.search(r"^\s*JWT_SECRET\s*=", py_src, re.MULTILINE):
+        print("FAIL: JWT_SECRET must not be assigned in fastapi_ssh_server.py", file=sys.stderr)
+        return 1
+
+    with open(svc_path, "r", encoding="utf-8", errors="replace") as handle:
+        svc = handle.read()
+    if "EnvironmentFile=-/etc/cyberpanel/fastapi_ssh_server.conf" not in svc:
+        print("FAIL: service unit must include EnvironmentFile for runtime conf", file=sys.stderr)
+        return 1
+
+    with open(install_path, "r", encoding="utf-8", errors="replace") as handle:
+        inst = handle.read()
+    if 'FirewallUtilities.addRule("tcp", "8888")' in inst:
+        print("FAIL: installer must not add public tcp 8888", file=sys.stderr)
+        return 1
+
+    print("OK: fastapi_ssh_security_checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/fastapi_ssh_security_smoke.sh
+++ b/test/fastapi_ssh_security_smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Regression checks for Web Terminal (fastapi_ssh_server) hardening.
+# Usage: bash test/fastapi_ssh_security_smoke.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+fail() {
+	echo "FAIL: $1" >&2
+	exit 1
+}
+
+if grep -Fq "DAsjK2gl50PE09d1N3uZPTQ6JdwwfiuhlyWKMVbUEpc" fastapi_ssh_server.py 2>/dev/null; then
+	fail "legacy shared JWT string must not appear in fastapi_ssh_server.py"
+fi
+
+if grep -Eq "^\s*JWT_SECRET\s*=" fastapi_ssh_server.py 2>/dev/null; then
+	fail "JWT_SECRET must not be assigned in fastapi_ssh_server.py (use /etc/cyberpanel/fastapi_ssh_server.conf)"
+fi
+
+if ! grep -q "EnvironmentFile=-/etc/cyberpanel/fastapi_ssh_server.conf" fastapi_ssh_server.service; then
+	fail "fastapi_ssh_server.service must load EnvironmentFile=-/etc/cyberpanel/fastapi_ssh_server.conf"
+fi
+
+if grep -q 'FirewallUtilities.addRule("tcp", "8888")' install/install.py; then
+	fail "install/install.py must not add public firewalld rule tcp 8888 by default"
+fi
+
+if awk '/ports = \[/,/40110-40210\/tcp/' install/install.py | grep -q "8888"; then
+	fail "AlmaLinux 9 firewall ports block in install/install.py must not include 8888"
+fi
+
+echo "OK: fastapi_ssh_server security smoke tests passed."

--- a/websiteFunctions/views.py
+++ b/websiteFunctions/views.py
@@ -2125,18 +2125,17 @@ def get_terminal_jwt(request):
     import logging
     logger = logging.getLogger("cyberpanel.ssh.jwt")
     try:
-        logger.error("get_terminal_jwt called")
-        logger.error(f"Request body: {request.body}")
+        logger.debug("get_terminal_jwt called")
         data = json.loads(request.body)
         domain = data.get('domain')
-        logger.error(f"Domain: {domain}")
+        logger.debug("Domain: %s", domain)
         if not domain:
-            logger.error("No domain provided")
+            logger.warning("No domain provided for Web Terminal JWT")
             return JsonResponse({'status': 0, 'error_message': 'Domain required'})
         user_id = request.session.get('userID')
-        logger.error(f"User ID from session: {user_id}")
+        logger.debug("User ID from session: %s", user_id)
         if not user_id:
-            logger.error("User not authenticated")
+            logger.warning("Web Terminal JWT request without session")
             return JsonResponse({'status': 0, 'error_message': 'Not authenticated'})
         from websiteFunctions.models import Websites
         from plogical.acl import ACLManager
@@ -2144,44 +2143,45 @@ def get_terminal_jwt(request):
         admin = Administrator.objects.get(pk=user_id)
         currentACL = ACLManager.loadedACL(user_id)
         if ACLManager.checkOwnership(domain, admin, currentACL) != 1:
-            logger.error("User not authorized for domain")
+            logger.warning("User not authorized for domain")
             return JsonResponse({'status': 0, 'error_message': 'Not authorized'})
         try:
             website = Websites.objects.get(domain=domain)
         except Websites.DoesNotExist:
-            logger.error("Website not found")
+            logger.warning("Website not found")
             return JsonResponse({'status': 0, 'error_message': 'Website not found'})
         ssh_user = website.externalApp
-        logger.error(f"SSH user: {ssh_user}")
+        logger.debug("SSH user resolved for Web Terminal")
         if not ssh_user:
-            logger.error("SSH user is empty or not set for this website.")
+            logger.warning("SSH user is empty or not set for this website.")
             return JsonResponse({'status': 0, 'error_message': 'SSH user not configured for this website.'})
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
         import jwt as pyjwt
-        # Read JWT_SECRET from fastapi_ssh_server.py using ProcessUtilities
-        jwt_secret = None
+        from plogical import fastapi_ssh_config
+
         try:
-            content = ProcessUtilities.outputExecutioner('cat /usr/local/CyberCP/fastapi_ssh_server.py')
-            for line in content.splitlines():
-                m = re.match(r'\s*JWT_SECRET\s*=\s*[\'"](.+)[\'"]', line)
-                if m and m.group(1) != 'REPLACE_ME_WITH_INSTALLER':
-                    jwt_secret = m.group(1)
-                    if os.path.exists(ProcessUtilities.debugPath):
-                        from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter
-                        CyberCPLogFileWriter.writeLog(f"JWT_SECRET: {jwt_secret}")
-                    break
-        except Exception as e:
-            logger.error(f"Could not read JWT_SECRET: {e}")
-        if not jwt_secret:
-            jwt_secret = 'YOUR_SECRET_KEY'  # fallback, should not be used in production
+            jwt_secret, jwt_iss, jwt_aud = fastapi_ssh_config.get_jwt_encode_settings()
+        except Exception as exc:
+            logger.error("Web Terminal JWT settings unavailable: %s", exc)
+            return JsonResponse(
+                {
+                    "status": 0,
+                    "error_message": "Web Terminal is not configured. Run CyberPanel upgrade or reinstall.",
+                }
+            )
+        now = datetime.now(timezone.utc)
         payload = {
-            'user_id': user_id,
-            'ssh_user': ssh_user,
-            'exp': datetime.utcnow() + timedelta(minutes=10)
+            "iss": jwt_iss,
+            "aud": jwt_aud,
+            "iat": now,
+            "nbf": now,
+            "sub": str(user_id),
+            "ssh_user": ssh_user,
+            "exp": now + timedelta(minutes=10),
         }
-        token = pyjwt.encode(payload, jwt_secret, algorithm='HS256')
-        logger.error(f"JWT generated: {token}")
-        return JsonResponse({'status': 1, 'token': token, 'ssh_user': ssh_user})
+        token = pyjwt.encode(payload, jwt_secret, algorithm="HS256")
+        logger.debug("Issued Web Terminal JWT for domain=%s", domain)
+        return JsonResponse({"status": 1, "token": token, "ssh_user": ssh_user})
     except Exception as e:
         logger.error(f"Exception in get_terminal_jwt: {str(e)}")
         return JsonResponse({'status': 0, 'error_message': str(e)})

--- a/websiteFunctions/website.py
+++ b/websiteFunctions/website.py
@@ -3965,85 +3965,47 @@ context /cyberpanel_suspension_page.html {
 
             Data['accessed_via_ip'] = bool(accessed_via_ip)
 
-            #### update jwt secret if needed
+            #### Web Terminal: runtime JWT file + localhost-only unit (no public 8888 firewall rule)
 
-            import secrets
+            from plogical import fastapi_ssh_config
 
-            fastapi_file = '/usr/local/CyberCP/fastapi_ssh_server.py'
-            from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter
             try:
-                
-                content = ProcessUtilities.outputExecutioner(f'cat {fastapi_file}')
-                if 'REPLACE_ME_WITH_INSTALLER' in content:
-                    new_secret = secrets.token_urlsafe(32)
-                    
-                    sed_cmd = f"sed -i 's|JWT_SECRET = \"REPLACE_ME_WITH_INSTALLER\"|JWT_SECRET = \"{new_secret}\"|' '{fastapi_file}'"
-                    ProcessUtilities.outputExecutioner(sed_cmd)
-                    
-                    command = 'systemctl restart fastapi_ssh_server'
-                    ProcessUtilities.outputExecutioner(command)
-            except Exception:
-                CyberCPLogFileWriter.writeLog(f"Failed to update JWT secret: {e}")
-                pass
+                fastapi_ssh_config.ensure_web_terminal_runtime_for_panel()
+            except Exception as cfg_exc:
+                CyberCPLogFileWriter.writeLog(
+                    "Web Terminal runtime ensure failed: %s" % str(cfg_exc)
+                )
 
-            #####
-
-            #####
-
-            from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter
-            # Ensure FastAPI SSH server systemd service file is in place
             try:
-                service_path = '/etc/systemd/system/fastapi_ssh_server.service'
-                local_service_path = 'fastapi_ssh_server.service'
-                check_service = ProcessUtilities.outputExecutioner(f'test -f {service_path} && echo exists || echo missing')
-                if 'missing' in check_service:
-                    ProcessUtilities.outputExecutioner(f'cp /usr/local/CyberCP/fastapi_ssh_server.service {service_path}')
-                    ProcessUtilities.outputExecutioner('systemctl daemon-reload')
-            except Exception as e:
-                CyberCPLogFileWriter.writeLog(f"Failed to copy or reload fastapi_ssh_server.service: {e}")
-            
+                service_path = "/etc/systemd/system/fastapi_ssh_server.service"
+                check_service = ProcessUtilities.outputExecutioner(
+                    f"test -f {service_path} && echo exists || echo missing"
+                )
+                if "missing" in check_service:
+                    ProcessUtilities.outputExecutioner(
+                        f"cp /usr/local/CyberCP/fastapi_ssh_server.service {service_path}"
+                    )
+                    ProcessUtilities.outputExecutioner("systemctl daemon-reload")
+            except Exception as svc_exc:
+                CyberCPLogFileWriter.writeLog(
+                    "Failed to copy or reload fastapi_ssh_server.service: %s"
+                    % str(svc_exc)
+                )
 
-            #####
-
-            # Ensure FastAPI SSH server is running using ProcessUtilities
             try:
-                ProcessUtilities.outputExecutioner('systemctl is-active --quiet fastapi_ssh_server')
-                ProcessUtilities.outputExecutioner('systemctl enable --now fastapi_ssh_server')
-                ProcessUtilities.outputExecutioner('systemctl start fastapi_ssh_server')
-
-                csfPath = '/etc/csf'
-
-                sshPort = '8888'
-
-                if os.path.exists(csfPath):
-                        dataIn = {'protocol': 'TCP_IN', 'ports': sshPort}
-
-                        # self.modifyPorts is a method in the firewallManager.py file so how can we call it here?
-                        # we need to call the method from the firewallManager.py file
-                        from firewall.firewallManager import FirewallManager
-                        firewallManager = FirewallManager()
-                        firewallManager.modifyPorts(dataIn)
-                        dataIn = {'protocol': 'TCP_OUT', 'ports': sshPort}
-                        firewallManager.modifyPorts(dataIn)
-                else:
-                    from plogical.firewallUtilities import FirewallUtilities
-                    from firewall.models import FirewallRules
-                    try:
-                        updateFW = FirewallRules.objects.get(name="WebTerminalPort")
-                        FirewallUtilities.deleteRule("tcp", updateFW.port, "0.0.0.0/0")
-                        updateFW.port = sshPort
-                        updateFW.save()
-                        FirewallUtilities.addRule('tcp', sshPort, "0.0.0.0/0")
-                    except:
-                        try:
-                            newFireWallRule = FirewallRules(name="WebTerminalPort", port=sshPort, proto="tcp")
-                            newFireWallRule.save()
-                            FirewallUtilities.addRule('tcp', sshPort, "0.0.0.0/0")
-                        except BaseException as msg:
-                            CyberCPLogFileWriter.writeToFile(str(msg))
-
-            except Exception as e:
-                CyberCPLogFileWriter.writeLog(f"Failed to ensure fastapi_ssh_server is running: {e}")
+                ProcessUtilities.outputExecutioner(
+                    "systemctl is-active --quiet fastapi_ssh_server"
+                )
+                ProcessUtilities.outputExecutioner(
+                    "systemctl enable --now fastapi_ssh_server"
+                )
+                ProcessUtilities.outputExecutioner(
+                    "systemctl start fastapi_ssh_server"
+                )
+            except Exception as run_exc:
+                CyberCPLogFileWriter.writeLog(
+                    "Failed to ensure fastapi_ssh_server is running: %s" % str(run_exc)
+                )
 
             # Fetch actual resource limits from lscgctl command if they exist
             Data['resource_limits'] = None
@@ -6141,83 +6103,47 @@ StrictHostKeyChecking no
         website = Websites.objects.get(domain=self.domain)
         externalApp = website.externalApp
 
-        #### update jwt secret if needed
+        #### Web Terminal: runtime JWT file + localhost-only unit (no public 8888 firewall rule)
 
-        import secrets
-        import re
         import os
         from plogical.processUtilities import ProcessUtilities
-
-        fastapi_file = '/usr/local/CyberCP/fastapi_ssh_server.py'
         from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter
+        from plogical import fastapi_ssh_config
+
         try:
-            
-            content = ProcessUtilities.outputExecutioner(f'cat {fastapi_file}')
-            if 'REPLACE_ME_WITH_INSTALLER' in content:
-                new_secret = secrets.token_urlsafe(32)
-                
-                sed_cmd = f"sed -i 's|JWT_SECRET = \"REPLACE_ME_WITH_INSTALLER\"|JWT_SECRET = \"{new_secret}\"|' '{fastapi_file}'"
-                ProcessUtilities.outputExecutioner(sed_cmd)
-                
-                command = 'systemctl restart fastapi_ssh_server'
-                ProcessUtilities.outputExecutioner(command)
-        except Exception:
-            CyberCPLogFileWriter.writeLog(f"Failed to update JWT secret: {e}")
-            pass
+            fastapi_ssh_config.ensure_web_terminal_runtime_for_panel()
+        except Exception as cfg_exc:
+            CyberCPLogFileWriter.writeLog(
+                "Web Terminal runtime ensure failed: %s" % str(cfg_exc)
+            )
 
-        #####
-
-        from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter
-        # Ensure FastAPI SSH server systemd service file is in place
         try:
-            service_path = '/etc/systemd/system/fastapi_ssh_server.service'
-            local_service_path = 'fastapi_ssh_server.service'
-            check_service = ProcessUtilities.outputExecutioner(f'test -f {service_path} && echo exists || echo missing')
-            if 'missing' in check_service:
-                ProcessUtilities.outputExecutioner(f'cp /usr/local/CyberCP/fastapi_ssh_server.service {service_path}')
-                ProcessUtilities.outputExecutioner('systemctl daemon-reload')
-        except Exception as e:
-            CyberCPLogFileWriter.writeLog(f"Failed to copy or reload fastapi_ssh_server.service: {e}")
+            service_path = "/etc/systemd/system/fastapi_ssh_server.service"
+            check_service = ProcessUtilities.outputExecutioner(
+                f"test -f {service_path} && echo exists || echo missing"
+            )
+            if "missing" in check_service:
+                ProcessUtilities.outputExecutioner(
+                    f"cp /usr/local/CyberCP/fastapi_ssh_server.service {service_path}"
+                )
+                ProcessUtilities.outputExecutioner("systemctl daemon-reload")
+        except Exception as svc_exc:
+            CyberCPLogFileWriter.writeLog(
+                "Failed to copy or reload fastapi_ssh_server.service: %s" % str(svc_exc)
+            )
 
-        # Ensure FastAPI SSH server is running using ProcessUtilities
         try:
-            ProcessUtilities.outputExecutioner('systemctl is-active --quiet fastapi_ssh_server')
-            ProcessUtilities.outputExecutioner('systemctl enable --now fastapi_ssh_server')
-            ProcessUtilities.outputExecutioner('systemctl start fastapi_ssh_server')
-
-            csfPath = '/etc/csf'
-
-            sshPort = '8888'
-
-            if os.path.exists(csfPath):
-                    dataIn = {'protocol': 'TCP_IN', 'ports': sshPort}
-
-                    # self.modifyPorts is a method in the firewallManager.py file so how can we call it here?
-                    # we need to call the method from the firewallManager.py file
-                    from firewall.firewallManager import FirewallManager
-                    firewallManager = FirewallManager()
-                    firewallManager.modifyPorts(dataIn)
-                    dataIn = {'protocol': 'TCP_OUT', 'ports': sshPort}
-                    firewallManager.modifyPorts(dataIn)
-            else:
-                from plogical.firewallUtilities import FirewallUtilities
-                from firewall.models import FirewallRules
-                try:
-                    updateFW = FirewallRules.objects.get(name="WebTerminalPort")
-                    FirewallUtilities.deleteRule("tcp", updateFW.port, "0.0.0.0/0")
-                    updateFW.port = sshPort
-                    updateFW.save()
-                    FirewallUtilities.addRule('tcp', sshPort, "0.0.0.0/0")
-                except:
-                    try:
-                        newFireWallRule = FirewallRules(name="WebTerminalPort", port=sshPort, proto="tcp")
-                        newFireWallRule.save()
-                        FirewallUtilities.addRule('tcp', sshPort, "0.0.0.0/0")
-                    except BaseException as msg:
-                        CyberCPLogFileWriter.writeToFile(str(msg))
-
-        except Exception as e:
-            CyberCPLogFileWriter.writeLog(f"Failed to ensure fastapi_ssh_server is running: {e}")
+            ProcessUtilities.outputExecutioner(
+                "systemctl is-active --quiet fastapi_ssh_server"
+            )
+            ProcessUtilities.outputExecutioner(
+                "systemctl enable --now fastapi_ssh_server"
+            )
+            ProcessUtilities.outputExecutioner("systemctl start fastapi_ssh_server")
+        except Exception as run_exc:
+            CyberCPLogFileWriter.writeLog(
+                "Failed to ensure fastapi_ssh_server is running: %s" % str(run_exc)
+            )
 
         # Add-on check logic
         url = "https://platform.cyberpersons.com/CyberpanelAdOns/Adonpermission"


### PR DESCRIPTION
…s, tests)

- Load JWT and iss/aud from /etc/cyberpanel/fastapi_ssh_server.conf; fail closed on weak secrets
- Systemd: EnvironmentFile, hardening; keep 0.0.0.0:8888 for existing browser wss to panel host
- Install/upgrade: write runtime conf, migration, no default firewalld 8888; after_install restarts if conf exists
- Panel: get_terminal_jwt via fastapi_ssh_config; remove public WebTerminal firewalld/CSF adds from website flows
- Add plogical/fastapi_ssh_config.py and test/ smoke + static checks