### PR TITLE
fix(ui): restore dark overview bars and speed theme toggle

### DIFF
--- a/baseTemplate/static/baseTemplate/css/cyberpanel-dark.css
+++ b/baseTemplate/static/baseTemplate/css/cyberpanel-dark.css
@@ -650,7 +650,19 @@
 [data-theme="dark"] #main-content .pricing-section { border-color: var(--border-color) !important; }
 [data-theme="dark"] #main-content .process-icon { background: var(--bg-secondary) !important; }
 [data-theme="dark"] #main-content .progress { background: var(--bg-muted) !important; }
-[data-theme="dark"] #main-content .progress-bar { background: var(--bg-muted) !important; }
+/* Track stays muted; fill keeps status colors */
+[data-theme="dark"] #main-content .progress-bar {
+  background: var(--accent-color, #5b5fcf) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-ok {
+  background: var(--bar-ok) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-warn {
+  background: var(--bar-warn) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-crit {
+  background: var(--bar-crit) !important;
+}
 [data-theme="dark"] #main-content .progress-bar-container { background: var(--bg-muted) !important; }
 [data-theme="dark"] #main-content .progress-bar-wrapper { background: var(--bg-muted) !important; }
 [data-theme="dark"] #main-content .progress-info { background: var(--warn-soft-bg) !important; border-color: var(--border-color) !important; }

--- a/baseTemplate/static/baseTemplate/css/cyberpanel-ui.css
+++ b/baseTemplate/static/baseTemplate/css/cyberpanel-ui.css
@@ -96,7 +96,16 @@
             color: var(--text-primary);
             overflow-x: hidden;
             min-height: 100vh;
-            transition: background-color 0.3s ease, color 0.3s ease;
+            transition: background-color 0.12s ease, color 0.12s ease;
+        }
+
+        /* Instant theme flips: skip animating shell colors while data-theme changes */
+        html.cp-theme-switching,
+        html.cp-theme-switching *,
+        html.cp-theme-switching *::before,
+        html.cp-theme-switching *::after {
+            transition: none !important;
+            animation: none !important;
         }
         
         /* Header */
@@ -112,7 +121,7 @@
             left: 260px;
             right: 0;
             z-index: 1000;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.12s ease;
         }
         
         #header .logo {
@@ -257,7 +266,7 @@
             top: 0;
             overflow-y: auto;
             z-index: 1001;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.12s ease;
         }
         
         .sidebar-logo {

--- a/baseTemplate/static/baseTemplate/custom-js/cyberpanel-theme.js
+++ b/baseTemplate/static/baseTemplate/custom-js/cyberpanel-theme.js
@@ -1,8 +1,12 @@
 /**
  * CyberPanel theme toggle (v2.4.8+ shell). Syncs data-theme, helper classes, and shell repaint.
+ * Theme flips disable CSS transitions for one paint so the huge dark stylesheet does not animate.
  */
 (function (global) {
     'use strict';
+
+    var switchingTimer = null;
+    var isSwitching = false;
 
     function normalizeTheme(value) {
         return value === 'dark' ? 'dark' : 'light';
@@ -16,24 +20,56 @@
         }
     }
 
-    function repaintShell() {
+    function clearShellInlineStyles() {
         var sidebar = global.document.getElementById('sidebar');
         var header = global.document.getElementById('header');
         if (sidebar) {
             sidebar.style.removeProperty('background-color');
             sidebar.style.removeProperty('background');
-            void sidebar.offsetHeight;
         }
         if (header) {
             header.style.removeProperty('background-color');
-            void header.offsetHeight;
         }
+    }
+
+    function endThemeSwitching(root) {
+        if (switchingTimer) {
+            global.clearTimeout(switchingTimer);
+            switchingTimer = null;
+        }
+        root.classList.remove('cp-theme-switching');
+        isSwitching = false;
+    }
+
+    function beginThemeSwitching(root) {
+        isSwitching = true;
+        root.classList.add('cp-theme-switching');
+        if (switchingTimer) {
+            global.clearTimeout(switchingTimer);
+        }
+        // Keep transitions off until after the browser paints the new theme.
+        global.requestAnimationFrame(function () {
+            global.requestAnimationFrame(function () {
+                endThemeSwitching(root);
+            });
+        });
+        // Fallback if rAF is delayed/throttled in background tabs.
+        switchingTimer = global.setTimeout(function () {
+            endThemeSwitching(root);
+        }, 120);
     }
 
     function applyTheme(theme, options) {
         options = options || {};
         theme = normalizeTheme(theme);
         var root = global.document.documentElement;
+        var current = normalizeTheme(root.getAttribute('data-theme'));
+        var themeChanged = current !== theme;
+
+        if (themeChanged && !options.skipSwitchGuard) {
+            beginThemeSwitching(root);
+        }
+
         root.setAttribute('data-theme', theme);
         root.classList.toggle('cp-theme-dark', theme === 'dark');
         root.classList.toggle('cp-theme-light', theme === 'light');
@@ -46,7 +82,8 @@
         }
 
         if (!options.skipRepaint) {
-            repaintShell();
+            // Clear stale inline backgrounds without forced layout thrashing.
+            clearShellInlineStyles();
         }
 
         var icon = global.document.getElementById('theme-icon');
@@ -68,13 +105,16 @@
     }
 
     function toggleTheme() {
+        if (isSwitching) {
+            return normalizeTheme(global.document.documentElement.getAttribute('data-theme'));
+        }
         var current = global.document.documentElement.getAttribute('data-theme');
         var next = normalizeTheme(current) === 'dark' ? 'light' : 'dark';
         return applyTheme(next);
     }
 
     function initThemeToggle() {
-        applyTheme(readStoredTheme(), { skipStore: true, silent: true });
+        applyTheme(readStoredTheme(), { skipStore: true, silent: true, skipSwitchGuard: true });
         var toggle = global.document.getElementById('theme-toggle');
         if (toggle && toggle.getAttribute('data-cp-theme-bound') !== '1') {
             toggle.setAttribute('data-cp-theme-bound', '1');

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -55,7 +55,7 @@
     <script src="{% static 'baseTemplate/vendor/select2/select2.full.min.js' %}?v={{ CP_VERSION }}" data-cfasync="false"></script>
     
     <!-- Modern Design System -->
-    <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-ui.css' %}?v={{ CP_VERSION }}">
+    <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-ui.css' %}?v={{ CP_VERSION }}&ui=2">
     <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-tokens.css' %}?v={{ CP_VERSION }}">
 
     {% block header_scripts %}{% endblock %}
@@ -868,7 +868,7 @@
             }
         };
     </script>
-<script src="{% static 'baseTemplate/custom-js/cyberpanel-theme.js' %}?v={{ CP_VERSION }}"></script>
+<script src="{% static 'baseTemplate/custom-js/cyberpanel-theme.js' %}?v={{ CP_VERSION }}&theme=2" data-cfasync="false"></script>
 
     {% block footer_scripts %}{% endblock %}
 </body>

--- a/public/static/baseTemplate/css/cyberpanel-dark.css
+++ b/public/static/baseTemplate/css/cyberpanel-dark.css
@@ -650,7 +650,19 @@
 [data-theme="dark"] #main-content .pricing-section { border-color: var(--border-color) !important; }
 [data-theme="dark"] #main-content .process-icon { background: var(--bg-secondary) !important; }
 [data-theme="dark"] #main-content .progress { background: var(--bg-muted) !important; }
-[data-theme="dark"] #main-content .progress-bar { background: var(--bg-muted) !important; }
+/* Track stays muted; fill keeps status colors */
+[data-theme="dark"] #main-content .progress-bar {
+  background: var(--accent-color, #5b5fcf) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-ok {
+  background: var(--bar-ok) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-warn {
+  background: var(--bar-warn) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-crit {
+  background: var(--bar-crit) !important;
+}
 [data-theme="dark"] #main-content .progress-bar-container { background: var(--bg-muted) !important; }
 [data-theme="dark"] #main-content .progress-bar-wrapper { background: var(--bg-muted) !important; }
 [data-theme="dark"] #main-content .progress-info { background: var(--warn-soft-bg) !important; border-color: var(--border-color) !important; }

--- a/public/static/baseTemplate/css/cyberpanel-ui.css
+++ b/public/static/baseTemplate/css/cyberpanel-ui.css
@@ -96,7 +96,16 @@
             color: var(--text-primary);
             overflow-x: hidden;
             min-height: 100vh;
-            transition: background-color 0.3s ease, color 0.3s ease;
+            transition: background-color 0.12s ease, color 0.12s ease;
+        }
+
+        /* Instant theme flips: skip animating shell colors while data-theme changes */
+        html.cp-theme-switching,
+        html.cp-theme-switching *,
+        html.cp-theme-switching *::before,
+        html.cp-theme-switching *::after {
+            transition: none !important;
+            animation: none !important;
         }
         
         /* Header */
@@ -112,7 +121,7 @@
             left: 260px;
             right: 0;
             z-index: 1000;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.12s ease;
         }
         
         #header .logo {
@@ -257,7 +266,7 @@
             top: 0;
             overflow-y: auto;
             z-index: 1001;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.12s ease;
         }
         
         .sidebar-logo {

--- a/public/static/baseTemplate/custom-js/cyberpanel-theme.js
+++ b/public/static/baseTemplate/custom-js/cyberpanel-theme.js
@@ -1,8 +1,12 @@
 /**
  * CyberPanel theme toggle (v2.4.8+ shell). Syncs data-theme, helper classes, and shell repaint.
+ * Theme flips disable CSS transitions for one paint so the huge dark stylesheet does not animate.
  */
 (function (global) {
     'use strict';
+
+    var switchingTimer = null;
+    var isSwitching = false;
 
     function normalizeTheme(value) {
         return value === 'dark' ? 'dark' : 'light';
@@ -16,24 +20,56 @@
         }
     }
 
-    function repaintShell() {
+    function clearShellInlineStyles() {
         var sidebar = global.document.getElementById('sidebar');
         var header = global.document.getElementById('header');
         if (sidebar) {
             sidebar.style.removeProperty('background-color');
             sidebar.style.removeProperty('background');
-            void sidebar.offsetHeight;
         }
         if (header) {
             header.style.removeProperty('background-color');
-            void header.offsetHeight;
         }
+    }
+
+    function endThemeSwitching(root) {
+        if (switchingTimer) {
+            global.clearTimeout(switchingTimer);
+            switchingTimer = null;
+        }
+        root.classList.remove('cp-theme-switching');
+        isSwitching = false;
+    }
+
+    function beginThemeSwitching(root) {
+        isSwitching = true;
+        root.classList.add('cp-theme-switching');
+        if (switchingTimer) {
+            global.clearTimeout(switchingTimer);
+        }
+        // Keep transitions off until after the browser paints the new theme.
+        global.requestAnimationFrame(function () {
+            global.requestAnimationFrame(function () {
+                endThemeSwitching(root);
+            });
+        });
+        // Fallback if rAF is delayed/throttled in background tabs.
+        switchingTimer = global.setTimeout(function () {
+            endThemeSwitching(root);
+        }, 120);
     }
 
     function applyTheme(theme, options) {
         options = options || {};
         theme = normalizeTheme(theme);
         var root = global.document.documentElement;
+        var current = normalizeTheme(root.getAttribute('data-theme'));
+        var themeChanged = current !== theme;
+
+        if (themeChanged && !options.skipSwitchGuard) {
+            beginThemeSwitching(root);
+        }
+
         root.setAttribute('data-theme', theme);
         root.classList.toggle('cp-theme-dark', theme === 'dark');
         root.classList.toggle('cp-theme-light', theme === 'light');
@@ -46,7 +82,8 @@
         }
 
         if (!options.skipRepaint) {
-            repaintShell();
+            // Clear stale inline backgrounds without forced layout thrashing.
+            clearShellInlineStyles();
         }
 
         var icon = global.document.getElementById('theme-icon');
@@ -68,13 +105,16 @@
     }
 
     function toggleTheme() {
+        if (isSwitching) {
+            return normalizeTheme(global.document.documentElement.getAttribute('data-theme'));
+        }
         var current = global.document.documentElement.getAttribute('data-theme');
         var next = normalizeTheme(current) === 'dark' ? 'light' : 'dark';
         return applyTheme(next);
     }
 
     function initThemeToggle() {
-        applyTheme(readStoredTheme(), { skipStore: true, silent: true });
+        applyTheme(readStoredTheme(), { skipStore: true, silent: true, skipSwitchGuard: true });
         var toggle = global.document.getElementById('theme-toggle');
         if (toggle && toggle.getAttribute('data-cp-theme-bound') !== '1') {
             toggle.setAttribute('data-cp-theme-bound', '1');

--- a/static/baseTemplate/css/cyberpanel-dark.css
+++ b/static/baseTemplate/css/cyberpanel-dark.css
@@ -650,7 +650,19 @@
 [data-theme="dark"] #main-content .pricing-section { border-color: var(--border-color) !important; }
 [data-theme="dark"] #main-content .process-icon { background: var(--bg-secondary) !important; }
 [data-theme="dark"] #main-content .progress { background: var(--bg-muted) !important; }
-[data-theme="dark"] #main-content .progress-bar { background: var(--bg-muted) !important; }
+/* Track stays muted; fill keeps status colors */
+[data-theme="dark"] #main-content .progress-bar {
+  background: var(--accent-color, #5b5fcf) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-ok {
+  background: var(--bar-ok) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-warn {
+  background: var(--bar-warn) !important;
+}
+[data-theme="dark"] #main-content .progress-bar.bar-crit {
+  background: var(--bar-crit) !important;
+}
 [data-theme="dark"] #main-content .progress-bar-container { background: var(--bg-muted) !important; }
 [data-theme="dark"] #main-content .progress-bar-wrapper { background: var(--bg-muted) !important; }
 [data-theme="dark"] #main-content .progress-info { background: var(--warn-soft-bg) !important; border-color: var(--border-color) !important; }

--- a/static/baseTemplate/css/cyberpanel-ui.css
+++ b/static/baseTemplate/css/cyberpanel-ui.css
@@ -96,7 +96,16 @@
             color: var(--text-primary);
             overflow-x: hidden;
             min-height: 100vh;
-            transition: background-color 0.3s ease, color 0.3s ease;
+            transition: background-color 0.12s ease, color 0.12s ease;
+        }
+
+        /* Instant theme flips: skip animating shell colors while data-theme changes */
+        html.cp-theme-switching,
+        html.cp-theme-switching *,
+        html.cp-theme-switching *::before,
+        html.cp-theme-switching *::after {
+            transition: none !important;
+            animation: none !important;
         }
         
         /* Header */
@@ -112,7 +121,7 @@
             left: 260px;
             right: 0;
             z-index: 1000;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.12s ease;
         }
         
         #header .logo {
@@ -257,7 +266,7 @@
             top: 0;
             overflow-y: auto;
             z-index: 1001;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.12s ease;
         }
         
         .sidebar-logo {

--- a/static/baseTemplate/custom-js/cyberpanel-theme.js
+++ b/static/baseTemplate/custom-js/cyberpanel-theme.js
@@ -1,8 +1,12 @@
 /**
  * CyberPanel theme toggle (v2.4.8+ shell). Syncs data-theme, helper classes, and shell repaint.
+ * Theme flips disable CSS transitions for one paint so the huge dark stylesheet does not animate.
  */
 (function (global) {
     'use strict';
+
+    var switchingTimer = null;
+    var isSwitching = false;
 
     function normalizeTheme(value) {
         return value === 'dark' ? 'dark' : 'light';
@@ -16,24 +20,56 @@
         }
     }
 
-    function repaintShell() {
+    function clearShellInlineStyles() {
         var sidebar = global.document.getElementById('sidebar');
         var header = global.document.getElementById('header');
         if (sidebar) {
             sidebar.style.removeProperty('background-color');
             sidebar.style.removeProperty('background');
-            void sidebar.offsetHeight;
         }
         if (header) {
             header.style.removeProperty('background-color');
-            void header.offsetHeight;
         }
+    }
+
+    function endThemeSwitching(root) {
+        if (switchingTimer) {
+            global.clearTimeout(switchingTimer);
+            switchingTimer = null;
+        }
+        root.classList.remove('cp-theme-switching');
+        isSwitching = false;
+    }
+
+    function beginThemeSwitching(root) {
+        isSwitching = true;
+        root.classList.add('cp-theme-switching');
+        if (switchingTimer) {
+            global.clearTimeout(switchingTimer);
+        }
+        // Keep transitions off until after the browser paints the new theme.
+        global.requestAnimationFrame(function () {
+            global.requestAnimationFrame(function () {
+                endThemeSwitching(root);
+            });
+        });
+        // Fallback if rAF is delayed/throttled in background tabs.
+        switchingTimer = global.setTimeout(function () {
+            endThemeSwitching(root);
+        }, 120);
     }
 
     function applyTheme(theme, options) {
         options = options || {};
         theme = normalizeTheme(theme);
         var root = global.document.documentElement;
+        var current = normalizeTheme(root.getAttribute('data-theme'));
+        var themeChanged = current !== theme;
+
+        if (themeChanged && !options.skipSwitchGuard) {
+            beginThemeSwitching(root);
+        }
+
         root.setAttribute('data-theme', theme);
         root.classList.toggle('cp-theme-dark', theme === 'dark');
         root.classList.toggle('cp-theme-light', theme === 'light');
@@ -46,7 +82,8 @@
         }
 
         if (!options.skipRepaint) {
-            repaintShell();
+            // Clear stale inline backgrounds without forced layout thrashing.
+            clearShellInlineStyles();
         }
 
         var icon = global.document.getElementById('theme-icon');
@@ -68,13 +105,16 @@
     }
 
     function toggleTheme() {
+        if (isSwitching) {
+            return normalizeTheme(global.document.documentElement.getAttribute('data-theme'));
+        }
         var current = global.document.documentElement.getAttribute('data-theme');
         var next = normalizeTheme(current) === 'dark' ? 'light' : 'dark';
         return applyTheme(next);
     }
 
     function initThemeToggle() {
-        applyTheme(readStoredTheme(), { skipStore: true, silent: true });
+        applyTheme(readStoredTheme(), { skipStore: true, silent: true, skipSwitchGuard: true });
         var toggle = global.document.getElementById('theme-toggle');
         if (toggle && toggle.getAttribute('data-cp-theme-bound') !== '1') {
             toggle.setAttribute('data-cp-theme-bound', '1');


### PR DESCRIPTION
Dark theme was painting progress fills the same muted color as the track. Theme switching also forced layout thrash and long color transitions; disable transitions for one paint and drop offsetHeight reflows.