### PR TITLE
fix(snappymail): drop conflicting RainLoop domain .ini on upgrade

### DIFF
--- a/scripts/utils/fix-snappymail.sh
+++ b/scripts/utils/fix-snappymail.sh
@@ -45,6 +45,27 @@ if [[ -f "$PUBLIC/snappymail/index.php" ]]; then
         chmod 755 "$PUBLIC/snappymail" 2>/dev/null || true
         systemctl restart lscpd 2>/dev/null || true
     fi
+
+    # Remove leftover RainLoop-era domain .ini when a matching .json exists
+    # (dual configs can confuse operators; SnappyMail prefers .json).
+    DOMAINS_DIR="/usr/local/lscp/cyberpanel/snappymail/data/_data_/_default_/domains"
+    DOMAINS_BAK="/usr/local/lscp/cyberpanel/snappymail/data/_data_/_default_/domains.bak"
+    if [[ -d "$DOMAINS_DIR" ]]; then
+        mkdir -p "$DOMAINS_BAK"
+        ts="$(date +%Y%m%d-%H%M%S)"
+        shopt -s nullglob
+        for jsonf in "$DOMAINS_DIR"/*.json; do
+            base="$(basename "$jsonf" .json)"
+            inif="$DOMAINS_DIR/${base}.ini"
+            if [[ -f "$inif" ]]; then
+                cp -a "$inif" "$DOMAINS_BAK/${base}.ini.$ts"
+                rm -f "$inif"
+                echo "Removed conflicting domain .ini (backed up): ${base}.ini"
+            fi
+        done
+        shopt -u nullglob
+    fi
+
     echo "Done. SnappyMail is at $PUBLIC/snappymail"
     echo "Test: https://YOUR_IP:2087/snappymail/index.php"
 else

--- a/to-do/SNAPPYMAIL-AUTHENTICATIONFAILED.md
+++ b/to-do/SNAPPYMAIL-AUTHENTICATIONFAILED.md
@@ -1,0 +1,38 @@
+# SnappyMail AUTHENTICATIONFAILED after v2.5.5-dev upgrade
+
+Date: 20/07/2026
+
+## Symptom
+
+SnappyMail at `:2087/snappymail/` shows:
+
+`AUTHENTICATIONFAILED Authentication failed`
+
+## Root cause
+
+This message comes from Dovecot (IMAP), not from a broken SnappyMail install. When the mailbox password does not match `e_users.password`, Dovecot rejects PLAIN auth and SnappyMail surfaces that exact string.
+
+Typical healthy signals:
+
+- Account exists in `cyberpanel.e_users` with `{CRYPT}$2b$12$...` (bcrypt)
+- `dovecot` and `postfix` are active; ports 143/993 listen
+- `include.php` points at `/usr/local/lscp/cyberpanel/snappymail/data/` (not rainloop)
+- Successful IMAP logins from `::1` prove SnappyMail can reach Dovecot
+
+## Operator fix
+
+Reset the mailbox password (panel UI or CLI), then retest:
+
+```bash
+cyberpanel changeEmailPassword --email user@example.com --password 'NEW_PASS'
+doveadm auth test user@example.com 'NEW_PASS'
+```
+
+## Secondary cleanup (upgrade hardening)
+
+RainLoop to SnappyMail migration can leave both `domains/<name>.ini` and `domains/<name>.json`. SnappyMail prefers `.json` (localhost:143 STARTTLS). Conflicting `.ini` (often 993/TLS) is removed on upgrade/fix when a sibling `.json` exists (backed up under `domains.bak/`).
+
+Implemented in:
+
+- `scripts/utils/fix-snappymail.sh`
+- `upgrade_modules/10_post_tweak.sh`

--- a/upgrade_modules/10_post_tweak.sh
+++ b/upgrade_modules/10_post_tweak.sh
@@ -343,6 +343,25 @@ else
     echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] WARNING: lscpd user not found, skipping ownership change" | tee -a /var/log/cyberpanel_upgrade_debug.log
 fi
 
+# Remove leftover RainLoop-era domain .ini when a matching .json exists.
+# Dual configs confuse operators; SnappyMail prefers .json (localhost:143 STARTTLS).
+DOMAINS_DIR="/usr/local/lscp/cyberpanel/snappymail/data/_data_/_default_/domains"
+DOMAINS_BAK="/usr/local/lscp/cyberpanel/snappymail/data/_data_/_default_/domains.bak"
+if [ -d "$DOMAINS_DIR" ]; then
+    mkdir -p "$DOMAINS_BAK"
+    ts="$(date +%Y%m%d-%H%M%S)"
+    for jsonf in "$DOMAINS_DIR"/*.json; do
+        [ -f "$jsonf" ] || continue
+        base="$(basename "$jsonf" .json)"
+        inif="$DOMAINS_DIR/${base}.ini"
+        if [ -f "$inif" ]; then
+            cp -a "$inif" "$DOMAINS_BAK/${base}.ini.$ts"
+            rm -f "$inif"
+            echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Removed conflicting SnappyMail domain .ini (backed up): ${base}.ini" | tee -a /var/log/cyberpanel_upgrade_debug.log
+        fi
+    done
+fi
+
 # Ensure /rainloop→/snappymail redirect exists (even when no migration ran)
 HTACCESS="/usr/local/CyberCP/public/.htaccess"
 if [ -d "/usr/local/CyberCP/public" ] && { [ ! -f "$HTACCESS" ] || ! grep -q "Redirect old RainLoop URL to SnappyMail" "$HTACCESS" 2>/dev/null; }; then


### PR DESCRIPTION
Remove leftover domains/*.ini when a sibling .json exists so IMAP settings stay consistent after RainLoop to SnappyMail migration.