### PR TITLE
fix(mail,upgrade): sieve guard + upgrade reliability from stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ continuously updated changelog also lives at
 https://cyberpanel.net/KnowledgeBase/home/change-logs/
 
 ## Unreleased
+### Build metadata
+- `version.txt` and panel `BUILD` advanced to **2.5.5 build 1** (still the 2.5.5-dev line; not a 2.4.9 backport of release notes).
+
+### Mail: sieve install-first guard (#1733)
+- Keep sieve when pigeonhole is present; try installing OS packages when missing;
+  strip `sieve`/`managesieve` from `dovecot.conf` only if install fails; always
+  verify Dovecot/Postfix afterward (`plogical/sieveGuard.py`).
+
+### Upgrade reliability (#1727, #1853)
+- Modular upgrade no longer hardcodes `/usr/bin/php` to lsphp74; picks an installed
+  lsphp (prefer 8.3+). `install.py` uses `os.path.lexists` so broken symlinks are replaced.
+- Modular upgrade records `UPGRADE_FAILED` from real `upgrade.py`/`PIPESTATUS` and
+  refuses to print a success banner when the Python upgrade failed.
+
 ### Fix: show full PHP patch on List Websites
 - List Websites now shows the live runtime version (e.g. `PHP 8.5.7`) from the
   site's `lsphp` binary, not only the selector label (`PHP 8.5`).

--- a/Test/test_sieve_guard.py
+++ b/Test/test_sieve_guard.py
@@ -1,0 +1,63 @@
+#!/usr/local/CyberCP/bin/python
+# -*- coding: utf-8 -*-
+"""Unit tests for plogical.sieveGuard (no live Dovecot required)."""
+from __future__ import print_function
+
+import os
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from plogical import sieveGuard
+
+
+class SieveGuardStripTests(unittest.TestCase):
+    def test_strip_sieve_and_managesieve_tokens(self):
+        conf = (
+            "protocols = imap pop3 sieve managesieve\n"
+            "protocol lda {\n"
+            "  mail_plugins = zlib sieve\n"
+            "}\n"
+            "ssl = yes\n"
+        )
+        path = None
+        try:
+            fd, path = tempfile.mkstemp(prefix='dovecot-sieve-', suffix='.conf')
+            os.close(fd)
+            with open(path, 'w') as fh:
+                fh.write(conf)
+            changed = sieveGuard.strip_sieve_from_dovecot_conf(conf_path=path, writer=None)
+            self.assertTrue(changed)
+            with open(path, 'r') as fh:
+                out = fh.read()
+            self.assertIn('protocols = imap pop3', out)
+            self.assertNotIn('sieve', out.split('protocols', 1)[1].split('\n', 1)[0])
+            self.assertIn('mail_plugins = zlib', out)
+            self.assertIn('ssl = yes', out)
+        finally:
+            if path and os.path.exists(path):
+                os.unlink(path)
+
+    def test_no_change_when_sieve_absent(self):
+        conf = "protocols = imap pop3\nmail_plugins = zlib\n"
+        path = None
+        try:
+            fd, path = tempfile.mkstemp(prefix='dovecot-nosieve-', suffix='.conf')
+            os.close(fd)
+            with open(path, 'w') as fh:
+                fh.write(conf)
+            changed = sieveGuard.strip_sieve_from_dovecot_conf(conf_path=path, writer=None)
+            self.assertFalse(changed)
+            with open(path, 'r') as fh:
+                self.assertEqual(fh.read(), conf)
+        finally:
+            if path and os.path.exists(path):
+                os.unlink(path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/baseTemplate/views.py
+++ b/baseTemplate/views.py
@@ -31,7 +31,7 @@ import re
 # Create your views here.
 
 VERSION = '2.5.5'
-BUILD = 'dev'
+BUILD = 1
 
 
 def _version_compare(a, b):

--- a/install/install.py
+++ b/install/install.py
@@ -27,7 +27,7 @@ import secrets
 import install_utils
 
 VERSION = '2.5.5'
-BUILD = 'dev'
+BUILD = 1
 
 # Using shared char_set from install_utils
 char_set = install_utils.char_set
@@ -4775,6 +4775,22 @@ user_query = SELECT email as user, password, 'vmail' as uid, 'vmail' as gid, '/h
             command = 'chmod o= /etc/dovecot/dovecot-sql.conf.ext'
             preFlightsChecks.call(command, self.distro, command, command, 1, 0, os.EX_OSERR)
 
+            ## Keep sieve when possible: try installing pigeonhole first; strip
+            ## only if still missing so Dovecot can start. (#1733)
+            try:
+                _cp_root = getattr(self, 'cyberPanelPath', None) or '/usr/local/CyberCP'
+                if _cp_root not in sys.path:
+                    sys.path.insert(0, _cp_root)
+                from plogical.sieveGuard import ensure_sieve_or_strip
+                ensure_sieve_or_strip(
+                    conf_path=dovecot,
+                    writer=logging.InstallLog.writeToFile,
+                    verify=True,
+                )
+            except BaseException as sieveMsg:
+                logging.InstallLog.writeToFile(
+                    '[ERROR] sieveGuard failed: ' + str(sieveMsg))
+
             ################################### Restart dovecot
 
             self.manage_service('dovecot', 'enable')
@@ -6114,8 +6130,10 @@ milter_default_action = accept
                 
                 preFlightsChecks.call(command, self.distro, command, command, 1, 0, os.EX_OSERR)
             
-            # Remove existing PHP symlink if it exists
-            if os.path.exists('/usr/bin/php'):
+            # Remove existing PHP symlink if it exists (lexists also catches a
+            # broken symlink, which os.path.exists misses; otherwise the ln below
+            # would fail with "File exists" and leave /usr/bin/php broken). (#1727)
+            if os.path.lexists('/usr/bin/php'):
                 os.remove('/usr/bin/php')
 
             # Create symlink to the best available PHP version

--- a/mailServer/mailserverManager.py
+++ b/mailServer/mailserverManager.py
@@ -1458,6 +1458,20 @@ class MailServerManager(multi.Thread):
             command = 'chmod o= /etc/dovecot/dovecot-sql.conf.ext'
             ProcessUtilities.executioner(command)
 
+            ## Keep sieve when possible: try installing pigeonhole first; strip
+            ## sieve/managesieve from dovecot.conf only if the module is still
+            ## missing so Dovecot can start. Always verify mail afterward. (#1733)
+            try:
+                from plogical.sieveGuard import ensure_sieve_or_strip
+                ensure_sieve_or_strip(
+                    conf_path=dovecot,
+                    writer=logging.CyberCPLogFileWriter.writeToFile,
+                    verify=True,
+                )
+            except BaseException as sieveMsg:
+                logging.CyberCPLogFileWriter.writeToFile(
+                    "sieveGuard failed: %s [setup_postfix_dovecot_config]" % str(sieveMsg))
+
             ################################### Restart dovecot
 
             command = 'systemctl enable dovecot.service'

--- a/plogical/mailUtilities.py
+++ b/plogical/mailUtilities.py
@@ -2455,6 +2455,20 @@ class MailServerManagerUtils(multi.Thread):
             command = 'chmod o= /etc/dovecot/dovecot-sql.conf.ext'
             ProcessUtilities.executioner(command)
 
+            ## Keep sieve when possible: try installing pigeonhole first; strip
+            ## sieve/managesieve from dovecot.conf only if the module is still
+            ## missing so Dovecot can start. Always verify mail afterward. (#1733)
+            try:
+                from plogical.sieveGuard import ensure_sieve_or_strip
+                ensure_sieve_or_strip(
+                    conf_path=dovecot,
+                    writer=logging.CyberCPLogFileWriter.writeToFile,
+                    verify=True,
+                )
+            except BaseException as sieveMsg:
+                logging.CyberCPLogFileWriter.writeToFile(
+                    "sieveGuard failed: %s [setup_postfix_dovecot_config]" % str(sieveMsg))
+
             ################################### Restart dovecot
 
             command = 'systemctl enable dovecot.service'
@@ -2852,11 +2866,12 @@ class MailServerManagerUtils(multi.Thread):
                 writeToFile.write('nameserver 8.8.8.8\n')
                 writeToFile.close()
 
-                command = 'systemctl restart postfix'
-                ProcessUtilities.executioner(command)
+            ## Always restart mail services at end of reset so new config takes effect. (#1733)
+            command = 'systemctl restart postfix'
+            ProcessUtilities.executioner(command)
 
-                command = 'doveadm reload'
-                ProcessUtilities.executioner(command)
+            command = 'systemctl restart dovecot'
+            ProcessUtilities.executioner(command)
 
             logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'], 'Completed [200].')
 

--- a/plogical/sieveGuard.py
+++ b/plogical/sieveGuard.py
@@ -1,0 +1,227 @@
+#!/usr/local/CyberCP/bin/python
+# -*- coding: utf-8 -*-
+"""
+Ensure Dovecot sieve (pigeonhole) is usable when possible (#1733).
+
+Policy for CyberPanel v2.5.5-dev:
+  1. Keep sieve enabled when the module is present or can be installed.
+  2. Try to install OS packages that provide sieve before stripping.
+  3. Strip sieve/managesieve from dovecot.conf only if the module is still absent.
+  4. Always verify Dovecot (and ideally Postfix) still run after changes.
+"""
+from __future__ import print_function
+
+import os
+import shutil
+
+SIEVE_MODULE_DIRS = (
+    '/usr/lib/dovecot/modules',
+    '/usr/lib64/dovecot/modules',
+    '/usr/lib/dovecot',
+    '/usr/lib64/dovecot',
+)
+
+DOVECOT_CONF = '/etc/dovecot/dovecot.conf'
+
+
+def _log(msg, writer=None):
+    text = '[sieveGuard] %s' % (msg,)
+    if writer is not None:
+        try:
+            writer(text)
+            return
+        except Exception:
+            pass
+    try:
+        from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as logging
+        logging.writeToFile(text)
+    except Exception:
+        try:
+            print(text)
+        except Exception:
+            pass
+
+
+def sieve_module_available():
+    """Return True if a sieve-related Dovecot module file is present."""
+    for mod_dir in SIEVE_MODULE_DIRS:
+        try:
+            if not os.path.isdir(mod_dir):
+                continue
+            for fn in os.listdir(mod_dir):
+                if 'sieve' in fn.lower():
+                    return True
+        except Exception:
+            continue
+    return False
+
+
+def _decide_distro():
+    try:
+        from plogical.processUtilities import ProcessUtilities
+        return ProcessUtilities.decideDistro()
+    except Exception:
+        pass
+    if os.path.exists('/etc/os-release'):
+        data = open('/etc/os-release', 'r').read().lower()
+        if 'ubuntu' in data or 'debian' in data:
+            return 'ubuntu'
+    return 'centos'
+
+
+def try_install_sieve_packages(writer=None):
+    """
+    Attempt to install pigeonhole/sieve packages for the current OS.
+    Returns True if sieve becomes available after the attempt (or already was).
+    """
+    if sieve_module_available():
+        return True
+
+    try:
+        from plogical.processUtilities import ProcessUtilities
+    except Exception as msg:
+        _log('Cannot import ProcessUtilities for package install: %s' % (msg,), writer)
+        return False
+
+    distro = _decide_distro()
+    commands = []
+
+    # Ubuntu/Debian package names
+    if distro in (getattr(ProcessUtilities, 'ubuntu', 'ubuntu'),
+                  getattr(ProcessUtilities, 'ubuntu20', 'ubuntu20'),
+                  'ubuntu'):
+        commands = [
+            'DEBIAN_FRONTEND=noninteractive apt-get update -y',
+            'DEBIAN_FRONTEND=noninteractive apt-get -y install dovecot-sieve dovecot-managesieved',
+        ]
+    else:
+        # RHEL/Alma/Rocky/CloudLinux: try pigeonhole packages for dovecot / dovecot23
+        commands = [
+            'dnf -y install dovecot-pigeonhole 2>/dev/null || yum -y install dovecot-pigeonhole 2>/dev/null || '
+            'dnf -y install dovecot23-pigeonhole 2>/dev/null || yum -y install dovecot23-pigeonhole 2>/dev/null || true',
+        ]
+
+    _log('Sieve module missing; attempting package install...', writer)
+    for command in commands:
+        try:
+            ProcessUtilities.executioner(command)
+        except Exception as msg:
+            _log('Package install command failed: %s (%s)' % (command, msg), writer)
+
+    available = sieve_module_available()
+    if available:
+        _log('Sieve module is available after install attempt.', writer)
+    else:
+        _log('Sieve module still unavailable after install attempt.', writer)
+    return available
+
+
+def strip_sieve_from_dovecot_conf(conf_path=DOVECOT_CONF, writer=None):
+    """Remove sieve/managesieve tokens from protocols and mail_plugins lines."""
+    if not os.path.exists(conf_path):
+        return False
+    try:
+        with open(conf_path, 'r') as fh:
+            conf_lines = fh.readlines()
+        changed = False
+        with open(conf_path, 'w') as fh:
+            for conf_line in conf_lines:
+                key = conf_line.split('=', 1)[0].strip()
+                if key in ('protocols', 'mail_plugins') and 'sieve' in conf_line:
+                    prefix, _, rhs = conf_line.partition('=')
+                    tokens = [t for t in rhs.split() if t not in ('sieve', 'managesieve')]
+                    conf_line = '%s= %s\n' % (prefix, ' '.join(tokens))
+                    changed = True
+                fh.write(conf_line)
+        if changed:
+            _log('Removed sieve/managesieve from %s so Dovecot can start.' % (conf_path,), writer)
+        return changed
+    except Exception as msg:
+        _log('Could not strip sieve from %s: %s' % (conf_path, msg), writer)
+        return False
+
+
+def verify_mail_services(writer=None):
+    """
+    Enable and restart dovecot/postfix, then confirm dovecot is active.
+    Returns True if dovecot appears active (or doveconf succeeds as a soft fallback).
+    """
+    try:
+        from plogical.processUtilities import ProcessUtilities
+    except Exception as msg:
+        _log('Cannot verify mail services: %s' % (msg,), writer)
+        return False
+
+    for svc in ('dovecot', 'postfix'):
+        try:
+            ProcessUtilities.executioner('systemctl enable %s' % (svc,))
+        except Exception:
+            pass
+
+    try:
+        ProcessUtilities.executioner('systemctl restart dovecot')
+    except Exception as msg:
+        _log('dovecot restart failed: %s' % (msg,), writer)
+
+    try:
+        ProcessUtilities.executioner('systemctl restart postfix')
+    except Exception as msg:
+        _log('postfix restart failed: %s' % (msg,), writer)
+
+    active = False
+    try:
+        out = ProcessUtilities.outputExecutioner('systemctl is-active dovecot')
+        if isinstance(out, (list, tuple)):
+            out = out[-1] if out else ''
+        active = str(out).strip() == 'active'
+    except Exception:
+        active = False
+
+    if not active:
+        # Soft fallback: config parse
+        try:
+            if shutil.which('doveconf'):
+                rc = ProcessUtilities.executioner('doveconf -n >/dev/null 2>&1')
+                active = (rc == 1)  # ProcessUtilities often returns 1 on success
+        except Exception:
+            pass
+
+    if active:
+        _log('Mail verification: dovecot is active after sieve guard.', writer)
+    else:
+        _log('Mail verification WARNING: dovecot may not be active; check journalctl -u dovecot.', writer)
+    return active
+
+
+def ensure_sieve_or_strip(conf_path=DOVECOT_CONF, writer=None, verify=True):
+    """
+    Main entry: keep sieve when possible; install if missing; strip only on failure.
+    Returns dict with keys: sieve_enabled (bool), installed_attempted (bool), stripped (bool), mail_ok (bool|None).
+    """
+    result = {
+        'sieve_enabled': False,
+        'install_attempted': False,
+        'stripped': False,
+        'mail_ok': None,
+    }
+
+    if sieve_module_available():
+        result['sieve_enabled'] = True
+        _log('Sieve module present; leaving dovecot sieve configuration enabled.', writer)
+        if verify:
+            result['mail_ok'] = verify_mail_services(writer=writer)
+        return result
+
+    result['install_attempted'] = True
+    if try_install_sieve_packages(writer=writer):
+        result['sieve_enabled'] = True
+        if verify:
+            result['mail_ok'] = verify_mail_services(writer=writer)
+        return result
+
+    # Install failed or unsupported: strip so Dovecot can start.
+    result['stripped'] = strip_sieve_from_dovecot_conf(conf_path=conf_path, writer=writer)
+    result['sieve_enabled'] = False
+    if verify:
+        result['mail_ok'] = verify_mail_services(writer=writer)
+    return result

--- a/plogical/upgrade.py
+++ b/plogical/upgrade.py
@@ -298,7 +298,7 @@ except ImportError:
     print("Recovery complete. Continuing with upgrade...")
 
 VERSION = '2.5.5'
-BUILD = 'dev'
+BUILD = 1
 
 CENTOS7 = 0
 CENTOS8 = 1

--- a/serverStatus/views.py
+++ b/serverStatus/views.py
@@ -26,7 +26,7 @@ EXPIRE = 3
 ### Version
 
 VERSION = '2.5.5'
-BUILD = 'dev'
+BUILD = 1
 
 
 def serverStatusHome(request):

--- a/upgrade_modules/01_variables.sh
+++ b/upgrade_modules/01_variables.sh
@@ -3,6 +3,10 @@
 # Sourced by cyberpanel_upgrade.sh.
 
 Set_Default_Variables() {
+  # Set to 1 when upgrade.py fails, so the final banner reports the failure instead
+  # of claiming success just because the panel still answers on its port. (#1853)
+  UPGRADE_FAILED=0
+
   echo -e "Clearing old log files..."
   rm -f /var/log/cyberpanel_upgrade_debug.log
   rm -f /var/log/installLogs.txt

--- a/upgrade_modules/08_main_upgrade.sh
+++ b/upgrade_modules/08_main_upgrade.sh
@@ -183,6 +183,7 @@ echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Python upgrade.py returned code: $RETURN
 if [ $RETURN_CODE -eq 0 ]; then
     echo "Upgrade successful."
     echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] First upgrade attempt successful" | tee -a /var/log/cyberpanel_upgrade_debug.log
+    UPGRADE_FAILED=0
 else
     echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] First upgrade attempt failed with code $RETURN_CODE, starting fallback..." | tee -a /var/log/cyberpanel_upgrade_debug.log
 
@@ -234,9 +235,16 @@ fi
 echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Running fallback: /usr/local/CyberPanelTemp/bin/python upgrade.py $Branch_Name" | tee -a /var/log/cyberpanel_upgrade_debug.log
 export CYBERPANEL_GIT_USER="${Git_User:-usmannasir}"
 /usr/local/CyberPanelTemp/bin/python upgrade.py "$Branch_Name" 2>&1 | tee -a /var/log/cyberpanel_upgrade_debug.log
-FALLBACK_CODE=$?
+# upgrade.py is piped into tee, so $? is tee's status (always 0) - read the real
+# exit code of upgrade.py from PIPESTATUS or a failed upgrade looks like a success. (#1853)
+FALLBACK_CODE=${PIPESTATUS[0]}
 echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Fallback upgrade returned code: $FALLBACK_CODE" | tee -a /var/log/cyberpanel_upgrade_debug.log
-Check_Return
+if [ "$FALLBACK_CODE" -ne 0 ]; then
+  UPGRADE_FAILED=1
+  echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] ERROR: Fallback upgrade.py also failed with code $FALLBACK_CODE" | tee -a /var/log/cyberpanel_upgrade_debug.log
+else
+  UPGRADE_FAILED=0
+fi
 
 echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] Removing temporary environment..." | tee -a /var/log/cyberpanel_upgrade_debug.log
 rm -rf /usr/local/CyberPanelTemp

--- a/upgrade_modules/10_post_tweak.sh
+++ b/upgrade_modules/10_post_tweak.sh
@@ -60,8 +60,18 @@ echo "$@" > /etc/cyberpanel/adminPass
 EOF
 chmod 700 /usr/bin/adminPass
 
+# Point /usr/bin/php at an lsphp that is actually installed, preferring the
+# default CLI version (8.3, matching upgrade.py/install.py) and falling back to
+# whatever is present. This block previously hardcoded lsphp74 unconditionally,
+# so on servers without PHP 7.4 it replaced a working symlink with a broken one
+# and `php -v` failed with "command not found". (#1727)
 rm -f /usr/bin/php
-ln -s /usr/local/lsws/lsphp74/bin/php /usr/bin/php
+for _php_ver in 83 84 85 82 81 80 74; do
+  if [ -x "/usr/local/lsws/lsphp${_php_ver}/bin/php" ]; then
+    ln -s "/usr/local/lsws/lsphp${_php_ver}/bin/php" /usr/bin/php
+    break
+  fi
+done
 
 if [[ -f /etc/cyberpanel/webadmin_passwd ]]; then
   chmod 600 /etc/cyberpanel/webadmin_passwd

--- a/upgrade_modules/11_display_final.sh
+++ b/upgrade_modules/11_display_final.sh
@@ -41,6 +41,20 @@ if [[ $Panel_Port = "" ]] ; then
   Panel_Port="8090"
 fi
 
+# A responding panel only proves the old build is still up; it says nothing about
+# whether the new code was applied. Never claim success when upgrade.py failed. (#1853)
+if [[ "${UPGRADE_FAILED:-0}" -ne 0 ]] ; then
+  echo "###################################################################"
+  echo "                CyberPanel UPGRADE FAILED                          "
+  echo "###################################################################"
+  echo -e "\nupgrade.py did not complete, so this server is STILL RUNNING THE OLD BUILD."
+  echo -e "If you were applying a security release, you are NOT patched yet."
+  echo -e "Check /var/log/cyberpanel_upgrade_debug.log for the failure, then re-run the upgrade.\n"
+  rm -rf /root/cyberpanel_upgrade_tmp
+  exit 1
+fi
+
+
 # Resolve server IP for remote access URL (avoid empty Remote: https://:2087)
 if [[ -z "$SERVER_IP" ]]; then
   SERVER_IP=$(hostname -I 2>/dev/null | awk '{print $1}')

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-{"version":"2.5.5","build":"dev"}
+{"version":"2.5.5","build":1}


### PR DESCRIPTION
## Summary
Ports the remaining useful gaps from [`stable` vs `v2.5.5-dev`](https://github.com/usmannasir/cyberpanel/compare/v2.5.5-dev...stable) into the 2.5.5-dev line, without copying 2.4.9 release-only notes.

- **Mail (#1733):** `plogical/sieveGuard.py` keeps sieve when pigeonhole is present; tries to install packages when missing; strips `sieve`/`managesieve` from `dovecot.conf` only if still absent; verifies Dovecot/Postfix. Wired into Email Debugger reset (`mailUtilities`), `mailserverManager`, and `install.py`.
- **Upgrade (#1727):** modular `10_post_tweak.sh` no longer hardcodes `lsphp74` for `/usr/bin/php`; picks an installed lsphp (prefer 8.3+). `install.py` uses `os.path.lexists` so broken symlinks are replaced.
- **Upgrade (#1853):** modular upgrade tracks real `upgrade.py` failure via `PIPESTATUS` / `UPGRADE_FAILED` and does not print a success banner on failure.
- **Build metadata:** `version.txt` and panel `BUILD` set to **2.5.5 build 1** (still the 2.5.5-dev line).

Most v2.4.9 security/reliability items were already on `v2.5.5-dev` via earlier ports (`991b5c28` and related).

## Test plan
- [x] `python -m unittest Test.test_sieve_guard -v`
- [x] `py_compile` on touched Python files
- [x] `bash -n` on touched upgrade modules
- [ ] Fresh install / Email Debugger reset on AlmaLinux 9 without pigeonhole: Dovecot starts
- [ ] Host with pigeonhole: sieve remains enabled
- [ ] Modular upgrade: `/usr/bin/php` points at an existing lsphp; failed `upgrade.py` shows failure banner