### PR TITLE
Settings: option to hide promotional content

### DIFF
--- a/baseTemplate/models.py
+++ b/baseTemplate/models.py
@@ -12,3 +12,4 @@ class version(models.Model):
 
 class CyberPanelCosmetic(models.Model):
     MainDashboardCSS = models.TextField(default='')
+    HidePromotions = models.IntegerField(default=0)

--- a/baseTemplate/templates/baseTemplate/design.html
+++ b/baseTemplate/templates/baseTemplate/design.html
@@ -213,6 +213,15 @@
                         <textarea id="appendthemedata" name="MainDashboardCSS" rows="12" class="form-control">{{ cosmetic.MainDashboardCSS }}</textarea>
                     </div>
 
+                    <div class="form-group" style="margin-top: 1.5rem;">
+                        <label for="HidePromotions" style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+                            <input type="checkbox" id="HidePromotions" name="HidePromotions" value="1"
+                                   {% if cosmetic.HidePromotions %}checked{% endif %}>
+                            <span>{% trans "Hide promotional content" %}</span>
+                        </label>
+                        <p class="page-subtitle" style="margin: 6px 0 0 26px;">{% trans "Removes Build Services / \"Hire Us\" entries and service advertisements from the menu, command palette, and notifications." %}</p>
+                    </div>
+
                     <div class="form-group" style="margin-top: 2rem;">
                         <button type="submit" class="btn btn-primary">
                             <i class="fa fa-save"></i> {% trans "Save Changes" %}

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -112,6 +112,7 @@
                         <button type="button" class="cp-notif-clear" id="cp-notif-clear">{% trans "Dismiss all" %}</button>
                     </div>
                     <div class="cp-notif-list" id="cp-notif-list">
+                        {% if not cosmetic.HidePromotions %}
                         <div class="cp-notif-item" data-key="emaildelivery" data-storekey="emailDeliveryNotificationDismissed" data-store="local">
                             <div class="cp-notif-ic ic-accent"><i class="fas fa-paper-plane" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -121,6 +122,7 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
+                        {% endif %}
                         <div class="cp-notif-item" data-key="backup" data-storekey="backupNotificationDismissed" data-store="session">
                             <div class="cp-notif-ic ic-warn"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -130,6 +132,7 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
+                        {% if not cosmetic.HidePromotions %}
                         <div class="cp-notif-item" data-key="ai" data-storekey="aiScannerNotificationDismissed" data-store="session">
                             <div class="cp-notif-ic ic-accent"><i class="fas fa-brain" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -148,6 +151,7 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
+                        {% endif %}
                     </div>
                     <div class="cp-notif-empty" id="cp-notif-empty" hidden>{% trans "You're all caught up." %}</div>
                 </div>
@@ -234,12 +238,14 @@
             <span>{% trans "Backups" %}</span>
         </a>
 
+        {% if not cosmetic.HidePromotions %}
         <!-- Build Services: prominent, available to everyone -->
         <a href="{% url 'buildServices' %}" class="menu-item menu-item-promo">
             <div class="icon-wrapper"><i class="fas fa-rocket"></i></div>
             <span>{% trans "Build Services" %}</span>
             <span class="badge badge-promo">{% trans "HIRE US" %}</span>
         </a>
+        {% endif %}
 
         <!-- ============================ ACCOUNT ============================ -->
         <div class="section-header">{% trans "ACCOUNT" %}</div>
@@ -318,6 +324,7 @@
             {l:'{% trans "Deploy WordPress" %}', h:'{% url "createWordpress" %}', i:'fa-circle-plus', g:'{% trans "Quick actions" %}'},
             {% if admin or createEmail %}{l:'{% trans "Create Email Account" %}', h:'{% url "createEmailAccount" %}', i:'fa-circle-plus', g:'{% trans "Quick actions" %}'},{% endif %}
             {% if admin or createDatabase %}{l:'{% trans "Create Database" %}', h:'{% url "createDatabase" %}', i:'fa-circle-plus', g:'{% trans "Quick actions" %}'},{% endif %}
+            {% if not cosmetic.HidePromotions %}
             {l:'{% trans "Build Services" %}', h:'{% url "buildServices" %}', i:'fa-rocket', g:'{% trans "Quick actions" %}'},
             // Build services (open the marketing pages on cyberpanel.net)
             {l:'{% trans "Website Development" %}', h:'https://cyberpanel.net/custom-development/web?utm_source=cyberpanel&utm_medium=panel&utm_campaign=build_services', i:'fa-globe', g:'{% trans "Build services" %}', t:'_blank'},
@@ -329,6 +336,7 @@
             {l:'{% trans "UI / UX Design" %}', h:'https://cyberpanel.net/custom-development/design?utm_source=cyberpanel&utm_medium=panel&utm_campaign=build_services', i:'fa-pen-ruler', g:'{% trans "Build services" %}', t:'_blank'},
             {l:'{% trans "DevOps & Server Management" %}', h:'https://cyberpanel.net/custom-development/devops?utm_source=cyberpanel&utm_medium=panel&utm_campaign=build_services', i:'fa-server', g:'{% trans "Build services" %}', t:'_blank'},
             {l:'{% trans "Maintenance & Support" %}', h:'https://cyberpanel.net/custom-development/support?utm_source=cyberpanel&utm_medium=panel&utm_campaign=build_services', i:'fa-life-ring', g:'{% trans "Build services" %}', t:'_blank'},
+            {% endif %}
             // Sites
             {l:'{% trans "Dashboard" %}', h:'{% url "index" %}', i:'fa-gauge-high', g:'{% trans "Sites" %}'},
             {l:'{% trans "Websites" %}', h:'{% url "listWebsites" %}', i:'fa-globe', g:'{% trans "Sites" %}'},

--- a/baseTemplate/views.py
+++ b/baseTemplate/views.py
@@ -408,6 +408,7 @@ def design(request):
     if request.method == 'POST':
         MainDashboardCSS = request.POST.get('MainDashboardCSS', '')
         cosmetic.MainDashboardCSS = MainDashboardCSS
+        cosmetic.HidePromotions = 1 if request.POST.get('HidePromotions') else 0
         cosmetic.save()
         finalData['saved'] = 1
 

--- a/plogical/upgrade.py
+++ b/plogical/upgrade.py
@@ -1638,6 +1638,12 @@ $cfg['Servers'][$i]['LogoutURL'] = 'phpmyadminsignin.php?logout';
             except:
                 pass
 
+            try:
+                cursor.execute(
+                    'ALTER TABLE baseTemplate_cyberpanelcosmetic ADD HidePromotions integer NOT NULL DEFAULT 0')
+            except:
+                pass
+
             # AI Scanner Tables
             try:
                 cursor.execute('''


### PR DESCRIPTION
## Summary

Adds a **Hide promotional content** checkbox under Settings → Design. When enabled it removes the Build Services / "HIRE US" sidebar entry, the Build-services quick action and marketing group in the command palette, and the Email Delivery / AI Scanner / .htaccess promotional notifications. The backups-not-configured notification is kept, since it is a genuine status warning rather than a promotion.

Self-hosters running panels for clients frequently ask for a way to present a clean, unbranded admin surface; this makes it a first-class, reversible setting instead of a hand-patched template.

## Implementation

- `HidePromotions` integer field (default 0) on the existing `CyberPanelCosmetic` singleton, so it is available in every template through the existing `cosmetic` context processor — no new queries.
- Schema change follows the house pattern: try/except `ALTER TABLE ... ADD ... DEFAULT 0` in `plogical/upgrade.py` next to the table's CREATE.
- Saved from the existing Design form POST; template gates are plain `{% if not cosmetic.HidePromotions %}` blocks.
- Default is off — out of the box nothing changes.