### PR TITLE
Dashboard /base/ pagination backport (stable)

### DIFF
--- a/baseTemplate/static/baseTemplate/custom-js/system-status.js
+++ b/baseTemplate/static/baseTemplate/custom-js/system-status.js
@@ -37,6 +37,31 @@ function randomPassword(length) {
 
 var app = angular.module('CyberCP', []);
 
+/* Dashboard API helpers: avoid worker exhaustion from poll storms */
+var DASH_HTTP_TIMEOUT = 25000;
+var dashPollInFlight = {};
+
+function dashGet($http, url, extraConfig) {
+    var cfg = extraConfig || {};
+    cfg.timeout = DASH_HTTP_TIMEOUT;
+    return $http.get(url, cfg);
+}
+
+function dashPollOnce($http, key, url, onSuccess) {
+    if (dashPollInFlight[key]) {
+        return;
+    }
+    dashPollInFlight[key] = true;
+    dashGet($http, url).then(function (response) {
+        dashPollInFlight[key] = false;
+        if (typeof onSuccess === 'function') {
+            onSuccess(response);
+        }
+    }, function () {
+        dashPollInFlight[key] = false;
+    });
+}
+
 var globalScope;
 
 function GlobalRespSuccess(response) {
@@ -116,70 +141,187 @@ function getWebsiteName(domain) {
     }
 }
 
+/* Smooth Overview metric display (CPU/RAM/Disk cards) */
+var cpMetricAnimator = {
+    lerpFactor: 0.12,
+    snapThreshold: 0.5,
+    animFrameId: null,
+    targets: { cpu: null, ram: null, disk: null },
+    display: { cpu: null, ram: null, disk: null },
+
+    reset: function () {
+        this.cancel();
+        this.targets = { cpu: null, ram: null, disk: null };
+        this.display = { cpu: null, ram: null, disk: null };
+    },
+
+    cancel: function () {
+        if (this.animFrameId !== null) {
+            cancelAnimationFrame(this.animFrameId);
+            this.animFrameId = null;
+        }
+    },
+
+    setTargets: function (cpu, ram, disk) {
+        this.targets.cpu = cpu;
+        this.targets.ram = ram;
+        this.targets.disk = disk;
+        if (this.display.cpu === null) {
+            this.display.cpu = cpu;
+        }
+        if (this.display.ram === null) {
+            this.display.ram = ram;
+        }
+        if (this.display.disk === null) {
+            this.display.disk = disk;
+        }
+    },
+
+    stepToward: function (current, target) {
+        if (target === null || target === undefined) {
+            return current;
+        }
+        if (current === null || current === undefined) {
+            return target;
+        }
+        var diff = target - current;
+        if (Math.abs(diff) <= this.snapThreshold) {
+            return target;
+        }
+        return current + (diff * this.lerpFactor);
+    },
+
+  tick: function ($scope) {
+        var self = this;
+        var keys = ['cpu', 'ram', 'disk'];
+        var done = true;
+
+        keys.forEach(function (key) {
+            var target = self.targets[key];
+            if (target === null || target === undefined || isNaN(target)) {
+                target = 0;
+            }
+            var next = self.stepToward(self.display[key], target);
+            if (Math.abs(target - next) > self.snapThreshold) {
+                done = false;
+            }
+            self.display[key] = next;
+        });
+
+        $scope.displayCpuUsage = Math.round(self.display.cpu || 0);
+        $scope.displayRamUsage = Math.round(self.display.ram || 0);
+        $scope.displayDiskUsage = Math.round(self.display.disk || 0);
+
+        if (!done) {
+            self.animFrameId = requestAnimationFrame(function () {
+                self.tick($scope);
+            });
+        } else {
+            self.animFrameId = null;
+            $scope.displayCpuUsage = Math.round(self.targets.cpu || 0);
+            $scope.displayRamUsage = Math.round(self.targets.ram || 0);
+            $scope.displayDiskUsage = Math.round(self.targets.disk || 0);
+            self.display.cpu = self.targets.cpu;
+            self.display.ram = self.targets.ram;
+            self.display.disk = self.targets.disk;
+        }
+
+        if (!$scope.$$phase) {
+            $scope.$apply();
+        }
+    },
+
+    animateTo: function ($scope, cpu, ram, disk) {
+        this.cancel();
+        this.setTargets(cpu, ram, disk);
+        this.tick($scope);
+    }
+};
+
 app.controller('systemStatusInfo', function ($scope, $http, $timeout) {
 
     $scope.uptimeLoaded = false;
     $scope.uptime = 'Loading...';
     $scope.statusError = false;
+    $scope.displayCpuUsage = undefined;
+    $scope.displayRamUsage = undefined;
+    $scope.displayDiskUsage = undefined;
+    var statusPollTimer = null;
+    var statusReqPending = false;
+    var STATUS_REFRESH_MS = 60000;
+
+    function scheduleStatusRefresh() {
+        if (statusPollTimer) {
+            $timeout.cancel(statusPollTimer);
+        }
+        statusPollTimer = $timeout(getStuff, STATUS_REFRESH_MS);
+    }
+
+    function resetDisplayMetrics() {
+        cpMetricAnimator.reset();
+        $scope.displayCpuUsage = undefined;
+        $scope.displayRamUsage = undefined;
+        $scope.displayDiskUsage = undefined;
+    }
 
     getStuff();
 
     $scope.getSystemStatus = function() {
-        getStuff();
+        getStuff(true);
     };
 
     $scope.retryStatus = function() {
         $scope.statusError = false;
-        $scope.cpuUsage = undefined;
-        $scope.ramUsage = undefined;
-        $scope.diskUsage = undefined;
-        getStuff();
+        resetDisplayMetrics();
+        $scope.cpuCores = undefined;
+        $scope.ramTotalMB = undefined;
+        $scope.diskTotalGB = undefined;
+        $scope.diskFreeGB = undefined;
+        getStuff(true);
     };
 
-    function getStuff() {
+    $scope.$on('$destroy', function () {
+        cpMetricAnimator.cancel();
+        if (statusPollTimer) {
+            $timeout.cancel(statusPollTimer);
+        }
+    });
 
-        url = "/base/getSystemStatus";
+    function getStuff(force) {
+        if (statusReqPending && !force) {
+            return;
+        }
+        statusReqPending = true;
 
-        $http.get(url).then(ListInitialData, cantLoadInitialData);
-
-
-        function ListInitialData(response) {
-
-            $scope.statusError = false;
-            $scope.cpuUsage = response.data.cpuUsage;
-            $scope.ramUsage = response.data.ramUsage;
-            $scope.diskUsage = response.data.diskUsage;
-            
-            // Total system information
-            $scope.cpuCores = response.data.cpuCores;
-            $scope.ramTotalMB = response.data.ramTotalMB;
-            $scope.diskTotalGB = response.data.diskTotalGB;
-            $scope.diskFreeGB = response.data.diskFreeGB;
-            
-            // Get uptime if available
-            if (response.data.uptime) {
-                $scope.uptime = response.data.uptime;
+        dashGet($http, '/base/getSystemStatus').then(function (response) {
+            statusReqPending = false;
+            if (response && response.data) {
+                $scope.statusError = false;
+                cpMetricAnimator.animateTo(
+                    $scope,
+                    response.data.cpuUsage,
+                    response.data.ramUsage,
+                    response.data.diskUsage
+                );
+                $scope.cpuCores = response.data.cpuCores;
+                $scope.ramTotalMB = response.data.ramTotalMB;
+                $scope.diskTotalGB = response.data.diskTotalGB;
+                $scope.diskFreeGB = response.data.diskFreeGB;
+                $scope.uptime = response.data.uptime || 'N/A';
                 $scope.uptimeLoaded = true;
             } else {
-                // Fallback: try to get uptime separately
-                $http.get("/base/getUptime").then(function(uptimeResponse) {
-                    if (uptimeResponse.data.uptime) {
-                        $scope.uptime = uptimeResponse.data.uptime;
-                        $scope.uptimeLoaded = true;
-                    }
-                });
+                $scope.uptime = 'Unavailable';
+                $scope.uptimeLoaded = true;
+                $scope.statusError = true;
             }
-
-        }
-
-        function cantLoadInitialData(response) {
+            scheduleStatusRefresh();
+        }, function () {
+            statusReqPending = false;
             $scope.uptime = 'Unavailable';
             $scope.uptimeLoaded = true;
             $scope.statusError = true;
-        }
-
-        $timeout(getStuff, 60000); // Update every minute
-
+            scheduleStatusRefresh();
+        });
     }
 });
 
@@ -427,7 +569,7 @@ app.controller('loadAvg', function ($scope, $http, $timeout) {
             console.log("Can't get load average data");
         }
 
-        //$timeout(getStuff, 2000);
+        //$timeout(getStuff, 60000); // was 2s; reduced panel load
 
     }
 });
@@ -537,7 +679,7 @@ app.controller('homePageStatus', function ($scope, $http, $timeout) {
             console.log("not good");
         }
 
-        $timeout(getStuff, 2000);
+        $timeout(getStuff, 60000); // was 2s; reduced panel load
 
     }
 
@@ -747,7 +889,7 @@ app.controller('designtheme', function ($scope, $http, $timeout) {
             console.log(response);
         }
 
-        //$timeout(getStuff, 2000);
+        //$timeout(getStuff, 60000); // was 2s; reduced panel load
 
     };
 });
@@ -929,20 +1071,110 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
 
     // Top Processes
     $scope.topProcesses = [];
+    $scope.topProcessesPaginated = [];
+    $scope.topProcessesCurrentPage = 1;
+    $scope.topProcessesPerPage = 5;
+    $scope.topProcessesGoToPageInput = 1;
     $scope.loadingTopProcesses = true;
     $scope.errorTopProcesses = '';
+
+    $scope.getTopProcessesTotalPages = function() {
+        var perPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        return Math.ceil(($scope.topProcesses || []).length / perPage);
+    };
+
+    $scope.getTopProcessesStart = function() {
+        if (!$scope.topProcesses || $scope.topProcesses.length === 0) {
+            return 0;
+        }
+        var perPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        return ($scope.topProcessesCurrentPage - 1) * perPage + 1;
+    };
+
+    $scope.getTopProcessesEnd = function() {
+        if (!$scope.topProcesses || $scope.topProcesses.length === 0) {
+            return 0;
+        }
+        var perPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        var end = $scope.topProcessesCurrentPage * perPage;
+        return Math.min(end, $scope.topProcesses.length);
+    };
+
+    $scope.updateTopProcessesPaginated = function() {
+        if (!$scope.topProcesses || $scope.topProcesses.length === 0) {
+            $scope.topProcessesPaginated = [];
+            return;
+        }
+        var perPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        var totalPages = $scope.getTopProcessesTotalPages();
+        if ($scope.topProcessesCurrentPage > totalPages) {
+            $scope.topProcessesCurrentPage = totalPages || 1;
+        }
+        if ($scope.topProcessesCurrentPage < 1) {
+            $scope.topProcessesCurrentPage = 1;
+        }
+        $scope.topProcessesGoToPageInput = $scope.topProcessesCurrentPage;
+        var start = ($scope.topProcessesCurrentPage - 1) * perPage;
+        var end = start + perPage;
+        $scope.topProcessesPaginated = $scope.topProcesses.slice(start, end);
+    };
+
+    $scope.topProcessesPrevPage = function() {
+        $scope.topProcessesGoToPage($scope.topProcessesCurrentPage - 1);
+    };
+
+    $scope.topProcessesNextPage = function() {
+        $scope.topProcessesGoToPage($scope.topProcessesCurrentPage + 1);
+    };
+
+    $scope.topProcessesChangePerPage = function() {
+        $scope.topProcessesPerPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        $scope.topProcessesCurrentPage = 1;
+        $scope.topProcessesGoToPageInput = 1;
+        $scope.updateTopProcessesPaginated();
+    };
+
+    $scope.topProcessesGoToPage = function(page) {
+        page = parseInt(page, 10);
+        var totalPages = $scope.getTopProcessesTotalPages();
+        if (page >= 1 && page <= totalPages) {
+            $scope.topProcessesCurrentPage = page;
+            $scope.updateTopProcessesPaginated();
+        } else {
+            $scope.topProcessesGoToPageInput = $scope.topProcessesCurrentPage;
+        }
+    };
+
+    $scope.topProcessesGoToPageNumber = function() {
+        $scope.topProcessesGoToPage($scope.topProcessesGoToPageInput);
+    };
+
     $scope.refreshTopProcesses = function() {
+        if (dashPollInFlight.topProcesses) {
+            return;
+        }
+        dashPollInFlight.topProcesses = true;
         $scope.loadingTopProcesses = true;
-        $http.get('/base/getTopProcesses').then(function (response) {
+        dashGet($http, '/base/getTopProcesses').then(function (response) {
+            dashPollInFlight.topProcesses = false;
             $scope.loadingTopProcesses = false;
             if (response.data && response.data.status === 1 && response.data.processes) {
                 $scope.topProcesses = response.data.processes;
+                $scope.topProcessesCurrentPage = 1;
+                $scope.topProcessesGoToPageInput = 1;
+                $scope.updateTopProcessesPaginated();
             } else {
                 $scope.topProcesses = [];
+                $scope.topProcessesPaginated = [];
+                $scope.topProcessesGoToPageInput = 1;
             }
-        }, function (err) {
+        }, function () {
+            dashPollInFlight.topProcesses = false;
             $scope.loadingTopProcesses = false;
             $scope.errorTopProcesses = 'Failed to load top processes.';
+            $scope.topProcesses = [];
+            $scope.topProcessesPaginated = [];
+            $scope.topProcessesGoToPageInput = 1;
         });
     };
 
@@ -950,90 +1182,102 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
     $scope.sshLogins = [];
     $scope.sshLoginsPaginated = [];
     $scope.sshLoginsCurrentPage = 1;
-    $scope.sshLoginsPerPage = 10;
-    $scope.sshLoginsGoToPage = 1;
+    $scope.sshLoginsPerPage = 5;
+    $scope.sshLoginsGoToPageInput = 1;
     $scope.loadingSSHLogins = true;
     $scope.errorSSHLogins = '';
     
     $scope.getSSHLoginsTotalPages = function() {
-        return Math.ceil($scope.sshLogins.length / $scope.sshLoginsPerPage);
+        var perPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        return Math.ceil(($scope.sshLogins || []).length / perPage);
     };
     
     $scope.getSSHLoginsStart = function() {
         if (!$scope.sshLogins || $scope.sshLogins.length === 0) {
             return 0;
         }
-        return ($scope.sshLoginsCurrentPage - 1) * $scope.sshLoginsPerPage + 1;
+        var perPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        return ($scope.sshLoginsCurrentPage - 1) * perPage + 1;
     };
     
     $scope.getSSHLoginsEnd = function() {
         if (!$scope.sshLogins || $scope.sshLogins.length === 0) {
             return 0;
         }
-        var end = $scope.sshLoginsCurrentPage * $scope.sshLoginsPerPage;
+        var perPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        var end = $scope.sshLoginsCurrentPage * perPage;
         return Math.min(end, $scope.sshLogins.length);
     };
     
     $scope.updateSSHLoginsPaginated = function() {
         if (!$scope.sshLogins || $scope.sshLogins.length === 0) {
             $scope.sshLoginsPaginated = [];
-            console.log('updateSSHLoginsPaginated: No data, cleared paginated array');
             return;
         }
-        var start = ($scope.sshLoginsCurrentPage - 1) * $scope.sshLoginsPerPage;
-        var end = start + $scope.sshLoginsPerPage;
+        var perPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        var totalPages = $scope.getSSHLoginsTotalPages();
+        if ($scope.sshLoginsCurrentPage > totalPages) {
+            $scope.sshLoginsCurrentPage = totalPages || 1;
+        }
+        if ($scope.sshLoginsCurrentPage < 1) {
+            $scope.sshLoginsCurrentPage = 1;
+        }
+        $scope.sshLoginsGoToPageInput = $scope.sshLoginsCurrentPage;
+        var start = ($scope.sshLoginsCurrentPage - 1) * perPage;
+        var end = start + perPage;
         $scope.sshLoginsPaginated = $scope.sshLogins.slice(start, end);
-        console.log('updateSSHLoginsPaginated: start=', start, 'end=', end, 'total=', $scope.sshLogins.length, 'paginated=', $scope.sshLoginsPaginated.length);
     };
     
     $scope.sshLoginsPrevPage = function() {
-        if ($scope.sshLoginsCurrentPage > 1) {
-            $scope.sshLoginsCurrentPage--;
-            $scope.updateSSHLoginsPaginated();
-        }
+        $scope.sshLoginsGoToPage($scope.sshLoginsCurrentPage - 1);
     };
     
     $scope.sshLoginsNextPage = function() {
-        if ($scope.sshLoginsCurrentPage < $scope.getSSHLoginsTotalPages()) {
-            $scope.sshLoginsCurrentPage++;
-            $scope.updateSSHLoginsPaginated();
-        }
+        $scope.sshLoginsGoToPage($scope.sshLoginsCurrentPage + 1);
     };
-    
-    $scope.sshLoginsGoToPageNumber = function() {
-        var page = parseInt($scope.sshLoginsGoToPage);
+
+    $scope.sshLoginsChangePerPage = function() {
+        $scope.sshLoginsPerPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        $scope.sshLoginsCurrentPage = 1;
+        $scope.sshLoginsGoToPageInput = 1;
+        $scope.updateSSHLoginsPaginated();
+    };
+
+    $scope.sshLoginsGoToPage = function(page) {
+        page = parseInt(page, 10);
         var totalPages = $scope.getSSHLoginsTotalPages();
         if (page >= 1 && page <= totalPages) {
             $scope.sshLoginsCurrentPage = page;
             $scope.updateSSHLoginsPaginated();
         } else {
-            $scope.sshLoginsGoToPage = $scope.sshLoginsCurrentPage;
+            $scope.sshLoginsGoToPageInput = $scope.sshLoginsCurrentPage;
         }
+    };
+    
+    $scope.sshLoginsGoToPageNumber = function() {
+        $scope.sshLoginsGoToPage($scope.sshLoginsGoToPageInput);
     };
     
     $scope.refreshSSHLogins = function() {
         $scope.loadingSSHLogins = true;
         $http.get('/base/getRecentSSHLogins').then(function (response) {
             $scope.loadingSSHLogins = false;
-            console.log('SSH Logins response:', response.data);
             if (response.data && response.data.logins && Array.isArray(response.data.logins)) {
                 $scope.sshLogins = response.data.logins;
                 $scope.sshLoginsCurrentPage = 1;
-                $scope.sshLoginsGoToPage = 1;
-                console.log('SSH Logins loaded:', $scope.sshLogins.length, 'items');
+                $scope.sshLoginsGoToPageInput = 1;
                 $scope.updateSSHLoginsPaginated();
-                console.log('SSH Logins paginated:', $scope.sshLoginsPaginated.length, 'items');
             } else {
-                console.warn('SSH Logins: No data or invalid format', response.data);
                 $scope.sshLogins = [];
                 $scope.sshLoginsPaginated = [];
+                $scope.sshLoginsGoToPageInput = 1;
             }
-        }, function (err) {
+        }, function () {
             $scope.loadingSSHLogins = false;
-            console.error('SSH Logins error:', err);
             $scope.errorSSHLogins = 'Failed to load SSH logins.';
             $scope.sshLogins = [];
             $scope.sshLoginsPaginated = [];
+            $scope.sshLoginsGoToPageInput = 1;
         });
     };
 
@@ -1041,104 +1285,211 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
     $scope.sshLogs = [];
     $scope.sshLogsPaginated = [];
     $scope.sshLogsCurrentPage = 1;
-    $scope.sshLogsPerPage = 10;
-    $scope.sshLogsGoToPage = 1;
+    $scope.sshLogsPerPage = 5;
+    $scope.sshLogsGoToPageInput = 1;
     $scope.loadingSSHLogs = true;
     $scope.errorSSHLogs = '';
     $scope.securityAlerts = [];
     $scope.loadingSecurityAnalysis = false;
     
     $scope.getSSHLogsTotalPages = function() {
-        return Math.ceil($scope.sshLogs.length / $scope.sshLogsPerPage);
+        var perPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        return Math.ceil(($scope.sshLogs || []).length / perPage);
     };
     
     $scope.getSSHLogsStart = function() {
         if (!$scope.sshLogs || $scope.sshLogs.length === 0) {
             return 0;
         }
-        return ($scope.sshLogsCurrentPage - 1) * $scope.sshLogsPerPage + 1;
+        var perPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        return ($scope.sshLogsCurrentPage - 1) * perPage + 1;
     };
     
     $scope.getSSHLogsEnd = function() {
         if (!$scope.sshLogs || $scope.sshLogs.length === 0) {
             return 0;
         }
-        var end = $scope.sshLogsCurrentPage * $scope.sshLogsPerPage;
+        var perPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        var end = $scope.sshLogsCurrentPage * perPage;
         return Math.min(end, $scope.sshLogs.length);
     };
     
     $scope.updateSSHLogsPaginated = function() {
         if (!$scope.sshLogs || $scope.sshLogs.length === 0) {
             $scope.sshLogsPaginated = [];
-            console.log('updateSSHLogsPaginated: No data, cleared paginated array');
             return;
         }
-        var start = ($scope.sshLogsCurrentPage - 1) * $scope.sshLogsPerPage;
-        var end = start + $scope.sshLogsPerPage;
+        var perPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        var totalPages = $scope.getSSHLogsTotalPages();
+        if ($scope.sshLogsCurrentPage > totalPages) {
+            $scope.sshLogsCurrentPage = totalPages || 1;
+        }
+        if ($scope.sshLogsCurrentPage < 1) {
+            $scope.sshLogsCurrentPage = 1;
+        }
+        $scope.sshLogsGoToPageInput = $scope.sshLogsCurrentPage;
+        var start = ($scope.sshLogsCurrentPage - 1) * perPage;
+        var end = start + perPage;
         $scope.sshLogsPaginated = $scope.sshLogs.slice(start, end);
-        console.log('updateSSHLogsPaginated: start=', start, 'end=', end, 'total=', $scope.sshLogs.length, 'paginated=', $scope.sshLogsPaginated.length);
     };
     
     $scope.sshLogsPrevPage = function() {
-        if ($scope.sshLogsCurrentPage > 1) {
-            $scope.sshLogsCurrentPage--;
-            $scope.updateSSHLogsPaginated();
-        }
+        $scope.sshLogsGoToPage($scope.sshLogsCurrentPage - 1);
     };
     
     $scope.sshLogsNextPage = function() {
-        if ($scope.sshLogsCurrentPage < $scope.getSSHLogsTotalPages()) {
-            $scope.sshLogsCurrentPage++;
-            $scope.updateSSHLogsPaginated();
-        }
+        $scope.sshLogsGoToPage($scope.sshLogsCurrentPage + 1);
     };
-    
-    $scope.sshLogsGoToPageNumber = function() {
-        var page = parseInt($scope.sshLogsGoToPage);
+
+    $scope.sshLogsChangePerPage = function() {
+        $scope.sshLogsPerPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        $scope.sshLogsCurrentPage = 1;
+        $scope.sshLogsGoToPageInput = 1;
+        $scope.updateSSHLogsPaginated();
+    };
+
+    $scope.sshLogsGoToPage = function(page) {
+        page = parseInt(page, 10);
         var totalPages = $scope.getSSHLogsTotalPages();
         if (page >= 1 && page <= totalPages) {
             $scope.sshLogsCurrentPage = page;
             $scope.updateSSHLogsPaginated();
         } else {
-            $scope.sshLogsGoToPage = $scope.sshLogsCurrentPage;
+            $scope.sshLogsGoToPageInput = $scope.sshLogsCurrentPage;
         }
+    };
+    
+    $scope.sshLogsGoToPageNumber = function() {
+        $scope.sshLogsGoToPage($scope.sshLogsGoToPageInput);
     };
     
     $scope.refreshSSHLogs = function() {
         $scope.loadingSSHLogs = true;
         $http.get('/base/getRecentSSHLogs').then(function (response) {
             $scope.loadingSSHLogs = false;
-            console.log('SSH Logs response:', response.data);
             if (response.data && response.data.logs && Array.isArray(response.data.logs)) {
                 $scope.sshLogs = response.data.logs;
                 $scope.sshLogsCurrentPage = 1;
-                $scope.sshLogsGoToPage = 1;
-                console.log('SSH Logs loaded:', $scope.sshLogs.length, 'items');
+                $scope.sshLogsGoToPageInput = 1;
                 $scope.updateSSHLogsPaginated();
-                console.log('SSH Logs paginated:', $scope.sshLogsPaginated.length, 'items');
-                // Analyze logs for security issues
                 $scope.analyzeSSHSecurity();
             } else {
-                console.warn('SSH Logs: No data or invalid format', response.data);
                 $scope.sshLogs = [];
                 $scope.sshLogsPaginated = [];
+                $scope.sshLogsGoToPageInput = 1;
             }
-        }, function (err) {
+        }, function () {
             $scope.loadingSSHLogs = false;
-            console.error('SSH Logs error:', err);
             $scope.errorSSHLogs = 'Failed to load SSH logs.';
             $scope.sshLogs = [];
             $scope.sshLogsPaginated = [];
+            $scope.sshLogsGoToPageInput = 1;
         });
     };
     
     // Security Analysis
     $scope.showAddonRequired = false;
     $scope.addonInfo = {};
-    
-    // IP Blocking functionality
     $scope.blockingIP = null;
     $scope.blockedIPs = {};
+
+    function notifyUser(title, text, type, delay) {
+        if (typeof PNotify !== 'undefined') {
+            new PNotify({
+                title: title,
+                text: text,
+                type: type || 'info',
+                delay: delay || 5000
+            });
+        }
+    }
+
+    function parseBanResponse(responseData) {
+        if (typeof responseData === 'string') {
+            try {
+                return JSON.parse(responseData);
+            } catch (e) {
+                return null;
+            }
+        }
+        return responseData;
+    }
+
+    function banIPAddress(ipAddress, reason, onSuccess) {
+        ipAddress = String(ipAddress || '').trim();
+        if (!ipAddress) {
+            notifyUser('Error', 'No IP address provided', 'error');
+            return;
+        }
+
+        var ipPattern = /^(\d{1,3}\.){3}\d{1,3}(\/\d{1,2})?$/;
+        if (!ipPattern.test(ipAddress)) {
+            notifyUser('Error', 'Invalid IP address format: ' + ipAddress, 'error');
+            return;
+        }
+
+        if ($scope.blockingIP === ipAddress) {
+            return;
+        }
+
+        if ($scope.blockedIPs && $scope.blockedIPs[ipAddress]) {
+            notifyUser('Info', 'IP address ' + ipAddress + ' is already banned', 'info', 3000);
+            return;
+        }
+
+        $scope.blockingIP = ipAddress;
+
+        $http.post('/firewall/addBannedIP', {
+            ip: ipAddress,
+            reason: reason,
+            duration: 'permanent'
+        }, {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        }).then(function (response) {
+            $scope.blockingIP = null;
+            var responseData = parseBanResponse(response.data);
+
+            if (responseData && (responseData.status === 1 || responseData.status === '1')) {
+                if (!$scope.blockedIPs) {
+                    $scope.blockedIPs = {};
+                }
+                $scope.blockedIPs[ipAddress] = true;
+                notifyUser(
+                    'IP Address Banned',
+                    'IP address ' + ipAddress + ' has been permanently banned and added to the firewall.',
+                    'success'
+                );
+                if (typeof onSuccess === 'function') {
+                    onSuccess();
+                }
+            } else {
+                var errorMsg = 'Failed to block IP address';
+                if (responseData && responseData.error_message) {
+                    errorMsg = responseData.error_message;
+                } else if (responseData && responseData.error) {
+                    errorMsg = responseData.error;
+                } else if (responseData && responseData.message) {
+                    errorMsg = responseData.message;
+                }
+                notifyUser('Error', errorMsg, 'error');
+            }
+        }, function (err) {
+            $scope.blockingIP = null;
+            var errorMessage = 'Failed to block IP address';
+            var errData = err.data;
+            if (typeof errData === 'string') {
+                errData = parseBanResponse(errData);
+            }
+            if (errData && typeof errData === 'object') {
+                errorMessage = errData.error_message || errData.error || errData.message || errorMessage;
+            } else if (err.status) {
+                errorMessage = 'HTTP ' + err.status + ': ' + errorMessage;
+            }
+            notifyUser('Error', errorMessage, 'error');
+        });
+    }
     
     $scope.analyzeSSHSecurity = function() {
         $scope.loadingSecurityAnalysis = true;
@@ -1159,67 +1510,28 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
             $scope.loadingSecurityAnalysis = false;
         });
     };
-    
+
     $scope.blockIPAddress = function(ipAddress) {
-        if (!$scope.blockingIP) {
-            $scope.blockingIP = ipAddress;
-            
-            var data = {
-                ip_address: ipAddress
-            };
-            
-            var config = {
-                headers: {
-                    'X-CSRFToken': getCookie('csrftoken')
-                }
-            };
-            
-            $http.post('/base/blockIPAddress', data, config).then(function (response) {
-                $scope.blockingIP = null;
-                if (response.data && response.data.status === 1) {
-                    // Mark IP as blocked
-                    $scope.blockedIPs[ipAddress] = true;
-                    
-                    // Show success notification
-                    new PNotify({
-                        title: 'Success',
-                        text: `IP address ${ipAddress} has been blocked successfully using ${response.data.firewall.toUpperCase()}`,
-                        type: 'success',
-                        delay: 5000
-                    });
-                    
-                    // Refresh security analysis to update alerts
-                    $scope.analyzeSSHSecurity();
-                } else {
-                    // Show error notification
-                    new PNotify({
-                        title: 'Error',
-                        text: response.data && response.data.error ? response.data.error : 'Failed to block IP address',
-                        type: 'error',
-                        delay: 5000
-                    });
-                }
-            }, function (err) {
-                $scope.blockingIP = null;
-                var errorMessage = 'Failed to block IP address';
-                if (err.data && err.data.error) {
-                    errorMessage = err.data.error;
-                } else if (err.data && err.data.message) {
-                    errorMessage = err.data.message;
-                }
-                
-                new PNotify({
-                    title: 'Error',
-                    text: errorMessage,
-                    type: 'error',
-                    delay: 5000
-                });
-            });
-        }
+        banIPAddress(
+            ipAddress,
+            'Brute force attack detected from SSH Security Analysis',
+            function () {
+                $scope.analyzeSSHSecurity();
+            }
+        );
     };
 
-    // Initial fetch
-    $scope.refreshTopProcesses();
+    $scope.banIPFromSSHLog = function(ipAddress) {
+        banIPAddress(
+            ipAddress,
+            'Suspicious activity detected from SSH logs',
+            function () {
+                $scope.refreshSSHLogs();
+            }
+        );
+    };
+
+    // Initial fetch (top processes polled on slower interval below)
     $scope.refreshSSHLogins();
     $scope.refreshSSHLogs();
 
@@ -1232,11 +1544,12 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
     // For rate calculation
     var lastRx = null, lastTx = null, lastDiskRead = null, lastDiskWrite = null, lastCPU = null;
     var lastCPUTimes = null;
-    var pollInterval = 2000; // ms
+    var pollInterval = 5000; // ms (was 2000; slower poll reduces lscpd worker exhaustion)
+    var topProcessPollInterval = 30000;
     var maxPoints = 30;
 
     function pollDashboardStats() {
-        $http.get('/base/getDashboardStats').then(function(response) {
+        dashPollOnce($http, 'dashboardStats', '/base/getDashboardStats', function(response) {
             if (response.data.status === 1) {
                 $scope.totalUsers = response.data.total_users;
                 $scope.totalSites = response.data.total_sites;
@@ -1250,8 +1563,7 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
     }
 
     function pollTraffic() {
-        console.log('pollTraffic called');
-        $http.get('/base/getTrafficStats').then(function(response) {
+        dashPollOnce($http, 'trafficStats', '/base/getTrafficStats', function(response) {
             if (response.data.admin_only) {
                 // Hide chart for non-admin users
                 $scope.hideSystemCharts = true;
@@ -1275,7 +1587,6 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
                         trafficChart.data.datasets[0].data = rxData.slice();
                         trafficChart.data.datasets[1].data = txData.slice();
                         trafficChart.update();
-                        console.log('trafficChart updated:', trafficChart.data.labels, trafficChart.data.datasets[0].data, trafficChart.data.datasets[1].data);
                     }
                 } else {
                     // First poll, push zero data point
@@ -1287,25 +1598,21 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
                         trafficChart.data.datasets[0].data = rxData.slice();
                         trafficChart.data.datasets[1].data = txData.slice();
                         trafficChart.update();
-                        console.log('trafficChart first update:', trafficChart.data.labels, trafficChart.data.datasets[0].data, trafficChart.data.datasets[1].data);
                         setTimeout(function() {
                             if (window.trafficChart) {
                                 window.trafficChart.resize();
                                 window.trafficChart.update();
-                                console.log('trafficChart forced resize/update after first poll.');
                             }
                         }, 1000);
                     }
                 }
                 lastRx = rx; lastTx = tx;
-            } else {
-                console.log('pollTraffic error or no data:', response);
             }
         });
     }
 
     function pollDiskIO() {
-        $http.get('/base/getDiskIOStats').then(function(response) {
+        dashPollOnce($http, 'diskIOStats', '/base/getDiskIOStats', function(response) {
             if (response.data.admin_only) {
                 // Hide chart for non-admin users
                 $scope.hideSystemCharts = true;
@@ -1348,7 +1655,7 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
     }
 
     function pollCPU() {
-        $http.get('/base/getCPULoadGraph').then(function(response) {
+        dashPollOnce($http, 'cpuLoadGraph', '/base/getCPULoadGraph', function(response) {
             if (response.data.admin_only) {
                 // Hide chart for non-admin users
                 $scope.hideSystemCharts = true;
@@ -1391,7 +1698,6 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
     }
 
     function setupCharts() {
-        console.log('setupCharts called, initializing charts...');
         var trafficCtx = document.getElementById('trafficChart').getContext('2d');
         trafficChart = new Chart(trafficCtx, {
             type: 'line',
@@ -1668,35 +1974,33 @@ app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
         });
     }
 
-    // Initial setup
+    // Initial setup (stagger polls so dashboard APIs do not stampede lscpd workers)
     $timeout(function() {
-        // Check if user is admin before setting up charts
-        $http.get('/base/getAdminStatus').then(function(response) {
+        dashGet($http, '/base/getAdminStatus').then(function(response) {
             if (response.data && response.data.admin === 1) {
                 setupCharts();
             } else {
                 $scope.hideSystemCharts = true;
             }
         }).catch(function() {
-            // If error, assume non-admin and hide charts
             $scope.hideSystemCharts = true;
         });
-        
-        // Immediately poll once so stats are updated on first load
-        pollDashboardStats();
-        pollTraffic();
-        pollDiskIO();
-        pollCPU();
-        // Start polling
-        function pollAll() {
+
+        function pollCharts() {
             pollDashboardStats();
             pollTraffic();
             pollDiskIO();
             pollCPU();
-            $scope.refreshTopProcesses();
-            $timeout(pollAll, pollInterval);
+            $timeout(pollCharts, pollInterval);
         }
-        pollAll();
+
+        function pollTopProcessesSlow() {
+            $scope.refreshTopProcesses();
+            $timeout(pollTopProcessesSlow, topProcessPollInterval);
+        }
+
+        pollCharts();
+        $timeout(pollTopProcessesSlow, 1500);
     }, 500);
 
     // SSH User Activity Modal

--- a/baseTemplate/templates/baseTemplate/homePage.html
+++ b/baseTemplate/templates/baseTemplate/homePage.html
@@ -127,16 +127,16 @@
             <div class="stat-card" ng-if="!statusError">
                 <div class="stat-card-header">
                     <span class="stat-card-title">{% trans "CPU USAGE" %}</span>
-                    <span class="cp-skeleton cp-skeleton-pill" ng-if="cpuUsage === undefined" aria-hidden="true"></span>
-                    <span class="stat-card-value" ng-if="cpuUsage !== undefined" aria-live="polite"
-                          ng-class="{'bar-ok': cpuUsage < 70, 'bar-warn': cpuUsage >= 70 && cpuUsage < 90, 'bar-crit': cpuUsage >= 90}">({$ cpuUsage $}%)</span>
+                    <span class="cp-skeleton cp-skeleton-pill" ng-if="displayCpuUsage === undefined" aria-hidden="true"></span>
+                    <span class="stat-card-value" ng-if="displayCpuUsage !== undefined" aria-live="polite"
+                          ng-class="{'bar-ok': displayCpuUsage < 70, 'bar-warn': displayCpuUsage >= 70 && displayCpuUsage < 90, 'bar-crit': displayCpuUsage >= 90}">({$ displayCpuUsage $}%)</span>
                 </div>
                 <div class="progress-bar-container">
-                    <span class="cp-skeleton cp-skeleton-bar" ng-if="cpuUsage === undefined" aria-hidden="true"></span>
-                    <div class="progress-bar" ng-if="cpuUsage !== undefined"
-                         ng-class="{'bar-ok': cpuUsage < 70, 'bar-warn': cpuUsage >= 70 && cpuUsage < 90, 'bar-crit': cpuUsage >= 90}"
-                         style="width: {$ cpuUsage $}%;"
-                         role="progressbar" aria-valuenow="{$ cpuUsage $}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'CPU usage percent' %}"></div>
+                    <span class="cp-skeleton cp-skeleton-bar" ng-if="displayCpuUsage === undefined" aria-hidden="true"></span>
+                    <div class="progress-bar" ng-if="displayCpuUsage !== undefined"
+                         ng-class="{'bar-ok': displayCpuUsage < 70, 'bar-warn': displayCpuUsage >= 70 && displayCpuUsage < 90, 'bar-crit': displayCpuUsage >= 90}"
+                         style="width: {$ displayCpuUsage $}%;"
+                         role="progressbar" aria-valuenow="{$ displayCpuUsage $}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'CPU usage percent' %}"></div>
                 </div>
                 <div class="stat-card-info">
                     <span class="cp-skeleton cp-skeleton-line" ng-if="cpuCores === undefined" style="max-width:140px;" aria-hidden="true"></span>
@@ -148,16 +148,16 @@
             <div class="stat-card" ng-if="!statusError">
                 <div class="stat-card-header">
                     <span class="stat-card-title">{% trans "MEMORY USAGE" %}</span>
-                    <span class="cp-skeleton cp-skeleton-pill" ng-if="ramUsage === undefined" aria-hidden="true"></span>
-                    <span class="stat-card-value" ng-if="ramUsage !== undefined" aria-live="polite"
-                          ng-class="{'bar-ok': ramUsage < 70, 'bar-warn': ramUsage >= 70 && ramUsage < 90, 'bar-crit': ramUsage >= 90}">({$ ramUsage $}%)</span>
+                    <span class="cp-skeleton cp-skeleton-pill" ng-if="displayRamUsage === undefined" aria-hidden="true"></span>
+                    <span class="stat-card-value" ng-if="displayRamUsage !== undefined" aria-live="polite"
+                          ng-class="{'bar-ok': displayRamUsage < 70, 'bar-warn': displayRamUsage >= 70 && displayRamUsage < 90, 'bar-crit': displayRamUsage >= 90}">({$ displayRamUsage $}%)</span>
                 </div>
                 <div class="progress-bar-container">
-                    <span class="cp-skeleton cp-skeleton-bar" ng-if="ramUsage === undefined" aria-hidden="true"></span>
-                    <div class="progress-bar" ng-if="ramUsage !== undefined"
-                         ng-class="{'bar-ok': ramUsage < 70, 'bar-warn': ramUsage >= 70 && ramUsage < 90, 'bar-crit': ramUsage >= 90}"
-                         style="width: {$ ramUsage $}%;"
-                         role="progressbar" aria-valuenow="{$ ramUsage $}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Memory usage percent' %}"></div>
+                    <span class="cp-skeleton cp-skeleton-bar" ng-if="displayRamUsage === undefined" aria-hidden="true"></span>
+                    <div class="progress-bar" ng-if="displayRamUsage !== undefined"
+                         ng-class="{'bar-ok': displayRamUsage < 70, 'bar-warn': displayRamUsage >= 70 && displayRamUsage < 90, 'bar-crit': displayRamUsage >= 90}"
+                         style="width: {$ displayRamUsage $}%;"
+                         role="progressbar" aria-valuenow="{$ displayRamUsage $}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Memory usage percent' %}"></div>
                 </div>
                 <div class="stat-card-info">
                     <span class="cp-skeleton cp-skeleton-line" ng-if="ramTotalMB === undefined" style="max-width:160px;" aria-hidden="true"></span>
@@ -169,16 +169,16 @@
             <div class="stat-card" ng-if="!statusError">
                 <div class="stat-card-header">
                     <span class="stat-card-title">{% trans "DISK USAGE" %}</span>
-                    <span class="cp-skeleton cp-skeleton-pill" ng-if="diskUsage === undefined" aria-hidden="true"></span>
-                    <span class="stat-card-value" ng-if="diskUsage !== undefined" aria-live="polite"
-                          ng-class="{'bar-ok': diskUsage < 70, 'bar-warn': diskUsage >= 70 && diskUsage < 90, 'bar-crit': diskUsage >= 90}">({$ diskUsage $}%)</span>
+                    <span class="cp-skeleton cp-skeleton-pill" ng-if="displayDiskUsage === undefined" aria-hidden="true"></span>
+                    <span class="stat-card-value" ng-if="displayDiskUsage !== undefined" aria-live="polite"
+                          ng-class="{'bar-ok': displayDiskUsage < 70, 'bar-warn': displayDiskUsage >= 70 && displayDiskUsage < 90, 'bar-crit': displayDiskUsage >= 90}">({$ displayDiskUsage $}%)</span>
                 </div>
                 <div class="progress-bar-container">
-                    <span class="cp-skeleton cp-skeleton-bar" ng-if="diskUsage === undefined" aria-hidden="true"></span>
-                    <div class="progress-bar" ng-if="diskUsage !== undefined"
-                         ng-class="{'bar-ok': diskUsage < 70, 'bar-warn': diskUsage >= 70 && diskUsage < 90, 'bar-crit': diskUsage >= 90}"
-                         style="width: {$ diskUsage $}%;"
-                         role="progressbar" aria-valuenow="{$ diskUsage $}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Disk usage percent' %}"></div>
+                    <span class="cp-skeleton cp-skeleton-bar" ng-if="displayDiskUsage === undefined" aria-hidden="true"></span>
+                    <div class="progress-bar" ng-if="displayDiskUsage !== undefined"
+                         ng-class="{'bar-ok': displayDiskUsage < 70, 'bar-warn': displayDiskUsage >= 70 && displayDiskUsage < 90, 'bar-crit': displayDiskUsage >= 90}"
+                         style="width: {$ displayDiskUsage $}%;"
+                         role="progressbar" aria-valuenow="{$ displayDiskUsage $}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Disk usage percent' %}"></div>
                 </div>
                 <div class="stat-card-info">
                     <span class="cp-skeleton cp-skeleton-line" ng-if="diskFreeGB === undefined" style="max-width:200px;" aria-hidden="true"></span>
@@ -315,7 +315,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="login in sshLogins">
+                    <tr ng-repeat="login in sshLoginsPaginated">
                         <td><strong>{$ login.user $}</strong></td>
                         <td><code style="background: #f0f0ff; padding: 2px 6px; border-radius: 4px; font-size: 11px;">{$ login.ip $}</code></td>
                         <td>
@@ -330,6 +330,32 @@
                     </tr>
                 </tbody>
             </table>
+
+            <div ng-if="!loadingSSHLogins && sshLogins.length > 0" class="pagination-controls" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 16px; padding: 12px 0; border-top: 1px solid #e8e9ff;">
+                <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+                    <span style="color: #64748b; font-size: 13px;">{% trans "Show" %}</span>
+                    <select ng-model="sshLoginsPerPage" ng-change="sshLoginsChangePerPage()" style="padding: 6px 10px; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 13px; background: white; min-width: 64px;">
+                        <option ng-value="5">5</option>
+                        <option ng-value="10">10</option>
+                        <option ng-value="25">25</option>
+                        <option ng-value="50">50</option>
+                        <option ng-value="100">100</option>
+                    </select>
+                    <span style="color: #64748b; font-size: 13px;">{% trans "per page" %}</span>
+                </div>
+                <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+                    <span style="color: #64748b; font-size: 13px;">{$ getSSHLoginsStart() $}-{$ getSSHLoginsEnd() $} {% trans "of" %} {$ sshLogins.length $}</span>
+                    <button type="button" ng-click="sshLoginsPrevPage()" ng-disabled="sshLoginsCurrentPage <= 1" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;" title="{% trans 'Previous' %}">
+                        <i class="fas fa-chevron-left"></i>
+                    </button>
+                    <button type="button" ng-click="sshLoginsNextPage()" ng-disabled="sshLoginsCurrentPage >= getSSHLoginsTotalPages()" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;" title="{% trans 'Next' %}">
+                        <i class="fas fa-chevron-right"></i>
+                    </button>
+                    <label style="color: #64748b; font-size: 13px; margin: 0;">{% trans "Go to page" %}</label>
+                    <input type="number" min="1" ng-attr-max="{$ getSSHLoginsTotalPages() $}" ng-model="sshLoginsGoToPageInput" ng-keypress="$event.keyCode === 13 && sshLoginsGoToPageNumber(); $event.preventDefault()" style="width: 56px; padding: 6px 8px; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 13px;" aria-label="{% trans 'Go to page' %}">
+                    <button type="button" ng-click="sshLoginsGoToPageNumber()" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;">{% trans "Go" %}</button>
+                </div>
+            </div>
             
             <!-- Loading skeleton (no fake data) -->
             <table class="activity-table" ng-if="loadingSSHLogins" aria-hidden="true">
@@ -435,21 +461,23 @@
                                     <strong style="font-size: 12px; color: #1e293b;">Recommendation:</strong>
                                     <p style="margin: 4px 0 0 0; font-size: 12px; color: #475569; white-space: pre-line;">{$ alert.recommendation $}</p>
                                 </div>
-                                <!-- Add to Firewall Button for Brute Force Attacks -->
-                                <div ng-if="alert.title === 'Brute Force Attack Detected' && alert.details && alert.details['IP Address']" style="margin-top: 12px;">
-                                    <button ng-click="blockIPAddress(alert.details['IP Address'])" 
-                                            ng-disabled="blockingIP === alert.details['IP Address']"
+                                <div ng-if="alert.details && (alert.details['IP Address'] || alert.details['Top IP'])" style="margin-top: 12px;">
+                                    <button ng-click="blockIPAddress(alert.details['IP Address'] || alert.details['Top IP']); $event.stopPropagation()"
+                                            ng-disabled="blockingIP === (alert.details['IP Address'] || alert.details['Top IP'])"
                                             style="background: #dc2626; color: white; border: none; padding: 8px 16px; border-radius: 6px; font-size: 12px; font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; gap: 6px;"
-                                            onmouseover="this.style.background='#b91c1c'" 
+                                            onmouseover="this.style.background='#b91c1c'"
                                             onmouseout="this.style.background='#dc2626'">
-                                        <i class="fas fa-ban" ng-if="blockingIP !== alert.details['IP Address']"></i>
-                                        <i class="fas fa-spinner fa-spin" ng-if="blockingIP === alert.details['IP Address']"></i>
-                                        <span ng-if="blockingIP !== alert.details['IP Address']">Block IP</span>
-                                        <span ng-if="blockingIP === alert.details['IP Address']">Blocking...</span>
+                                        <i class="fas fa-ban" ng-if="blockingIP !== (alert.details['IP Address'] || alert.details['Top IP'])"></i>
+                                        <i class="fas fa-spinner fa-spin" ng-if="blockingIP === (alert.details['IP Address'] || alert.details['Top IP'])"></i>
+                                        <span ng-if="blockingIP !== (alert.details['IP Address'] || alert.details['Top IP'])">{% trans "Ban IP Permanently" %}</span>
+                                        <span ng-if="blockingIP === (alert.details['IP Address'] || alert.details['Top IP'])">{% trans "Banning..." %}</span>
                                     </button>
-                                    <span ng-if="blockedIPs && blockedIPs[alert.details['IP Address']]" 
+                                    <a href="/firewall/" target="_blank" rel="noopener" style="margin-left: 10px; color: #5b5fcf; font-size: 12px; text-decoration: none;">
+                                        <i class="fas fa-external-link-alt"></i> {% trans "Manage in Firewall" %}
+                                    </a>
+                                    <span ng-if="blockedIPs && blockedIPs[alert.details['IP Address'] || alert.details['Top IP']]"
                                           style="margin-left: 10px; color: #10b981; font-size: 12px; font-weight: 600;">
-                                        <i class="fas fa-check-circle"></i> Blocked
+                                        <i class="fas fa-check-circle"></i> {% trans "Blocked" %}
                                     </span>
                                 </div>
                             </div>
@@ -475,15 +503,69 @@
                     <tr>
                         <th>{% trans "TIMESTAMP" %}</th>
                         <th>{% trans "MESSAGE" %}</th>
+                        <th>{% trans "IP ADDRESS" %}</th>
+                        <th>{% trans "ACTIONS" %}</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="log in sshLogs">
+                    <tr ng-repeat="log in sshLogsPaginated">
                         <td><strong>{$ log.timestamp $}</strong></td>
                         <td><code style="background: #f0f0ff; padding: 4px 8px; border-radius: 4px; font-size: 11px; display: inline-block; word-break: break-word; overflow-wrap: break-word;">{$ log.message $}</code></td>
+                        <td>
+                            <span ng-if="log.ip_address" style="font-family: monospace; color: #5b5fcf; font-weight: 600;">{$ log.ip_address $}</span>
+                            <span ng-if="!log.ip_address" style="color: #8893a7;">-</span>
+                        </td>
+                        <td>
+                            <button ng-if="log.ip_address && blockingIP !== log.ip_address && !blockedIPs[log.ip_address]"
+                                    ng-click="banIPFromSSHLog(log.ip_address)"
+                                    style="background: #dc2626; color: white; border: none; padding: 6px 12px; border-radius: 6px; font-size: 11px; font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; gap: 4px;"
+                                    onmouseover="this.style.background='#b91c1c'"
+                                    onmouseout="this.style.background='#dc2626'"
+                                    title="{% trans 'Ban this IP address permanently' %}">
+                                <i class="fas fa-ban"></i>
+                                {% trans "Ban IP" %}
+                            </button>
+                            <button ng-if="log.ip_address && blockingIP === log.ip_address"
+                                    disabled
+                                    style="background: #9ca3af; color: white; border: none; padding: 6px 12px; border-radius: 6px; font-size: 11px; font-weight: 600; cursor: not-allowed; display: inline-flex; align-items: center; gap: 4px;">
+                                <i class="fas fa-spinner fa-spin"></i>
+                                {% trans "Banning..." %}
+                            </button>
+                            <span ng-if="log.ip_address && blockedIPs[log.ip_address]"
+                                  style="color: #10b981; font-size: 11px; font-weight: 600; display: inline-flex; align-items: center; gap: 4px;">
+                                <i class="fas fa-check-circle"></i>
+                                {% trans "Banned" %}
+                            </span>
+                            <span ng-if="!log.ip_address" style="color: #8893a7; font-size: 11px;">-</span>
+                        </td>
                     </tr>
                 </tbody>
             </table>
+            <div ng-if="!loadingSSHLogs && sshLogs.length > 0" class="pagination-controls" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 16px; padding: 12px 0; border-top: 1px solid #e8e9ff;">
+                <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+                    <span style="color: #64748b; font-size: 13px;">{% trans "Show" %}</span>
+                    <select ng-model="sshLogsPerPage" ng-change="sshLogsChangePerPage()" style="padding: 6px 10px; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 13px; background: white; min-width: 64px;">
+                        <option ng-value="5">5</option>
+                        <option ng-value="10">10</option>
+                        <option ng-value="25">25</option>
+                        <option ng-value="50">50</option>
+                        <option ng-value="100">100</option>
+                    </select>
+                    <span style="color: #64748b; font-size: 13px;">{% trans "per page" %}</span>
+                </div>
+                <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+                    <span style="color: #64748b; font-size: 13px;">{$ getSSHLogsStart() $}-{$ getSSHLogsEnd() $} {% trans "of" %} {$ sshLogs.length $}</span>
+                    <button type="button" ng-click="sshLogsPrevPage()" ng-disabled="sshLogsCurrentPage <= 1" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;" title="{% trans 'Previous' %}">
+                        <i class="fas fa-chevron-left"></i>
+                    </button>
+                    <button type="button" ng-click="sshLogsNextPage()" ng-disabled="sshLogsCurrentPage >= getSSHLogsTotalPages()" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;" title="{% trans 'Next' %}">
+                        <i class="fas fa-chevron-right"></i>
+                    </button>
+                    <label style="color: #64748b; font-size: 13px; margin: 0;">{% trans "Go to page" %}</label>
+                    <input type="number" min="1" ng-attr-max="{$ getSSHLogsTotalPages() $}" ng-model="sshLogsGoToPageInput" ng-keypress="$event.keyCode === 13 && sshLogsGoToPageNumber(); $event.preventDefault()" style="width: 56px; padding: 6px 8px; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 13px;" aria-label="{% trans 'Go to page' %}">
+                    <button type="button" ng-click="sshLogsGoToPageNumber()" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;">{% trans "Go" %}</button>
+                </div>
+            </div>
         </div>
         
         <!-- Top Process Tab -->
@@ -508,7 +590,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="process in topProcesses">
+                    <tr ng-repeat="process in topProcessesPaginated">
                         <td>{$ process.pid $}</td>
                         <td>{$ process.user $}</td>
                         <td>{$ process.cpu $}%</td>
@@ -517,6 +599,32 @@
                     </tr>
                 </tbody>
             </table>
+
+            <div ng-if="!loadingTopProcesses && !errorTopProcesses && topProcesses.length > 0" class="pagination-controls" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 16px; padding: 12px 0; border-top: 1px solid #e8e9ff;">
+                <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+                    <span style="color: #64748b; font-size: 13px;">{% trans "Show" %}</span>
+                    <select ng-model="topProcessesPerPage" ng-change="topProcessesChangePerPage()" style="padding: 6px 10px; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 13px; background: white; min-width: 64px;">
+                        <option ng-value="5">5</option>
+                        <option ng-value="10">10</option>
+                        <option ng-value="25">25</option>
+                        <option ng-value="50">50</option>
+                        <option ng-value="100">100</option>
+                    </select>
+                    <span style="color: #64748b; font-size: 13px;">{% trans "per page" %}</span>
+                </div>
+                <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+                    <span style="color: #64748b; font-size: 13px;">{$ getTopProcessesStart() $}-{$ getTopProcessesEnd() $} {% trans "of" %} {$ topProcesses.length $}</span>
+                    <button type="button" ng-click="topProcessesPrevPage()" ng-disabled="topProcessesCurrentPage <= 1" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;" title="{% trans 'Previous' %}">
+                        <i class="fas fa-chevron-left"></i>
+                    </button>
+                    <button type="button" ng-click="topProcessesNextPage()" ng-disabled="topProcessesCurrentPage >= getTopProcessesTotalPages()" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;" title="{% trans 'Next' %}">
+                        <i class="fas fa-chevron-right"></i>
+                    </button>
+                    <label style="color: #64748b; font-size: 13px; margin: 0;">{% trans "Go to page" %}</label>
+                    <input type="number" min="1" ng-attr-max="{$ getTopProcessesTotalPages() $}" ng-model="topProcessesGoToPageInput" ng-keypress="$event.keyCode === 13 && topProcessesGoToPageNumber(); $event.preventDefault()" style="width: 56px; padding: 6px 8px; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 13px;" aria-label="{% trans 'Go to page' %}">
+                    <button type="button" ng-click="topProcessesGoToPageNumber()" style="padding: 6px 12px; border: 1px solid #e2e8f0; border-radius: 6px; background: white; cursor: pointer; font-size: 13px;">{% trans "Go" %}</button>
+                </div>
+            </div>
         </div>
         
         <!-- Traffic Tab -->

--- a/baseTemplate/views.py
+++ b/baseTemplate/views.py
@@ -720,9 +720,19 @@ def getRecentSSHLogins(request):
         import re, time
         from collections import OrderedDict
 
-        # Run 'last -n 20' to get recent SSH logins
+        # Pagination params
         try:
-            output = ProcessUtilities.outputExecutioner('last -n 20')
+            page = max(1, int(request.GET.get('page', 1)))
+        except (ValueError, TypeError):
+            page = 1
+        try:
+            per_page = min(100, max(5, int(request.GET.get('per_page', 20))))
+        except (ValueError, TypeError):
+            per_page = 20
+
+        # Run 'last -n 500' to get enough entries for pagination
+        try:
+            output = ProcessUtilities.outputExecutioner('last -n 500')
         except Exception as e:
             return HttpResponse(json.dumps({'error': 'Failed to run last: %s' % str(e)}), content_type='application/json', status=500)
 
@@ -744,25 +754,57 @@ def getRecentSSHLogins(request):
             date_match = re.search(r'([A-Za-z]{3} [A-Za-z]{3} +\d+ [\d:]+)', line)
             date_str = date_match.group(1) if date_match else ''
             session_info = ''
-            if '-' in line:
-                # Session ended
-                session_info = line.split('-')[-1].strip()
-            elif 'still logged in' in line:
+            is_active = False
+            if 'still logged in' in line:
                 session_info = 'still logged in'
-            # GeoIP lookup (cache per request)
+                is_active = True
+            elif '-' in line:
+                # Session ended - parse the end time and duration
+                # Format: "Tue May 27 11:34 - 13:47  (02:13)" or "crash (00:40)"
+                end_part = line.split('-')[-1].strip()
+                # Check if it's a crash or normal logout
+                if 'crash' in end_part.lower():
+                    # Extract crash duration if available
+                    crash_match = re.search(r'crash\s*\(([^)]+)\)', end_part, re.IGNORECASE)
+                    if crash_match:
+                        session_info = f"crash ({crash_match.group(1)})"
+                    else:
+                        session_info = 'crash'
+                else:
+                    # Normal session end - try to extract duration
+                    duration_match = re.search(r'\(([^)]+)\)', end_part)
+                    if duration_match:
+                        session_info = f"ended ({duration_match.group(1)})"
+                    else:
+                        # Just show the end time
+                        time_match = re.search(r'([A-Za-z]{3}\s+[A-Za-z]{3}\s+\d+\s+[\d:]+)', end_part)
+                        if time_match:
+                            session_info = f"ended at {time_match.group(1)}"
+                        else:
+                            session_info = 'ended'
+                is_active = False
+            # GeoIP lookup (cache per request) - support both IPv4 and IPv6
             country = flag = ''
-            if re.match(r'\d+\.\d+\.\d+\.\d+', ip) and ip != '127.0.0.1':
+            # Check if IP is IPv4
+            is_ipv4 = re.match(r'^\d+\.\d+\.\d+\.\d+$', ip)
+            # Check if IP is IPv6 (simplified check)
+            is_ipv6 = ':' in ip and not is_ipv4
+            
+            if is_ipv4 and ip != '127.0.0.1':
                 if ip in ip_cache:
                     country, flag = ip_cache[ip]
                 else:
                     try:
-                        geo = requests.get(f'http://ip-api.com/json/{ip}', timeout=2).json()
+                        geo = requests.get(f'http://ip-api.com/json/{ip}', timeout=1).json()
                         country = geo.get('countryCode', '')
                         flag = f"https://flagcdn.com/24x18/{country.lower()}.png" if country else ''
                         ip_cache[ip] = (country, flag)
                     except Exception:
                         country, flag = '', ''
-            elif ip == '127.0.0.1':
+            elif is_ipv6 and ip != '::1':
+                # IPv6 - set flag to indicate IPv6 (GeoIP API may not support IPv6 well)
+                country, flag = 'IPv6', ''
+            elif ip == '127.0.0.1' or ip == '::1':
                 country, flag = 'Local', ''
             logins.append({
                 'user': user,
@@ -771,9 +813,22 @@ def getRecentSSHLogins(request):
                 'flag': flag,
                 'date': date_str,
                 'session': session_info,
+                'is_active': is_active,
                 'raw': line
             })
-        return HttpResponse(json.dumps({'logins': logins}), content_type='application/json')
+        total = len(logins)
+        total_pages = (total + per_page - 1) // per_page if total > 0 else 1
+        page = min(page, total_pages) if total_pages > 0 else 1
+        start = (page - 1) * per_page
+        end = start + per_page
+        paginated_logins = logins[start:end]
+        return HttpResponse(json.dumps({
+            'logins': paginated_logins,
+            'total': total,
+            'page': page,
+            'per_page': per_page,
+            'total_pages': total_pages
+        }), content_type='application/json')
     except Exception as e:
         return HttpResponse(json.dumps({'error': str(e)}), content_type='application/json', status=500)
 
@@ -787,18 +842,33 @@ def getRecentSSHLogs(request):
         currentACL = ACLManager.loadedACL(user_id)
         if not currentACL.get('admin', 0):
             return HttpResponse(json.dumps({'error': 'Admin only'}), content_type='application/json', status=403)
+
+        # Pagination params
+        try:
+            page = max(1, int(request.GET.get('page', 1)))
+        except (ValueError, TypeError):
+            page = 1
+        try:
+            per_page = min(100, max(5, int(request.GET.get('per_page', 25))))
+        except (ValueError, TypeError):
+            per_page = 25
+
         from plogical.processUtilities import ProcessUtilities
+        import re
         distro = ProcessUtilities.decideDistro()
         if distro in [ProcessUtilities.ubuntu, ProcessUtilities.ubuntu20]:
             log_path = '/var/log/auth.log'
         else:
             log_path = '/var/log/secure'
         try:
-            output = ProcessUtilities.outputExecutioner(f'tail -n 100 {log_path}')
+            output = ProcessUtilities.outputExecutioner(f'tail -n 500 {log_path}')
         except Exception as e:
             return HttpResponse(json.dumps({'error': f'Failed to read log: {str(e)}'}), content_type='application/json', status=500)
         lines = output.split('\n')
         logs = []
+        # IP address regex patterns (IPv4)
+        ipv4_pattern = r'\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b'
+        
         for line in lines:
             if not line.strip():
                 continue
@@ -809,8 +879,41 @@ def getRecentSSHLogs(request):
             else:
                 timestamp = ''
                 message = line
-            logs.append({'timestamp': timestamp, 'message': message, 'raw': line})
-        return HttpResponse(json.dumps({'logs': logs}), content_type='application/json')
+            
+            # Extract IP address from the log line
+            ip_address = None
+            ip_matches = re.findall(ipv4_pattern, line)
+            if ip_matches:
+                # Filter out localhost and common non-external IPs
+                for ip in ip_matches:
+                    if ip not in ['127.0.0.1', '0.0.0.0', '::1'] and not ip.startswith('192.168.') and not ip.startswith('10.') and not ip.startswith('172.'):
+                        ip_address = ip
+                        break
+                # If no external IP found, use the first match anyway (might be needed for internal attacks)
+                if not ip_address and ip_matches:
+                    ip_address = ip_matches[0]
+            
+            logs.append({
+                'timestamp': timestamp, 
+                'message': message, 
+                'raw': line,
+                'ip_address': ip_address
+            })
+        # Reverse so newest logs appear first (page 1 = most recent)
+        logs.reverse()
+        total = len(logs)
+        total_pages = (total + per_page - 1) // per_page if total > 0 else 1
+        page = min(page, total_pages) if total_pages > 0 else 1
+        start = (page - 1) * per_page
+        end = start + per_page
+        paginated_logs = logs[start:end]
+        return HttpResponse(json.dumps({
+            'logs': paginated_logs,
+            'total': total,
+            'page': page,
+            'per_page': per_page,
+            'total_pages': total_pages
+        }), content_type='application/json')
     except Exception as e:
         return HttpResponse(json.dumps({'error': str(e)}), content_type='application/json', status=500)
 
@@ -1410,6 +1513,12 @@ def getTopProcesses(request):
         currentACL = ACLManager.loadedACL(user_id)
         if not currentACL.get('admin', 0):
             return HttpResponse(json.dumps({'error': 'Admin only'}), content_type='application/json', status=403)
+
+        from django.core.cache import cache
+        cache_key = 'cp_top_processes'
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return HttpResponse(json.dumps(cached), content_type='application/json')
         
         import subprocess
         import tempfile
@@ -1450,10 +1559,15 @@ def getTopProcesses(request):
                     }
                     processes.append(process)
             
-            return HttpResponse(json.dumps({
+            payload = {
                 'status': 1,
                 'processes': processes
-            }), content_type='application/json')
+            }
+            try:
+                cache.set(cache_key, payload, 8)
+            except Exception:
+                pass
+            return HttpResponse(json.dumps(payload), content_type='application/json')
             
         finally:
             # Clean up temporary file
@@ -1464,3 +1578,5 @@ def getTopProcesses(request):
                 
     except Exception as e:
         return HttpResponse(json.dumps({'error': str(e)}), content_type='application/json', status=500)
+
+

--- a/static/baseTemplate/custom-js/system-status.js
+++ b/static/baseTemplate/custom-js/system-status.js
@@ -4,6 +4,7 @@
 
 /* Utilities */
 
+
 function getCookie(name) {
     var cookieValue = null;
     if (document.cookie && document.cookie !== '') {
@@ -35,6 +36,31 @@ function randomPassword(length) {
 /* Java script code to monitor system status */
 
 var app = angular.module('CyberCP', []);
+
+/* Dashboard API helpers: avoid worker exhaustion from poll storms */
+var DASH_HTTP_TIMEOUT = 25000;
+var dashPollInFlight = {};
+
+function dashGet($http, url, extraConfig) {
+    var cfg = extraConfig || {};
+    cfg.timeout = DASH_HTTP_TIMEOUT;
+    return $http.get(url, cfg);
+}
+
+function dashPollOnce($http, key, url, onSuccess) {
+    if (dashPollInFlight[key]) {
+        return;
+    }
+    dashPollInFlight[key] = true;
+    dashGet($http, url).then(function (response) {
+        dashPollInFlight[key] = false;
+        if (typeof onSuccess === 'function') {
+            onSuccess(response);
+        }
+    }, function () {
+        dashPollInFlight[key] = false;
+    });
+}
 
 var globalScope;
 
@@ -115,31 +141,187 @@ function getWebsiteName(domain) {
     }
 }
 
+/* Smooth Overview metric display (CPU/RAM/Disk cards) */
+var cpMetricAnimator = {
+    lerpFactor: 0.12,
+    snapThreshold: 0.5,
+    animFrameId: null,
+    targets: { cpu: null, ram: null, disk: null },
+    display: { cpu: null, ram: null, disk: null },
+
+    reset: function () {
+        this.cancel();
+        this.targets = { cpu: null, ram: null, disk: null };
+        this.display = { cpu: null, ram: null, disk: null };
+    },
+
+    cancel: function () {
+        if (this.animFrameId !== null) {
+            cancelAnimationFrame(this.animFrameId);
+            this.animFrameId = null;
+        }
+    },
+
+    setTargets: function (cpu, ram, disk) {
+        this.targets.cpu = cpu;
+        this.targets.ram = ram;
+        this.targets.disk = disk;
+        if (this.display.cpu === null) {
+            this.display.cpu = cpu;
+        }
+        if (this.display.ram === null) {
+            this.display.ram = ram;
+        }
+        if (this.display.disk === null) {
+            this.display.disk = disk;
+        }
+    },
+
+    stepToward: function (current, target) {
+        if (target === null || target === undefined) {
+            return current;
+        }
+        if (current === null || current === undefined) {
+            return target;
+        }
+        var diff = target - current;
+        if (Math.abs(diff) <= this.snapThreshold) {
+            return target;
+        }
+        return current + (diff * this.lerpFactor);
+    },
+
+  tick: function ($scope) {
+        var self = this;
+        var keys = ['cpu', 'ram', 'disk'];
+        var done = true;
+
+        keys.forEach(function (key) {
+            var target = self.targets[key];
+            if (target === null || target === undefined || isNaN(target)) {
+                target = 0;
+            }
+            var next = self.stepToward(self.display[key], target);
+            if (Math.abs(target - next) > self.snapThreshold) {
+                done = false;
+            }
+            self.display[key] = next;
+        });
+
+        $scope.displayCpuUsage = Math.round(self.display.cpu || 0);
+        $scope.displayRamUsage = Math.round(self.display.ram || 0);
+        $scope.displayDiskUsage = Math.round(self.display.disk || 0);
+
+        if (!done) {
+            self.animFrameId = requestAnimationFrame(function () {
+                self.tick($scope);
+            });
+        } else {
+            self.animFrameId = null;
+            $scope.displayCpuUsage = Math.round(self.targets.cpu || 0);
+            $scope.displayRamUsage = Math.round(self.targets.ram || 0);
+            $scope.displayDiskUsage = Math.round(self.targets.disk || 0);
+            self.display.cpu = self.targets.cpu;
+            self.display.ram = self.targets.ram;
+            self.display.disk = self.targets.disk;
+        }
+
+        if (!$scope.$$phase) {
+            $scope.$apply();
+        }
+    },
+
+    animateTo: function ($scope, cpu, ram, disk) {
+        this.cancel();
+        this.setTargets(cpu, ram, disk);
+        this.tick($scope);
+    }
+};
+
 app.controller('systemStatusInfo', function ($scope, $http, $timeout) {
 
-    //getStuff();
+    $scope.uptimeLoaded = false;
+    $scope.uptime = 'Loading...';
+    $scope.statusError = false;
+    $scope.displayCpuUsage = undefined;
+    $scope.displayRamUsage = undefined;
+    $scope.displayDiskUsage = undefined;
+    var statusPollTimer = null;
+    var statusReqPending = false;
+    var STATUS_REFRESH_MS = 60000;
 
-    function getStuff() {
-
-
-        url = "/base/getSystemStatus";
-
-        $http.get(url).then(ListInitialData, cantLoadInitialData);
-
-
-        function ListInitialData(response) {
-
-            $scope.cpuUsage = response.data.cpuUsage;
-            $scope.ramUsage = response.data.ramUsage;
-            $scope.diskUsage = response.data.diskUsage;
-
+    function scheduleStatusRefresh() {
+        if (statusPollTimer) {
+            $timeout.cancel(statusPollTimer);
         }
+        statusPollTimer = $timeout(getStuff, STATUS_REFRESH_MS);
+    }
 
-        function cantLoadInitialData(response) {
+    function resetDisplayMetrics() {
+        cpMetricAnimator.reset();
+        $scope.displayCpuUsage = undefined;
+        $scope.displayRamUsage = undefined;
+        $scope.displayDiskUsage = undefined;
+    }
+
+    getStuff();
+
+    $scope.getSystemStatus = function() {
+        getStuff(true);
+    };
+
+    $scope.retryStatus = function() {
+        $scope.statusError = false;
+        resetDisplayMetrics();
+        $scope.cpuCores = undefined;
+        $scope.ramTotalMB = undefined;
+        $scope.diskTotalGB = undefined;
+        $scope.diskFreeGB = undefined;
+        getStuff(true);
+    };
+
+    $scope.$on('$destroy', function () {
+        cpMetricAnimator.cancel();
+        if (statusPollTimer) {
+            $timeout.cancel(statusPollTimer);
         }
+    });
 
-        //$timeout(getStuff, 2000);
+    function getStuff(force) {
+        if (statusReqPending && !force) {
+            return;
+        }
+        statusReqPending = true;
 
+        dashGet($http, '/base/getSystemStatus').then(function (response) {
+            statusReqPending = false;
+            if (response && response.data) {
+                $scope.statusError = false;
+                cpMetricAnimator.animateTo(
+                    $scope,
+                    response.data.cpuUsage,
+                    response.data.ramUsage,
+                    response.data.diskUsage
+                );
+                $scope.cpuCores = response.data.cpuCores;
+                $scope.ramTotalMB = response.data.ramTotalMB;
+                $scope.diskTotalGB = response.data.diskTotalGB;
+                $scope.diskFreeGB = response.data.diskFreeGB;
+                $scope.uptime = response.data.uptime || 'N/A';
+                $scope.uptimeLoaded = true;
+            } else {
+                $scope.uptime = 'Unavailable';
+                $scope.uptimeLoaded = true;
+                $scope.statusError = true;
+            }
+            scheduleStatusRefresh();
+        }, function () {
+            statusReqPending = false;
+            $scope.uptime = 'Unavailable';
+            $scope.uptimeLoaded = true;
+            $scope.statusError = true;
+            scheduleStatusRefresh();
+        });
     }
 });
 
@@ -387,7 +569,7 @@ app.controller('loadAvg', function ($scope, $http, $timeout) {
             console.log("Can't get load average data");
         }
 
-        //$timeout(getStuff, 2000);
+        //$timeout(getStuff, 60000); // was 2s; reduced panel load
 
     }
 });
@@ -497,7 +679,7 @@ app.controller('homePageStatus', function ($scope, $http, $timeout) {
             console.log("not good");
         }
 
-        $timeout(getStuff, 2000);
+        $timeout(getStuff, 60000); // was 2s; reduced panel load
 
     }
 
@@ -562,10 +744,20 @@ app.controller('versionManagment', function ($scope, $http, $timeout) {
         $scope.updateFinish = true;
         $scope.couldNotConnect = true;
 
+        var data = {
+            branchSelect: document.getElementById("branchSelect").value,
+
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
 
         url = "/base/upgrade";
-
-        $http.get(url).then(ListInitialData, cantLoadInitialData);
+        $http.post(url, data, config).then(ListInitialData, cantLoadInitialData);
 
 
         function ListInitialData(response) {
@@ -618,6 +810,7 @@ app.controller('versionManagment', function ($scope, $http, $timeout) {
 
 
         function ListInitialDatas(response) {
+            console.log(response.data.upgradeLog);
 
 
             if (response.data.upgradeStatus === 1) {
@@ -635,7 +828,7 @@ app.controller('versionManagment', function ($scope, $http, $timeout) {
                 } else {
                     $scope.upgradelogBox = false;
                     $scope.upgradeLog = response.data.upgradeLog;
-                    $timeout(getUpgradeStatus, 2000);
+                    timeout(getUpgradeStatus, 2000);
                 }
             }
 
@@ -696,7 +889,1272 @@ app.controller('designtheme', function ($scope, $http, $timeout) {
             console.log(response);
         }
 
-        //$timeout(getStuff, 2000);
+        //$timeout(getStuff, 60000); // was 2s; reduced panel load
 
+    };
+});
+
+
+app.controller('OnboardingCP', function ($scope, $http, $timeout, $window) {
+
+    $scope.cyberpanelLoading = true;
+    $scope.ExecutionStatus = true;
+    $scope.ReportStatus = true;
+    $scope.OnboardineDone = true;
+    
+    var statusTimer = null;
+
+    function statusFunc() {
+        $scope.cyberpanelLoading = false;
+        $scope.ExecutionStatus = false;
+        var url = "/emailPremium/statusFunc";
+
+        var data = {
+            statusFile: statusFile
+        };
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialData, cantLoadInitialData);
+
+
+        function ListInitialData(response) {
+            if (response.data.status === 1) {
+                if (response.data.abort === 1) {
+                    $scope.functionProgress = {"width": "100%"};
+                    $scope.functionStatus = response.data.currentStatus;
+                    $scope.cyberpanelLoading = true;
+                    $scope.OnboardineDone = false;
+                    if (statusTimer) {
+                        $timeout.cancel(statusTimer);
+                        statusTimer = null;
+                    }
+                } else {
+                    $scope.functionProgress = {"width": response.data.installationProgress + "%"};
+                    $scope.functionStatus = response.data.currentStatus;
+                    statusTimer = $timeout(statusFunc, 3000);
+                }
+
+            } else {
+                $scope.cyberpanelLoading = true;
+                $scope.functionStatus = response.data.error_message;
+                $scope.functionProgress = {"width": response.data.installationProgress + "%"};
+                if (statusTimer) {
+                    $timeout.cancel(statusTimer);
+                    statusTimer = null;
+                }
+            }
+
+        }
+
+        function cantLoadInitialData(response) {
+            $scope.functionProgress = {"width": response.data.installationProgress + "%"};
+            $scope.functionStatus = 'Could not connect to server, please refresh this page.';
+            $timeout.cancel();
+        }
+    }
+
+    $scope.RunOnboarding = function () {
+        $scope.cyberpanelLoading = false;
+        $scope.OnboardineDone = true;
+
+        var url = "/base/runonboarding";
+
+        var data = {
+            hostname: $scope.hostname,
+            rDNSCheck: $scope.rDNSCheck
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+
+        $http.post(url, data, config).then(ListInitialData, cantLoadInitialData);
+
+        function ListInitialData(response) {
+            $scope.cyberpanelLoading = true;
+            if (response.data.status === 1) {
+                statusFile = response.data.tempStatusPath;
+                statusFunc();
+
+
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+
+        }
+
+        function cantLoadInitialData(response) {
+            $scope.cyberpanelLoading = true;
+
+            new PNotify({
+                title: 'Error',
+                text: 'Could not connect to server, please refresh this page.',
+                type: 'error'
+            });
+        }
+    };
+
+    $scope.RestartCyberPanel = function () {
+        $scope.cyberpanelLoading = false;
+
+        var url = "/base/RestartCyberPanel";
+
+        var data = {
+
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+
+        $http.post(url, data, config).then(ListInitialData, cantLoadInitialData);
+        $scope.cyberpanelLoading = true;
+        new PNotify({
+                    title: 'Success',
+                    text: 'Refresh your browser after 3 seconds to fetch new SSL.',
+                    type: 'success'
+                });
+
+        function ListInitialData(response) {
+            $scope.cyberpanelLoading = true;
+            if (response.data.status === 1) {
+
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+
+        }
+
+        function cantLoadInitialData(response) {
+            $scope.cyberpanelLoading = true;
+
+            new PNotify({
+                title: 'Error',
+                text: 'Could not connect to server, please refresh this page.',
+                type: 'error'
+            });
+        }
+    };
+
+});
+
+app.controller('dashboardStatsController', function ($scope, $http, $timeout) {
+    // Card values
+    $scope.totalUsers = 0;
+    $scope.totalSites = 0;
+    $scope.totalWPSites = 0;
+    $scope.totalDBs = 0;
+    $scope.totalEmails = 0;
+    $scope.totalFTPUsers = 0;
+    $scope.statsLoaded = false;
+
+    // Hide system charts for non-admin users
+    $scope.hideSystemCharts = false;
+
+    // Top Processes
+    $scope.topProcesses = [];
+    $scope.topProcessesPaginated = [];
+    $scope.topProcessesCurrentPage = 1;
+    $scope.topProcessesPerPage = 5;
+    $scope.topProcessesGoToPageInput = 1;
+    $scope.loadingTopProcesses = true;
+    $scope.errorTopProcesses = '';
+
+    $scope.getTopProcessesTotalPages = function() {
+        var perPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        return Math.ceil(($scope.topProcesses || []).length / perPage);
+    };
+
+    $scope.getTopProcessesStart = function() {
+        if (!$scope.topProcesses || $scope.topProcesses.length === 0) {
+            return 0;
+        }
+        var perPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        return ($scope.topProcessesCurrentPage - 1) * perPage + 1;
+    };
+
+    $scope.getTopProcessesEnd = function() {
+        if (!$scope.topProcesses || $scope.topProcesses.length === 0) {
+            return 0;
+        }
+        var perPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        var end = $scope.topProcessesCurrentPage * perPage;
+        return Math.min(end, $scope.topProcesses.length);
+    };
+
+    $scope.updateTopProcessesPaginated = function() {
+        if (!$scope.topProcesses || $scope.topProcesses.length === 0) {
+            $scope.topProcessesPaginated = [];
+            return;
+        }
+        var perPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        var totalPages = $scope.getTopProcessesTotalPages();
+        if ($scope.topProcessesCurrentPage > totalPages) {
+            $scope.topProcessesCurrentPage = totalPages || 1;
+        }
+        if ($scope.topProcessesCurrentPage < 1) {
+            $scope.topProcessesCurrentPage = 1;
+        }
+        $scope.topProcessesGoToPageInput = $scope.topProcessesCurrentPage;
+        var start = ($scope.topProcessesCurrentPage - 1) * perPage;
+        var end = start + perPage;
+        $scope.topProcessesPaginated = $scope.topProcesses.slice(start, end);
+    };
+
+    $scope.topProcessesPrevPage = function() {
+        $scope.topProcessesGoToPage($scope.topProcessesCurrentPage - 1);
+    };
+
+    $scope.topProcessesNextPage = function() {
+        $scope.topProcessesGoToPage($scope.topProcessesCurrentPage + 1);
+    };
+
+    $scope.topProcessesChangePerPage = function() {
+        $scope.topProcessesPerPage = Math.max(parseInt($scope.topProcessesPerPage, 10) || 5, 1);
+        $scope.topProcessesCurrentPage = 1;
+        $scope.topProcessesGoToPageInput = 1;
+        $scope.updateTopProcessesPaginated();
+    };
+
+    $scope.topProcessesGoToPage = function(page) {
+        page = parseInt(page, 10);
+        var totalPages = $scope.getTopProcessesTotalPages();
+        if (page >= 1 && page <= totalPages) {
+            $scope.topProcessesCurrentPage = page;
+            $scope.updateTopProcessesPaginated();
+        } else {
+            $scope.topProcessesGoToPageInput = $scope.topProcessesCurrentPage;
+        }
+    };
+
+    $scope.topProcessesGoToPageNumber = function() {
+        $scope.topProcessesGoToPage($scope.topProcessesGoToPageInput);
+    };
+
+    $scope.refreshTopProcesses = function() {
+        if (dashPollInFlight.topProcesses) {
+            return;
+        }
+        dashPollInFlight.topProcesses = true;
+        $scope.loadingTopProcesses = true;
+        dashGet($http, '/base/getTopProcesses').then(function (response) {
+            dashPollInFlight.topProcesses = false;
+            $scope.loadingTopProcesses = false;
+            if (response.data && response.data.status === 1 && response.data.processes) {
+                $scope.topProcesses = response.data.processes;
+                $scope.topProcessesCurrentPage = 1;
+                $scope.topProcessesGoToPageInput = 1;
+                $scope.updateTopProcessesPaginated();
+            } else {
+                $scope.topProcesses = [];
+                $scope.topProcessesPaginated = [];
+                $scope.topProcessesGoToPageInput = 1;
+            }
+        }, function () {
+            dashPollInFlight.topProcesses = false;
+            $scope.loadingTopProcesses = false;
+            $scope.errorTopProcesses = 'Failed to load top processes.';
+            $scope.topProcesses = [];
+            $scope.topProcessesPaginated = [];
+            $scope.topProcessesGoToPageInput = 1;
+        });
+    };
+
+    // SSH Logins
+    $scope.sshLogins = [];
+    $scope.sshLoginsPaginated = [];
+    $scope.sshLoginsCurrentPage = 1;
+    $scope.sshLoginsPerPage = 5;
+    $scope.sshLoginsGoToPageInput = 1;
+    $scope.loadingSSHLogins = true;
+    $scope.errorSSHLogins = '';
+    
+    $scope.getSSHLoginsTotalPages = function() {
+        var perPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        return Math.ceil(($scope.sshLogins || []).length / perPage);
+    };
+    
+    $scope.getSSHLoginsStart = function() {
+        if (!$scope.sshLogins || $scope.sshLogins.length === 0) {
+            return 0;
+        }
+        var perPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        return ($scope.sshLoginsCurrentPage - 1) * perPage + 1;
+    };
+    
+    $scope.getSSHLoginsEnd = function() {
+        if (!$scope.sshLogins || $scope.sshLogins.length === 0) {
+            return 0;
+        }
+        var perPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        var end = $scope.sshLoginsCurrentPage * perPage;
+        return Math.min(end, $scope.sshLogins.length);
+    };
+    
+    $scope.updateSSHLoginsPaginated = function() {
+        if (!$scope.sshLogins || $scope.sshLogins.length === 0) {
+            $scope.sshLoginsPaginated = [];
+            return;
+        }
+        var perPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        var totalPages = $scope.getSSHLoginsTotalPages();
+        if ($scope.sshLoginsCurrentPage > totalPages) {
+            $scope.sshLoginsCurrentPage = totalPages || 1;
+        }
+        if ($scope.sshLoginsCurrentPage < 1) {
+            $scope.sshLoginsCurrentPage = 1;
+        }
+        $scope.sshLoginsGoToPageInput = $scope.sshLoginsCurrentPage;
+        var start = ($scope.sshLoginsCurrentPage - 1) * perPage;
+        var end = start + perPage;
+        $scope.sshLoginsPaginated = $scope.sshLogins.slice(start, end);
+    };
+    
+    $scope.sshLoginsPrevPage = function() {
+        $scope.sshLoginsGoToPage($scope.sshLoginsCurrentPage - 1);
+    };
+    
+    $scope.sshLoginsNextPage = function() {
+        $scope.sshLoginsGoToPage($scope.sshLoginsCurrentPage + 1);
+    };
+
+    $scope.sshLoginsChangePerPage = function() {
+        $scope.sshLoginsPerPage = Math.max(parseInt($scope.sshLoginsPerPage, 10) || 5, 1);
+        $scope.sshLoginsCurrentPage = 1;
+        $scope.sshLoginsGoToPageInput = 1;
+        $scope.updateSSHLoginsPaginated();
+    };
+
+    $scope.sshLoginsGoToPage = function(page) {
+        page = parseInt(page, 10);
+        var totalPages = $scope.getSSHLoginsTotalPages();
+        if (page >= 1 && page <= totalPages) {
+            $scope.sshLoginsCurrentPage = page;
+            $scope.updateSSHLoginsPaginated();
+        } else {
+            $scope.sshLoginsGoToPageInput = $scope.sshLoginsCurrentPage;
+        }
+    };
+    
+    $scope.sshLoginsGoToPageNumber = function() {
+        $scope.sshLoginsGoToPage($scope.sshLoginsGoToPageInput);
+    };
+    
+    $scope.refreshSSHLogins = function() {
+        $scope.loadingSSHLogins = true;
+        $http.get('/base/getRecentSSHLogins').then(function (response) {
+            $scope.loadingSSHLogins = false;
+            if (response.data && response.data.logins && Array.isArray(response.data.logins)) {
+                $scope.sshLogins = response.data.logins;
+                $scope.sshLoginsCurrentPage = 1;
+                $scope.sshLoginsGoToPageInput = 1;
+                $scope.updateSSHLoginsPaginated();
+            } else {
+                $scope.sshLogins = [];
+                $scope.sshLoginsPaginated = [];
+                $scope.sshLoginsGoToPageInput = 1;
+            }
+        }, function () {
+            $scope.loadingSSHLogins = false;
+            $scope.errorSSHLogins = 'Failed to load SSH logins.';
+            $scope.sshLogins = [];
+            $scope.sshLoginsPaginated = [];
+            $scope.sshLoginsGoToPageInput = 1;
+        });
+    };
+
+    // SSH Logs
+    $scope.sshLogs = [];
+    $scope.sshLogsPaginated = [];
+    $scope.sshLogsCurrentPage = 1;
+    $scope.sshLogsPerPage = 5;
+    $scope.sshLogsGoToPageInput = 1;
+    $scope.loadingSSHLogs = true;
+    $scope.errorSSHLogs = '';
+    $scope.securityAlerts = [];
+    $scope.loadingSecurityAnalysis = false;
+    
+    $scope.getSSHLogsTotalPages = function() {
+        var perPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        return Math.ceil(($scope.sshLogs || []).length / perPage);
+    };
+    
+    $scope.getSSHLogsStart = function() {
+        if (!$scope.sshLogs || $scope.sshLogs.length === 0) {
+            return 0;
+        }
+        var perPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        return ($scope.sshLogsCurrentPage - 1) * perPage + 1;
+    };
+    
+    $scope.getSSHLogsEnd = function() {
+        if (!$scope.sshLogs || $scope.sshLogs.length === 0) {
+            return 0;
+        }
+        var perPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        var end = $scope.sshLogsCurrentPage * perPage;
+        return Math.min(end, $scope.sshLogs.length);
+    };
+    
+    $scope.updateSSHLogsPaginated = function() {
+        if (!$scope.sshLogs || $scope.sshLogs.length === 0) {
+            $scope.sshLogsPaginated = [];
+            return;
+        }
+        var perPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        var totalPages = $scope.getSSHLogsTotalPages();
+        if ($scope.sshLogsCurrentPage > totalPages) {
+            $scope.sshLogsCurrentPage = totalPages || 1;
+        }
+        if ($scope.sshLogsCurrentPage < 1) {
+            $scope.sshLogsCurrentPage = 1;
+        }
+        $scope.sshLogsGoToPageInput = $scope.sshLogsCurrentPage;
+        var start = ($scope.sshLogsCurrentPage - 1) * perPage;
+        var end = start + perPage;
+        $scope.sshLogsPaginated = $scope.sshLogs.slice(start, end);
+    };
+    
+    $scope.sshLogsPrevPage = function() {
+        $scope.sshLogsGoToPage($scope.sshLogsCurrentPage - 1);
+    };
+    
+    $scope.sshLogsNextPage = function() {
+        $scope.sshLogsGoToPage($scope.sshLogsCurrentPage + 1);
+    };
+
+    $scope.sshLogsChangePerPage = function() {
+        $scope.sshLogsPerPage = Math.max(parseInt($scope.sshLogsPerPage, 10) || 5, 1);
+        $scope.sshLogsCurrentPage = 1;
+        $scope.sshLogsGoToPageInput = 1;
+        $scope.updateSSHLogsPaginated();
+    };
+
+    $scope.sshLogsGoToPage = function(page) {
+        page = parseInt(page, 10);
+        var totalPages = $scope.getSSHLogsTotalPages();
+        if (page >= 1 && page <= totalPages) {
+            $scope.sshLogsCurrentPage = page;
+            $scope.updateSSHLogsPaginated();
+        } else {
+            $scope.sshLogsGoToPageInput = $scope.sshLogsCurrentPage;
+        }
+    };
+    
+    $scope.sshLogsGoToPageNumber = function() {
+        $scope.sshLogsGoToPage($scope.sshLogsGoToPageInput);
+    };
+    
+    $scope.refreshSSHLogs = function() {
+        $scope.loadingSSHLogs = true;
+        $http.get('/base/getRecentSSHLogs').then(function (response) {
+            $scope.loadingSSHLogs = false;
+            if (response.data && response.data.logs && Array.isArray(response.data.logs)) {
+                $scope.sshLogs = response.data.logs;
+                $scope.sshLogsCurrentPage = 1;
+                $scope.sshLogsGoToPageInput = 1;
+                $scope.updateSSHLogsPaginated();
+                $scope.analyzeSSHSecurity();
+            } else {
+                $scope.sshLogs = [];
+                $scope.sshLogsPaginated = [];
+                $scope.sshLogsGoToPageInput = 1;
+            }
+        }, function () {
+            $scope.loadingSSHLogs = false;
+            $scope.errorSSHLogs = 'Failed to load SSH logs.';
+            $scope.sshLogs = [];
+            $scope.sshLogsPaginated = [];
+            $scope.sshLogsGoToPageInput = 1;
+        });
+    };
+    
+    // Security Analysis
+    $scope.showAddonRequired = false;
+    $scope.addonInfo = {};
+    $scope.blockingIP = null;
+    $scope.blockedIPs = {};
+
+    function notifyUser(title, text, type, delay) {
+        if (typeof PNotify !== 'undefined') {
+            new PNotify({
+                title: title,
+                text: text,
+                type: type || 'info',
+                delay: delay || 5000
+            });
+        }
+    }
+
+    function parseBanResponse(responseData) {
+        if (typeof responseData === 'string') {
+            try {
+                return JSON.parse(responseData);
+            } catch (e) {
+                return null;
+            }
+        }
+        return responseData;
+    }
+
+    function banIPAddress(ipAddress, reason, onSuccess) {
+        ipAddress = String(ipAddress || '').trim();
+        if (!ipAddress) {
+            notifyUser('Error', 'No IP address provided', 'error');
+            return;
+        }
+
+        var ipPattern = /^(\d{1,3}\.){3}\d{1,3}(\/\d{1,2})?$/;
+        if (!ipPattern.test(ipAddress)) {
+            notifyUser('Error', 'Invalid IP address format: ' + ipAddress, 'error');
+            return;
+        }
+
+        if ($scope.blockingIP === ipAddress) {
+            return;
+        }
+
+        if ($scope.blockedIPs && $scope.blockedIPs[ipAddress]) {
+            notifyUser('Info', 'IP address ' + ipAddress + ' is already banned', 'info', 3000);
+            return;
+        }
+
+        $scope.blockingIP = ipAddress;
+
+        $http.post('/firewall/addBannedIP', {
+            ip: ipAddress,
+            reason: reason,
+            duration: 'permanent'
+        }, {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        }).then(function (response) {
+            $scope.blockingIP = null;
+            var responseData = parseBanResponse(response.data);
+
+            if (responseData && (responseData.status === 1 || responseData.status === '1')) {
+                if (!$scope.blockedIPs) {
+                    $scope.blockedIPs = {};
+                }
+                $scope.blockedIPs[ipAddress] = true;
+                notifyUser(
+                    'IP Address Banned',
+                    'IP address ' + ipAddress + ' has been permanently banned and added to the firewall.',
+                    'success'
+                );
+                if (typeof onSuccess === 'function') {
+                    onSuccess();
+                }
+            } else {
+                var errorMsg = 'Failed to block IP address';
+                if (responseData && responseData.error_message) {
+                    errorMsg = responseData.error_message;
+                } else if (responseData && responseData.error) {
+                    errorMsg = responseData.error;
+                } else if (responseData && responseData.message) {
+                    errorMsg = responseData.message;
+                }
+                notifyUser('Error', errorMsg, 'error');
+            }
+        }, function (err) {
+            $scope.blockingIP = null;
+            var errorMessage = 'Failed to block IP address';
+            var errData = err.data;
+            if (typeof errData === 'string') {
+                errData = parseBanResponse(errData);
+            }
+            if (errData && typeof errData === 'object') {
+                errorMessage = errData.error_message || errData.error || errData.message || errorMessage;
+            } else if (err.status) {
+                errorMessage = 'HTTP ' + err.status + ': ' + errorMessage;
+            }
+            notifyUser('Error', errorMessage, 'error');
+        });
+    }
+    
+    $scope.analyzeSSHSecurity = function() {
+        $scope.loadingSecurityAnalysis = true;
+        $scope.showAddonRequired = false;
+        $http.post('/base/analyzeSSHSecurity', {}).then(function (response) {
+            $scope.loadingSecurityAnalysis = false;
+            if (response.data) {
+                if (response.data.addon_required) {
+                    $scope.showAddonRequired = true;
+                    $scope.addonInfo = response.data;
+                    $scope.securityAlerts = [];
+                } else if (response.data.status === 1) {
+                    $scope.securityAlerts = response.data.alerts;
+                    $scope.showAddonRequired = false;
+                }
+            }
+        }, function (err) {
+            $scope.loadingSecurityAnalysis = false;
+        });
+    };
+
+    $scope.blockIPAddress = function(ipAddress) {
+        banIPAddress(
+            ipAddress,
+            'Brute force attack detected from SSH Security Analysis',
+            function () {
+                $scope.analyzeSSHSecurity();
+            }
+        );
+    };
+
+    $scope.banIPFromSSHLog = function(ipAddress) {
+        banIPAddress(
+            ipAddress,
+            'Suspicious activity detected from SSH logs',
+            function () {
+                $scope.refreshSSHLogs();
+            }
+        );
+    };
+
+    // Initial fetch (top processes polled on slower interval below)
+    $scope.refreshSSHLogins();
+    $scope.refreshSSHLogs();
+
+    // Chart.js chart objects
+    var trafficChart, diskIOChart, cpuChart;
+    // Data arrays for live graphs
+    var trafficLabels = [], rxData = [], txData = [];
+    var diskLabels = [], readData = [], writeData = [];
+    var cpuLabels = [], cpuUsageData = [];
+    // For rate calculation
+    var lastRx = null, lastTx = null, lastDiskRead = null, lastDiskWrite = null, lastCPU = null;
+    var lastCPUTimes = null;
+    var pollInterval = 5000; // ms (was 2000; slower poll reduces lscpd worker exhaustion)
+    var topProcessPollInterval = 30000;
+    var maxPoints = 30;
+
+    function pollDashboardStats() {
+        dashPollOnce($http, 'dashboardStats', '/base/getDashboardStats', function(response) {
+            if (response.data.status === 1) {
+                $scope.totalUsers = response.data.total_users;
+                $scope.totalSites = response.data.total_sites;
+                $scope.totalWPSites = response.data.total_wp_sites;
+                $scope.totalDBs = response.data.total_dbs;
+                $scope.totalEmails = response.data.total_emails;
+                $scope.totalFTPUsers = response.data.total_ftp_users;
+                $scope.statsLoaded = true;
+            }
+        });
+    }
+
+    function pollTraffic() {
+        dashPollOnce($http, 'trafficStats', '/base/getTrafficStats', function(response) {
+            if (response.data.admin_only) {
+                // Hide chart for non-admin users
+                $scope.hideSystemCharts = true;
+                return;
+            }
+            if (response.data.status === 1) {
+                var now = new Date();
+                var rx = response.data.rx_bytes;
+                var tx = response.data.tx_bytes;
+                if (lastRx !== null && lastTx !== null) {
+                    var rxRate = (rx - lastRx) / (pollInterval / 1000); // bytes/sec
+                    var txRate = (tx - lastTx) / (pollInterval / 1000);
+                    trafficLabels.push(now.toLocaleTimeString());
+                    rxData.push(rxRate);
+                    txData.push(txRate);
+                    if (trafficLabels.length > maxPoints) {
+                        trafficLabels.shift(); rxData.shift(); txData.shift();
+                    }
+                    if (trafficChart) {
+                        trafficChart.data.labels = trafficLabels.slice();
+                        trafficChart.data.datasets[0].data = rxData.slice();
+                        trafficChart.data.datasets[1].data = txData.slice();
+                        trafficChart.update();
+                    }
+                } else {
+                    // First poll, push zero data point
+                    trafficLabels.push(now.toLocaleTimeString());
+                    rxData.push(0);
+                    txData.push(0);
+                    if (trafficChart) {
+                        trafficChart.data.labels = trafficLabels.slice();
+                        trafficChart.data.datasets[0].data = rxData.slice();
+                        trafficChart.data.datasets[1].data = txData.slice();
+                        trafficChart.update();
+                        setTimeout(function() {
+                            if (window.trafficChart) {
+                                window.trafficChart.resize();
+                                window.trafficChart.update();
+                            }
+                        }, 1000);
+                    }
+                }
+                lastRx = rx; lastTx = tx;
+            }
+        });
+    }
+
+    function pollDiskIO() {
+        dashPollOnce($http, 'diskIOStats', '/base/getDiskIOStats', function(response) {
+            if (response.data.admin_only) {
+                // Hide chart for non-admin users
+                $scope.hideSystemCharts = true;
+                return;
+            }
+            if (response.data.status === 1) {
+                var now = new Date();
+                var read = response.data.read_bytes;
+                var write = response.data.write_bytes;
+                if (lastDiskRead !== null && lastDiskWrite !== null) {
+                    var readRate = (read - lastDiskRead) / (pollInterval / 1000); // bytes/sec
+                    var writeRate = (write - lastDiskWrite) / (pollInterval / 1000);
+                    diskLabels.push(now.toLocaleTimeString());
+                    readData.push(readRate);
+                    writeData.push(writeRate);
+                    if (diskLabels.length > maxPoints) {
+                        diskLabels.shift(); readData.shift(); writeData.shift();
+                    }
+                    if (diskIOChart) {
+                        diskIOChart.data.labels = diskLabels.slice();
+                        diskIOChart.data.datasets[0].data = readData.slice();
+                        diskIOChart.data.datasets[1].data = writeData.slice();
+                        diskIOChart.update();
+                    }
+                } else {
+                    // First poll, push zero data point
+                    diskLabels.push(now.toLocaleTimeString());
+                    readData.push(0);
+                    writeData.push(0);
+                    if (diskIOChart) {
+                        diskIOChart.data.labels = diskLabels.slice();
+                        diskIOChart.data.datasets[0].data = readData.slice();
+                        diskIOChart.data.datasets[1].data = writeData.slice();
+                        diskIOChart.update();
+                    }
+                }
+                lastDiskRead = read; lastDiskWrite = write;
+            }
+        });
+    }
+
+    function pollCPU() {
+        dashPollOnce($http, 'cpuLoadGraph', '/base/getCPULoadGraph', function(response) {
+            if (response.data.admin_only) {
+                // Hide chart for non-admin users
+                $scope.hideSystemCharts = true;
+                return;
+            }
+            if (response.data.status === 1 && response.data.cpu_times && response.data.cpu_times.length >= 4) {
+                var now = new Date();
+                var cpuTimes = response.data.cpu_times;
+                if (lastCPUTimes) {
+                    var idle = cpuTimes[3];
+                    var total = cpuTimes.reduce(function(a, b) { return a + b; }, 0);
+                    var lastIdle = lastCPUTimes[3];
+                    var lastTotal = lastCPUTimes.reduce(function(a, b) { return a + b; }, 0);
+                    var idleDiff = idle - lastIdle;
+                    var totalDiff = total - lastTotal;
+                    var usage = totalDiff > 0 ? (100 * (1 - idleDiff / totalDiff)) : 0;
+                    cpuLabels.push(now.toLocaleTimeString());
+                    cpuUsageData.push(usage);
+                    if (cpuLabels.length > maxPoints) {
+                        cpuLabels.shift(); cpuUsageData.shift();
+                    }
+                    if (cpuChart) {
+                        cpuChart.data.labels = cpuLabels.slice();
+                        cpuChart.data.datasets[0].data = cpuUsageData.slice();
+                        cpuChart.update();
+                    }
+                } else {
+                    // First poll, push zero data point
+                    cpuLabels.push(now.toLocaleTimeString());
+                    cpuUsageData.push(0);
+                    if (cpuChart) {
+                        cpuChart.data.labels = cpuLabels.slice();
+                        cpuChart.data.datasets[0].data = cpuUsageData.slice();
+                        cpuChart.update();
+                    }
+                }
+                lastCPUTimes = cpuTimes;
+            }
+        });
+    }
+
+    function setupCharts() {
+        var trafficCtx = document.getElementById('trafficChart').getContext('2d');
+        trafficChart = new Chart(trafficCtx, {
+            type: 'line',
+            data: {
+                labels: [],
+                datasets: [
+                    { 
+                        label: 'Download', 
+                        data: [], 
+                        borderColor: '#5b5fcf', 
+                        backgroundColor: 'rgba(91,95,207,0.1)', 
+                        pointBackgroundColor: '#5b5fcf',
+                        pointBorderColor: '#5b5fcf',
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        borderWidth: 2,
+                        tension: 0.4, 
+                        fill: true 
+                    },
+                    { 
+                        label: 'Upload', 
+                        data: [], 
+                        borderColor: '#4a90e2', 
+                        backgroundColor: 'rgba(74,144,226,0.1)', 
+                        pointBackgroundColor: '#4a90e2',
+                        pointBorderColor: '#4a90e2',
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        borderWidth: 2,
+                        tension: 0.4, 
+                        fill: true 
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                animation: { duration: 0 },
+                plugins: {
+                    legend: { 
+                        display: true, 
+                        position: 'top',
+                        labels: { 
+                            font: { size: 12, weight: '600' },
+                            color: '#64748b',
+                            usePointStyle: true,
+                            padding: 20
+                        } 
+                    },
+                    title: { display: false },
+                    tooltip: { 
+                        enabled: true, 
+                        mode: 'index', 
+                        intersect: false,
+                        backgroundColor: 'rgba(255,255,255,0.95)',
+                        titleColor: '#2f3640',
+                        bodyColor: '#64748b',
+                        borderColor: '#e8e9ff',
+                        borderWidth: 1,
+                        cornerRadius: 8,
+                        padding: 12
+                    }
+                },
+                interaction: { mode: 'nearest', axis: 'x', intersect: false },
+                scales: {
+                    x: { 
+                        grid: { color: '#f0f0ff', drawBorder: false }, 
+                        ticks: { 
+                            font: { size: 11 },
+                            color: '#94a3b8',
+                            maxTicksLimit: 8
+                        }
+                    },
+                    y: { 
+                        beginAtZero: true, 
+                        grid: { color: '#f0f0ff', drawBorder: false }, 
+                        ticks: { 
+                            font: { size: 11 },
+                            color: '#94a3b8'
+                        }
+                    }
+                },
+                layout: { padding: { top: 10, bottom: 10, left: 10, right: 10 } }
+            }
+        });
+        window.trafficChart = trafficChart;
+        setTimeout(function() {
+            if (window.trafficChart) {
+                window.trafficChart.resize();
+                window.trafficChart.update();
+                console.log('trafficChart resized and updated after setup.');
+            }
+        }, 500);
+        var diskCtx = document.getElementById('diskIOChart').getContext('2d');
+        diskIOChart = new Chart(diskCtx, {
+            type: 'line',
+            data: {
+                labels: [],
+                datasets: [
+                    { 
+                        label: 'Read', 
+                        data: [], 
+                        borderColor: '#5b5fcf', 
+                        backgroundColor: 'rgba(91,95,207,0.1)', 
+                        pointBackgroundColor: '#5b5fcf',
+                        pointBorderColor: '#5b5fcf',
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        borderWidth: 2,
+                        tension: 0.4, 
+                        fill: true 
+                    },
+                    { 
+                        label: 'Write', 
+                        data: [], 
+                        borderColor: '#e74c3c', 
+                        backgroundColor: 'rgba(231,76,60,0.1)', 
+                        pointBackgroundColor: '#e74c3c',
+                        pointBorderColor: '#e74c3c',
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        borderWidth: 2,
+                        tension: 0.4, 
+                        fill: true 
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                animation: { duration: 0 },
+                plugins: {
+                    legend: { 
+                        display: true, 
+                        position: 'top',
+                        labels: { 
+                            font: { size: 12, weight: '600' },
+                            color: '#64748b',
+                            usePointStyle: true,
+                            padding: 20
+                        } 
+                    },
+                    title: { display: false },
+                    tooltip: { 
+                        enabled: true, 
+                        mode: 'index', 
+                        intersect: false,
+                        backgroundColor: 'rgba(255,255,255,0.95)',
+                        titleColor: '#2f3640',
+                        bodyColor: '#64748b',
+                        borderColor: '#e8e9ff',
+                        borderWidth: 1,
+                        cornerRadius: 8,
+                        padding: 12
+                    }
+                },
+                interaction: { mode: 'nearest', axis: 'x', intersect: false },
+                scales: {
+                    x: { 
+                        grid: { color: '#f0f0ff', drawBorder: false }, 
+                        ticks: { 
+                            font: { size: 11 },
+                            color: '#94a3b8',
+                            maxTicksLimit: 8
+                        }
+                    },
+                    y: { 
+                        beginAtZero: true, 
+                        grid: { color: '#f0f0ff', drawBorder: false }, 
+                        ticks: { 
+                            font: { size: 11 },
+                            color: '#94a3b8'
+                        }
+                    }
+                },
+                layout: { padding: { top: 10, bottom: 10, left: 10, right: 10 } }
+            }
+        });
+        var cpuCtx = document.getElementById('cpuChart').getContext('2d');
+        cpuChart = new Chart(cpuCtx, {
+            type: 'line',
+            data: {
+                labels: [],
+                datasets: [
+                    { 
+                        label: 'CPU Usage (%)', 
+                        data: [], 
+                        borderColor: '#5b5fcf', 
+                        backgroundColor: 'rgba(91,95,207,0.1)', 
+                        pointBackgroundColor: '#5b5fcf',
+                        pointBorderColor: '#5b5fcf',
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        borderWidth: 2,
+                        tension: 0.4, 
+                        fill: true 
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                animation: { duration: 0 },
+                plugins: {
+                    legend: { 
+                        display: true, 
+                        position: 'top',
+                        labels: { 
+                            font: { size: 12, weight: '600' },
+                            color: '#64748b',
+                            usePointStyle: true,
+                            padding: 20
+                        } 
+                    },
+                    title: { display: false },
+                    tooltip: { 
+                        enabled: true, 
+                        mode: 'index', 
+                        intersect: false,
+                        backgroundColor: 'rgba(255,255,255,0.95)',
+                        titleColor: '#2f3640',
+                        bodyColor: '#64748b',
+                        borderColor: '#e8e9ff',
+                        borderWidth: 1,
+                        cornerRadius: 8,
+                        padding: 12
+                    }
+                },
+                interaction: { mode: 'nearest', axis: 'x', intersect: false },
+                scales: {
+                    x: { 
+                        grid: { color: '#f0f0ff', drawBorder: false }, 
+                        ticks: { 
+                            font: { size: 11 },
+                            color: '#94a3b8',
+                            maxTicksLimit: 8
+                        }
+                    },
+                    y: { 
+                        beginAtZero: true, 
+                        max: 100, 
+                        grid: { color: '#f0f0ff', drawBorder: false }, 
+                        ticks: { 
+                            font: { size: 11 },
+                            color: '#94a3b8'
+                        }
+                    }
+                },
+                layout: { padding: { top: 10, bottom: 10, left: 10, right: 10 } }
+            }
+        });
+
+        // Redraw charts on tab shown
+        $("a[data-toggle='tab']").on('shown.bs.tab', function (e) {
+            setTimeout(function() {
+                if (trafficChart) trafficChart.resize();
+                if (diskIOChart) diskIOChart.resize();
+                if (cpuChart) cpuChart.resize();
+            }, 100);
+        });
+        
+        // Also handle custom tab switching
+        document.addEventListener('DOMContentLoaded', function() {
+            var tabs = document.querySelectorAll('a[data-toggle="tab"]');
+            tabs.forEach(function(tab) {
+                tab.addEventListener('click', function(e) {
+                    setTimeout(function() {
+                        if (trafficChart) trafficChart.resize();
+                        if (diskIOChart) diskIOChart.resize();
+                        if (cpuChart) cpuChart.resize();
+                    }, 200);
+                });
+            });
+        });
+    }
+
+    // Initial setup (stagger polls so dashboard APIs do not stampede lscpd workers)
+    $timeout(function() {
+        dashGet($http, '/base/getAdminStatus').then(function(response) {
+            if (response.data && response.data.admin === 1) {
+                setupCharts();
+            } else {
+                $scope.hideSystemCharts = true;
+            }
+        }).catch(function() {
+            $scope.hideSystemCharts = true;
+        });
+
+        function pollCharts() {
+            pollDashboardStats();
+            pollTraffic();
+            pollDiskIO();
+            pollCPU();
+            $timeout(pollCharts, pollInterval);
+        }
+
+        function pollTopProcessesSlow() {
+            $scope.refreshTopProcesses();
+            $timeout(pollTopProcessesSlow, topProcessPollInterval);
+        }
+
+        pollCharts();
+        $timeout(pollTopProcessesSlow, 1500);
+    }, 500);
+
+    // SSH User Activity Modal
+    $scope.showSSHActivityModal = false;
+    $scope.sshActivity = { processes: [], w: [] };
+    $scope.sshActivityUser = '';
+    $scope.loadingSSHActivity = false;
+    $scope.errorSSHActivity = '';
+    
+    $scope.viewSSHActivity = function(login) {
+        $scope.showSSHActivityModal = true;
+        $scope.sshActivity = { processes: [], w: [] };
+        $scope.sshActivityUser = login.user;
+        $scope.loadingSSHActivity = true;
+        $scope.errorSSHActivity = '';
+        var tty = '';
+        // Try to extract tty from login.raw or login.session if available
+        if (login.raw) {
+            var match = login.raw.match(/(pts\/[0-9]+)/);
+            if (match) tty = match[1];
+        }
+        console.log('Fetching SSH activity for user:', login.user, 'IP:', login.ip, 'TTY:', tty);
+        $http.post('/base/getSSHUserActivity', { user: login.user, tty: tty, ip: login.ip || '' }, {
+            timeout: 30000
+        }).then(function(response) {
+            console.log('SSH Activity response received:', response);
+            $scope.loadingSSHActivity = false;
+            if (response.data && response.data.error) {
+                console.error('SSH Activity error:', response.data.error);
+                $scope.errorSSHActivity = response.data.error;
+                $scope.sshActivity = { processes: [], w: [], shell_history: [], geoip: {}, disk_usage: '' };
+            } else if (response.data) {
+                console.log('SSH Activity data:', response.data);
+                $scope.sshActivity = response.data;
+                $scope.errorSSHActivity = '';
+            } else {
+                console.warn('SSH Activity: No data in response');
+                $scope.sshActivity = { processes: [], w: [], shell_history: [], geoip: {}, disk_usage: '' };
+                $scope.errorSSHActivity = 'No data received from server.';
+            }
+        }, function(err) {
+            $scope.loadingSSHActivity = false;
+            console.error('Error fetching SSH activity:', err);
+            console.error('Error status:', err.status);
+            console.error('Error data:', err.data);
+            if (err.status === 0) {
+                $scope.errorSSHActivity = 'Network error: Unable to connect to server. Please check your connection.';
+            } else if (err.status === -1) {
+                $scope.errorSSHActivity = 'Request timeout. The server took too long to respond.';
+            } else if (err.data && err.data.error) {
+                $scope.errorSSHActivity = err.data.error;
+            } else if (err.data && err.data.errorMessage) {
+                $scope.errorSSHActivity = err.data.errorMessage;
+            } else if (err.status === 403) {
+                $scope.errorSSHActivity = 'Access denied. Admin privileges required.';
+            } else if (err.status === 400) {
+                $scope.errorSSHActivity = 'Invalid request. Please try again.';
+            } else if (err.status === 500) {
+                $scope.errorSSHActivity = 'Server error. Please try again later.';
+            } else {
+                $scope.errorSSHActivity = 'Failed to fetch activity. Status: ' + (err.status || 'Unknown') + '. Please check your connection and try again.';
+            }
+            $scope.sshActivity = { processes: [], w: [], shell_history: [], geoip: {}, disk_usage: '' };
+        });
+    };
+    
+    $scope.closeSSHActivityModal = function() {
+        $scope.showSSHActivityModal = false;
+        $scope.sshActivity = { processes: [], w: [] };
+        $scope.sshActivityUser = '';
+        $scope.loadingSSHActivity = false;
+        $scope.errorSSHActivity = '';
+    };
+
+    // Close modal when clicking backdrop
+    $scope.closeModalOnBackdrop = function(event) {
+        if (event.target === event.currentTarget) {
+            $scope.closeSSHActivityModal();
+        }
+    };
+    
+    // Kill a specific process
+    $scope.killProcess = function(pid, user) {
+        if (!confirm('Are you sure you want to kill process ' + pid + '? This action cannot be undone.')) {
+            return;
+        }
+        
+        console.log('Killing process:', pid, 'for user:', user);
+        $http.post('/base/killSSHProcess', { pid: pid, user: user }, { timeout: 10000 }).then(function(response) {
+            var notify = window.cpToast || function (m) { alert(m); };
+            if (response.data && response.data.success) {
+                notify('Process ' + pid + ' killed successfully.', 'success');
+                // Reload activity data
+                if ($scope.sshActivityUser) {
+                    var login = { user: $scope.sshActivityUser, ip: '', tty: '' };
+                    $scope.viewSSHActivity(login);
+                }
+            } else if (response.data && response.data.error) {
+                notify('Error: ' + response.data.error, 'error');
+            } else {
+                notify('Unknown error occurred.', 'error');
+            }
+        }, function(err) {
+            console.error('Error killing process:', err);
+            var errorMsg = 'Failed to kill process. ';
+            if (err.data && err.data.error) {
+                errorMsg += err.data.error;
+            } else if (err.status === 403) {
+                errorMsg += 'Access denied.';
+            } else if (err.status === 404) {
+                errorMsg += 'Process not found.';
+            } else {
+                errorMsg += 'Please try again.';
+            }
+            (window.cpToast || function (m) { alert(m); })(errorMsg, 'error');
+        });
+    };
+    
+    // Kill all sessions for a user
+    $scope.killSession = function(user) {
+        if (!confirm('WARNING: This will force close ALL active sessions for user "' + user + '". This action cannot be undone.\n\nAre you sure you want to continue?')) {
+            return;
+        }
+        
+        if (!confirm('Final confirmation: Kill all sessions for user "' + user + '"?')) {
+            return;
+        }
+        
+        console.log('Killing session for user:', user);
+        $http.post('/base/killSSHSession', { user: user }, { timeout: 10000 }).then(function(response) {
+            if (response.data && response.data.success) {
+                alert('All sessions for user ' + user + ' have been terminated successfully.');
+                // Close modal and refresh SSH logins
+                $scope.closeSSHActivityModal();
+                // Refresh SSH logins list
+                if (typeof $scope.loadSSHLogins === 'function') {
+                    $scope.loadSSHLogins();
+                }
+            } else if (response.data && response.data.error) {
+                alert('Error: ' + response.data.error);
+            } else {
+                alert('Unknown error occurred.');
+            }
+        }, function(err) {
+            console.error('Error killing session:', err);
+            var errorMsg = 'Failed to kill session. ';
+            if (err.data && err.data.error) {
+                errorMsg += err.data.error;
+            } else if (err.status === 403) {
+                errorMsg += 'Access denied.';
+            } else {
+                errorMsg += 'Please try again.';
+            }
+            alert(errorMsg);
+        });
     };
 });


### PR DESCRIPTION
## Summary

- Backports dashboard `/base/` pagination from `v2.5.5-dev` (scoped, not the full dev branch)
- Adds client-side pagination for **Recent SSH Logins**, **SSH Logs**, and **Top Processes** (per-page selector, prev/next, go-to-page)
- Updates `system-status.js` with poll dedupe/throttle to avoid overlapping dashboard API calls
- Expands SSH login/log fetch windows (`last -n 500`, `tail -n 500`), adds IP extraction in auth logs, and caches top-process output

## Files (4)

- `baseTemplate/templates/baseTemplate/homePage.html`
- `baseTemplate/static/baseTemplate/custom-js/system-status.js`
- `static/baseTemplate/custom-js/system-status.js`
- `baseTemplate/views.py` (SSH endpoints + top-process cache only)

## Source commits (v2.5.5-dev)

`8db49bab`, `7736e0ef`, `9ac5a160`, `bcb058f8`, `a6220841`, `e7ca39dd`, `0dab5385`, `3d47c27e`

Related plugin-store backports: #1818 / #1819

## Test plan

- [ ] Log in as admin and open `/base/`
- [ ] Verify SSH Logins table shows pagination controls (3/5/10 per page, arrows, go-to-page)
- [ ] Verify SSH Logs table pagination and IP column/actions
- [ ] Verify Top Processes pagination (default 5 per page)
- [ ] Confirm dashboard metrics still load without timeout under normal polling