### PR TITLE
Fix CWE-532: remove debug print() statements that log plaintext password

### DIFF
--- a/loginSystem/views.py
+++ b/loginSystem/views.py
@@ -44,11 +44,6 @@ def verifyLogin(request):
                 username = data.get('username', '')
                 password = data.get('password', '')
 
-                # Debug logging
-                print(f"Login attempt - Username: {username}, Password length: {len(password) if password else 0}")
-                print(f"Password contains '$': {'$' in password if password else False}")
-                print(f"Raw password: {repr(password)}")
-
                 try:
                     language_selection = data.get('languageSelection', 'english')
                     if language_selection == "English":
@@ -98,7 +93,6 @@ def verifyLogin(request):
                     response.set_cookie(settings.LANGUAGE_COOKIE_NAME, user_Language)
 
             admin = Administrator.objects.get(userName=username)
-            print(f"Found admin user: {admin.userName}, password hash length: {len(admin.password) if admin.password else 0}")
 
             if admin.state == 'SUSPENDED':
                 data = {'userID': 0, 'loginStatus': 0, 'error_message': 'Account currently suspended.'}
@@ -116,7 +110,6 @@ def verifyLogin(request):
                     return response
 
             password_check_result = hashPassword.check_password(admin.password, password)
-            print(f"Password check result: {password_check_result}")
 
             if password_check_result:
                 if admin.twoFA:


### PR DESCRIPTION
## Summary

Removes five `print()` statements in `loginSystem/views.py::verifyLogin()` that log the typed password (cleartext) and the password-check result to stderr.log on every login attempt.

## Vulnerability

- **CWE-532** Insertion of Sensitive Information into Log File
- **CWE-312** Cleartext Storage of Sensitive Information
- **Affected version:** 2.4.5
- **Reported privately:** 2026-05-11
  - Email: security@cyberpanel.net (ticket RPLQ71)
  - GitHub PVR: GHSA-38vc-fh4r-m99j

The specific `Raw password: {repr(password)}` line captures the plaintext password the user typed into the form. The `Password check result: True/False` line confirms which submissions were valid, which means any leaked stderr.log content (backups, log shippers, operator review) is a direct credential leak.

## Changes

Single file, seven deletions:

- `loginSystem/views.py` lines 47-50 (the `# Debug logging` comment plus three `print()` statements that log username, password length, $-presence, and the cleartext password itself)
- `loginSystem/views.py` line 101 (`print()` logging the fetched admin row's username and password-hash length)
- `loginSystem/views.py` line 119 (`print()` logging the boolean result of `hashPassword.check_password()`)

No functional change to the login flow. Removing pure stderr writes; control flow is untouched.

## Verification

- `python3 -m py_compile loginSystem/views.py` passes
- Local reproduction on a 2.4.5 install before patch: `grep "Raw password" /home/cyberpanel/stderr.log` returned typed passwords after each login. After patch: no matches.

## Operator note

Sanitization recipe for affected log files (operators of any v2.4.5 install should run this once):

\`\`\`bash
grep -vE "Raw password:|Password contains '\\\\\$':|Login attempt - Username:|Found admin user:.*password hash length|Password check result:" /home/cyberpanel/stderr.log > /tmp/stderr.sanitized.log
cat /tmp/stderr.sanitized.log > /home/cyberpanel/stderr.log
rm -f /tmp/stderr.sanitized.log
\`\`\`

Operators who logged into the panel during the 2.4.5 window should also rotate admin passwords as a precaution. Cleartext may have been written to operator-controlled secondary destinations: backups, log shippers, monitoring agents.