### PR TITLE
Fix domain alias delete actions

### DIFF
--- a/websiteFunctions/templates/websiteFunctions/domainAlias.html
+++ b/websiteFunctions/templates/websiteFunctions/domainAlias.html
@@ -178,32 +178,37 @@
                                     <table class="table">
                                         <thead>
                                         <tr>
-                                            <th>Domain</th>
-                                            <th>Launch</th>
-                                            <th>Path</th>
+                                            <th>{% trans "Master Domain" %}</th>
+                                            <th>{% trans "Alias" %}</th>
+                                            <th>{% trans "File System Path" %}</th>
                                             <th>SSL</th>
                                             <th>Delete</th>
                                         </tr>
                                         </thead>
                                         <tbody>
-                                        <tr ng-repeat="record in childDomains | filter:logSearch">
-                                            <td ng-bind="record.childDomain"></td>
-                                            <td><a href="{$ record.childLunch $}"><img width="30px" height="30"
-                                                                                       class="center-block"
-                                                                                       src="{% static 'baseTemplate/assets/image-resources/webPanel.png' %}"></a>
-                                            </td>
-                                            <td ng-bind="record.path"></td>
-                                            <td>
-                                                <button type="button"
-                                                        ng-click="issueSSL(record.childDomain,record.path)"
-                                                        class="btn ra-50 btn-primary">{% trans "Issue" %}</button>
-                                            </td>
-                                            <td>
-                                                <button type="button"
-                                                        ng-click="deleteChildDomain(record.childDomain)"
-                                                        class="btn ra-50 btn-primary">{% trans "Delete" %}</button>
-                                            </td>
-                                        </tr>
+                                        {% if noAlias %}
+                                            {% for alias in aliases %}
+                                                <tr>
+                                                    <td>{{ masterDomain }}</td>
+                                                    <td>{{ alias }}</td>
+                                                    <td>{{ path }}</td>
+                                                    <td>
+                                                        <button type="button"
+                                                                ng-click="issueSSL('{{ masterDomain }}', '{{ alias }}')"
+                                                                class="btn ra-50 btn-primary">{% trans "Issue" %}</button>
+                                                    </td>
+                                                    <td>
+                                                        <button type="button"
+                                                                ng-click="removeAlias('{{ masterDomain }}', '{{ alias }}')"
+                                                                class="btn ra-50 btn-primary">{% trans "Delete" %}</button>
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                        {% else %}
+                                            <tr>
+                                                <td colspan="5">{% trans "Domain Aliases not found." %}</td>
+                                            </tr>
+                                        {% endif %}
                                         </tbody>
                                     </table>
                                 </div>

--- a/websiteFunctions/test_domain_alias_template.py
+++ b/websiteFunctions/test_domain_alias_template.py
@@ -1,0 +1,18 @@
+import pathlib
+import unittest
+
+
+class DomainAliasTemplateTest(unittest.TestCase):
+    def test_domain_alias_template_uses_alias_actions(self):
+        template_path = pathlib.Path(__file__).with_name("templates") / "websiteFunctions" / "domainAlias.html"
+        template = template_path.read_text(encoding="utf-8")
+
+        self.assertIn("removeAlias('{{ masterDomain }}', '{{ alias }}')", template)
+        self.assertIn("issueSSL('{{ masterDomain }}', '{{ alias }}')", template)
+        self.assertIn("{% for alias in aliases %}", template)
+        self.assertNotIn("deleteChildDomain(record.childDomain)", template)
+        self.assertNotIn("record in childDomains", template)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- render alias rows from the alias context instead of child-domain placeholders
- wire the delete button to `removeAlias()` and SSL issuance to the correct alias values
- add a regression test to keep the domain alias template pointed at alias actions

Fixes #1434

## Testing
- `python -m unittest websiteFunctions.test_domain_alias_template`