### PR TITLE
Fix Domain Alias UI wiring + clean up Angular template inconsistencies

### DIFF
--- a/websiteFunctions/templates/websiteFunctions/domainAlias.html
+++ b/websiteFunctions/templates/websiteFunctions/domainAlias.html
@@ -37,7 +37,7 @@
 
                     </form>
 
-                    <!---------- HTML For creating domains --------------->
+                    <!---------- HTML For creating aliases --------------->
                     <div class="col-md-12 mx-10">
                         <form id="domainCreationForm" name="websiteCreationForm" action="/"
                               class="form-horizontal bordered-row">
@@ -46,7 +46,7 @@
                                 <label class="col-sm-3 control-label">{% trans "Domain Name" %}</label>
                                 <div class="col-sm-6">
                                     <input name="dom" type="text" class="form-control"
-                                           ng-model="domainNameCreate" required>
+                                           ng-model="aliasDomain" required>
                                 </div>
                                 <div style="margin-bottom: 1%;" class=" col-sm-1">
                                     <a title="{% trans 'Cancel' %}" ng-click="hideDomainCreationForm()" href="">
@@ -55,7 +55,7 @@
                                 </div>
                             </div>
 
-                            <div ng-hide="installationDetailsForm" ng-hide="installationDetailsForm"
+                            <div ng-hide="installationDetailsForm"
                                  class="form-group">
                                 <label class="col-sm-3 control-label">{% trans "Additional Features" %}</label>
                                 <div class="col-sm-9">
@@ -72,7 +72,7 @@
                             <div ng-hide="installationDetailsForm" class="form-group">
                                 <label class="col-sm-3 control-label"></label>
                                 <div class="col-sm-4">
-                                    <button type="button" ng-click="createDomain()"
+                                    <button type="button" ng-click="addAliasFunc()"
                                             class="btn btn-primary btn-lg">{% trans "Create Alias" %}</button>
 
                                 </div>
@@ -99,7 +99,7 @@
                                     </div>
 
                                     <div ng-hide="success" class="alert alert-success">
-                                        <p>{% trans "Website succesfully created." %}</p>
+                                        <p>{% trans "Alias succesfully created." %}</p>
                                     </div>
 
 
@@ -163,7 +163,7 @@
 
                                 <div class="col-sm-11">
                                     <input placeholder="Search Domain..." ng-model="logSearch" name="dom"
-                                           type="text" class="form-control" ng-model="domainNameCreate"
+                                           type="text" class="form-control"
                                            required>
                                 </div>
 
@@ -205,7 +205,7 @@
                                                 </td>
                                                 <td>
                                                     <button type="button"
-                                                            ng-click="issueAliasSSL('{{ masterDomain }}', '{{ alias }}')"
+                                                            ng-click="issueSSL('{{ masterDomain }}', '{{ alias }}')"
                                                             class="btn ra-50 btn-primary">{% trans "Issue SSL" %}</button>
                                                 </td>
                                                 <td>

--- a/websiteFunctions/templates/websiteFunctions/website.html
+++ b/websiteFunctions/templates/websiteFunctions/website.html
@@ -1871,7 +1871,7 @@
                                     </div>
                                 </div>
 
-                                <div ng-hide="installationDetailsForm" ng-hide="installationDetailsForm"
+                                <div ng-hide="installationDetailsForm"
                                      class="form-group">
                                     <label class="col-sm-3 control-label">{% trans "Additional Features" %}</label>
                                     <div class="col-sm-9">
@@ -2029,15 +2029,15 @@
                                                     </td>
                                                     <td ng-bind="record.path"></td>
                                                     <td>
-                                                        <select ng-change="changeChildBaseDir(record.childDomain,childBaseDir)"
-                                                                ng-model="childBaseDir" class="form-control">
+                                                        <select ng-change="changeChildBaseDir(record.childDomain, record.childBaseDir)"
+                                                                ng-model="record.childBaseDir" class="form-control">
                                                             <option>Enable</option>
                                                             <option>Disable</option>
                                                         </select>
                                                     </td>
                                                     <td>
-                                                        <select ng-change="changePHP(record.childDomain,phpSelection)"
-                                                                ng-model="phpSelection" class="form-control">
+                                                        <select ng-change="changePHP(record.childDomain, record.phpSelection)"
+                                                                ng-model="record.phpSelection" class="form-control">
                                                             {% for php in phps %}
                                                                 <option>{{ php }}</option>
                                                             {% endfor %}


### PR DESCRIPTION
**Context / Why**
We found multiple cases where the Domain Alias UI was partially wired like the child-domain / domain-creation UI. That creates risky, unexpected outcomes (e.g., “Create Alias” triggering the domain-creation flow, and alias actions being bound to non-alias handlers). In addition, a few Angular/template inconsistencies (duplicate directives and shared `ng-model`s inside `ng-repeat`) can cause silent or confusing UI behavior.

This PR aligns the templates with the intended controller functions and removes inconsistent bindings.

---

## What changed

### 1) Domain Alias creation uses alias flow (not domain creation)
File: ` /cyberpanel/websiteFunctions/templates/websiteFunctions/domainAlias.html`

- The alias input now binds to `ng-model="aliasDomain"` instead of `domainNameCreate`.
- The “Create Alias” button now calls `addAliasFunc()` (the alias endpoint flow) instead of `createDomain()`.
- The success message copy is corrected to “Alias successfully created.”
- Removed duplicate `ng-hide="installationDetailsForm"` and removed the duplicate `ng-model` on the search field to prevent ambiguous Angular bindings.

**Impact**
Creating an alias now consistently posts through the alias controller logic (`/websites/submitAliasCreation`) rather than the domain/child-domain creation flow.

---

### 2) Alias SSL action uses the correct controller method
File: `/cyberpanel/websiteFunctions/templates/websiteFunctions/domainAlias.html`

- The alias table button now calls `issueSSL(masterDomain, alias)` (which is what `manageAliasController` defines and routes to `/websites/issueAliasSSL`) rather than calling a mismatched/incorrect function name.

**Impact**
Alias SSL issuance is executed via the expected alias SSL endpoint and function signature.

---

### 3) Fix shared per-row dropdown state in child-domain listing
File: `/cyberpanel/websiteFunctions/templates/websiteFunctions/website.html`

- Removed duplicate `ng-hide="installationDetailsForm"`.
- Updated `ng-repeat` row dropdowns to use per-row models:
  - `record.childBaseDir` instead of a shared `childBaseDir`
  - `record.phpSelection` instead of a shared `phpSelection`
- Updated corresponding `ng-change` calls to pass the row-scoped values.

**Impact**
Selecting PHP/open_basedir in one row no longer “bleeds” state into other rows or causes confusing UI jumps.

---

## Files changed
- `cyberpanel/websiteFunctions/templates/websiteFunctions/domainAlias.html`
- `/cyberpanel/websiteFunctions/templates/websiteFunctions/website.html`

---

## How to test

### Domain Alias
1. Go to a website → **Domain Aliases**
2. Enter an alias domain and click **Create Alias**
3. Confirm:
   - Request uses alias flow (`addAliasFunc()` → `/websites/submitAliasCreation`)
   - Alias appears in the alias table after reload
4. Click **Issue SSL** for an alias
   - Confirm it calls `/websites/issueAliasSSL` with `(masterDomain, aliasDomain)`

### Child domains table
1. Go to website → child domains listing section
2. Change PHP for one row; ensure other rows don’t change selection
3. Toggle open_basedir for one row; ensure other rows don’t change selection

---

## Risk / Notes
- Changes are template-only wiring/binding fixes; backend behavior/endpoints are unchanged.
- This reduces risk of accidental misuse of destructive endpoints by ensuring the Domain Alias page uses alias-specific handler functions and models.