### PR TITLE
post-upgrade: restore SnappyMail when missing; fix CP python shim; ad…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Syntax check shell scripts
         run: |
-          for f in cyberpanel_upgrade.sh preUpgrade.sh fix-phpmyadmin.sh cyberpanel.sh cyberpanel_utility.sh; do
+          for f in cyberpanel_upgrade.sh preUpgrade.sh fix-phpmyadmin.sh fix-snappymail.sh cyberpanel.sh cyberpanel_utility.sh; do
             [ ! -f "$f" ] && continue
             bash -n "$f" || { echo "FAIL (syntax): $f"; exit 1; }
             echo "OK $f"

--- a/fix-snappymail.sh
+++ b/fix-snappymail.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Fix SnappyMail 404 after upgrade (missing /usr/local/CyberCP/public/snappymail). Run as root on the panel server.
+# Usage: sudo bash fix-snappymail.sh
+# Then open https://YOUR_IP:2087/snappymail/index.php (or Webmail in the panel).
+
+set -e
+CP="${CP:-/usr/local/CyberCP}"
+PUBLIC="$CP/public"
+PYTHON="${PYTHON:-$CP/bin/python}"
+
+if [[ $(id -u) -ne 0 ]]; then
+    echo "Run as root: sudo bash $0"
+    exit 1
+fi
+
+echo "Ensuring $PUBLIC exists..."
+mkdir -p "$PUBLIC"
+
+if [[ ! -x "$PYTHON" ]]; then
+    PYTHON=$(command -v python3 2>/dev/null || command -v python2 2>/dev/null || true)
+fi
+if [[ -z "$PYTHON" ]]; then
+    echo "ERROR: No Python found. Fix panel Python or install SnappyMail manually."
+    exit 1
+fi
+
+echo "Installing SnappyMail via panel upgrade module..."
+export DJANGO_SETTINGS_MODULE=CyberCP.settings
+"$PYTHON" -c "
+import sys
+sys.path.insert(0, '$CP')
+from plogical.upgrade import Upgrade
+Upgrade.downoad_and_install_raindloop()
+" 2>&1 || true
+
+if [[ -f "$PUBLIC/snappymail/index.php" ]]; then
+    echo "Setting ownership to lscpd:lscpd..."
+    chown -R lscpd:lscpd "$PUBLIC/snappymail" 2>/dev/null || true
+    chmod 755 "$PUBLIC/snappymail" 2>/dev/null || true
+    echo "Done. SnappyMail is at $PUBLIC/snappymail"
+    echo "Test: https://YOUR_IP:2087/snappymail/index.php"
+else
+    echo "WARNING: $PUBLIC/snappymail/index.php was not created. Check logs above."
+    exit 1
+fi

--- a/upgrade_modules/10_post_tweak.sh
+++ b/upgrade_modules/10_post_tweak.sh
@@ -2,6 +2,16 @@
 # CyberPanel upgrade – post-upgrade system tweaks (PHP, LSWS, SnappyMail, etc.). Sourced by cyberpanel_upgrade.sh.
 
 Post_Upgrade_System_Tweak() {
+  # Cron and upgrade helpers expect /usr/local/CyberCP/bin/python (legacy CyberPanel venv path may be missing).
+  if [[ ! -x /usr/local/CyberCP/bin/python ]]; then
+    mkdir -p /usr/local/CyberCP/bin
+    _py="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+    if [[ -n "$_py" && -x "$_py" ]]; then
+      ln -sfn "$_py" /usr/local/CyberCP/bin/python
+      echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Restored /usr/local/CyberCP/bin/python -> $_py" | tee -a /var/log/cyberpanel_upgrade_debug.log
+    fi
+  fi
+
   if [[ "$Server_OS" = "CentOS" ]] ; then
 
   #for cenots 7/8
@@ -391,6 +401,26 @@ if [ ! -f /usr/local/CyberCP/public/phpmyadmin/index.php ]; then
     echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] phpMyAdmin repair completed successfully (index.php restored)." | tee -a /var/log/cyberpanel_upgrade_debug.log
   else
     echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] WARNING: phpMyAdmin repair did not restore index.php. Run /usr/local/CyberCP/fix-phpmyadmin.sh manually." | tee -a /var/log/cyberpanel_upgrade_debug.log
+  fi
+fi
+
+# Validate SnappyMail web app after upgrade and self-heal if missing (Django serves /snappymail/ from PUBLIC_ROOT/snappymail).
+if [ ! -f /usr/local/CyberCP/public/snappymail/index.php ]; then
+  echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] WARNING: SnappyMail index.php missing after upgrade, attempting repair..." | tee -a /var/log/cyberpanel_upgrade_debug.log
+  if [ -x /usr/local/CyberCP/fix-snappymail.sh ]; then
+    bash /usr/local/CyberCP/fix-snappymail.sh 2>&1 | tee -a /var/log/cyberpanel_upgrade_debug.log || true
+  elif [ -x /usr/local/CyberCP/bin/python ]; then
+    export DJANGO_SETTINGS_MODULE=CyberCP.settings
+    /usr/local/CyberCP/bin/python -c "import sys; sys.path.insert(0, '/usr/local/CyberCP'); from plogical.upgrade import Upgrade; Upgrade.downoad_and_install_raindloop()" 2>&1 | tee -a /var/log/cyberpanel_upgrade_debug.log || true
+  else
+    python3 -c "import sys; sys.path.insert(0, '/usr/local/CyberCP'); from plogical.upgrade import Upgrade; Upgrade.downoad_and_install_raindloop()" 2>&1 | tee -a /var/log/cyberpanel_upgrade_debug.log || true
+  fi
+
+  if [ -f /usr/local/CyberCP/public/snappymail/index.php ]; then
+    echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] SnappyMail repair completed successfully (index.php restored)." | tee -a /var/log/cyberpanel_upgrade_debug.log
+    chown -R lscpd:lscpd /usr/local/CyberCP/public/snappymail 2>/dev/null || true
+  else
+    echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] WARNING: SnappyMail repair did not restore index.php. Run /usr/local/CyberCP/fix-snappymail.sh manually." | tee -a /var/log/cyberpanel_upgrade_debug.log
   fi
 fi
 


### PR DESCRIPTION
…d fix-snappymail.sh

- Ensure /usr/local/CyberCP/bin/python exists (symlink to system python3) so cron and upgrade Python hooks run after legacy venv removal.
- If public/snappymail/index.php is missing after upgrade, run fix-snappymail.sh or Upgrade.downoad_and_install_raindloop() and log outcome.
- Add fix-snappymail.sh operator script (mirror fix-phpmyadmin.sh).
- CI: bash -n fix-snappymail.sh.