### PR TITLE
security: deny sensitive web files by default (#1859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ continuously updated changelog also lives at
 https://cyberpanel.net/KnowledgeBase/home/change-logs/
 
 ## Unreleased
+### Security: default deny for sensitive web files (#1859)
+- New OpenLiteSpeed and LiteSpeed Enterprise / Apache vhost templates block direct
+  HTTP access to `.env`, `.git`, `.htpasswd`, `.user.ini`, and `.htaccess` (403).
+- Existing sites: run `CPScripts/retrofit-sensitive-file-denials.sh` (restarts LSWS).
+- Helper: `vhost.ensureSensitiveFileDenials()` for idempotent injection into OLS configs.
+
 ### Build metadata
 - `version.txt` and panel `BUILD` advanced to **2.5.5 build 1** (still the 2.5.5-dev line; not a 2.4.9 backport of release notes).
 

--- a/CPScripts/retrofit-sensitive-file-denials.sh
+++ b/CPScripts/retrofit-sensitive-file-denials.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Retrofit CyberPanel sensitive-file deny rules (#1859) into existing OLS vhosts.
+# Safe to re-run: skips configs that already contain the BEGIN marker.
+#
+# Usage:
+#   /usr/local/CyberCP/CPScripts/retrofit-sensitive-file-denials.sh
+#   /usr/local/CyberCP/CPScripts/retrofit-sensitive-file-denials.sh --dry-run
+#   /usr/local/CyberCP/CPScripts/retrofit-sensitive-file-denials.sh --no-restart
+
+set -euo pipefail
+
+VHOST_ROOT="${VHOST_ROOT:-/usr/local/lsws/conf/vhosts}"
+DRY_RUN=0
+RESTART=1
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --no-restart) RESTART=0 ;;
+        -h|--help)
+            sed -n '2,12p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -d "$VHOST_ROOT" ]]; then
+    echo "Vhost root not found: $VHOST_ROOT" >&2
+    exit 1
+fi
+
+export VHOST_ROOT
+export CYBERPANEL_SENSITIVE_DENY_DRY_RUN="$DRY_RUN"
+
+python3 - <<'PY'
+import os
+import sys
+
+sys.path.insert(0, '/usr/local/CyberCP')
+from plogical.vhost import vhost
+
+vhost_root = os.environ.get('VHOST_ROOT', '/usr/local/lsws/conf/vhosts')
+dry_run = os.environ.get('CYBERPANEL_SENSITIVE_DENY_DRY_RUN', '0') == '1'
+
+modified = 0
+skipped = 0
+errors = 0
+examined = 0
+
+for name in sorted(os.listdir(vhost_root)):
+    if name in ('Example', 'cyberpanel'):
+        continue
+    vh = os.path.join(vhost_root, name, 'vhost.conf')
+    if not os.path.isfile(vh):
+        continue
+    examined += 1
+    if dry_run:
+        with open(vh, 'r') as fh:
+            content = fh.read()
+        if '# BEGIN CyberPanel sensitive-file denials (#1859)' in content:
+            skipped += 1
+            print('SKIP (already present): %s' % vh)
+        else:
+            modified += 1
+            print('WOULD UPDATE: %s' % vh)
+        continue
+
+    result = vhost.ensureSensitiveFileDenials(vh)
+    if result == 1:
+        modified += 1
+        print('UPDATED: %s' % vh)
+    elif result == 0:
+        skipped += 1
+        print('SKIP: %s' % vh)
+    else:
+        errors += 1
+        print('ERROR: %s' % vh, file=sys.stderr)
+
+print('examined=%s updated=%s skipped=%s errors=%s dry_run=%s' % (
+    examined, modified, skipped, errors, dry_run))
+sys.exit(1 if errors else 0)
+PY
+
+rc=$?
+if [[ $rc -ne 0 ]]; then
+    exit "$rc"
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "Dry run complete; LiteSpeed not restarted."
+    exit 0
+fi
+
+if [[ "$RESTART" -eq 1 ]]; then
+    if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files lsws.service >/dev/null 2>&1; then
+        systemctl restart lsws
+        systemctl is-active --quiet lsws && echo "lsws restarted OK" || {
+            echo "lsws restart reported not-active" >&2
+            exit 1
+        }
+    elif [[ -x /usr/local/lsws/bin/lswsctrl ]]; then
+        /usr/local/lsws/bin/lswsctrl restart
+        echo "lswsctrl restart issued"
+    else
+        echo "Could not find lsws restart method; configs updated but not reloaded." >&2
+        exit 1
+    fi
+else
+    echo "Configs updated; restart skipped (--no-restart)."
+fi

--- a/Test/test_sensitive_file_denials.py
+++ b/Test/test_sensitive_file_denials.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Unit checks for CyberPanel sensitive-file denial helpers (#1859)."""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, '/usr/local/CyberCP')
+
+from plogical.vhostConfs import vhostConfs
+from plogical.vhost import vhost
+
+
+def test_template_contains_rules():
+    for name in ('olsMasterConf', 'olsChildConf', 'lswsMasterConf', 'lswsChildConf'):
+        conf = getattr(vhostConfs, name)
+        assert '# BEGIN CyberPanel sensitive-file denials (#1859)' in conf, name
+        assert r'RewriteRule (^|/)\.env - [F,L]' in conf, name
+        assert r'RewriteRule (^|/)\.git(/|$) - [F,L]' in conf, name
+
+
+def test_ensure_injects_into_bare_rewrite():
+    bare = (
+        'docRoot /tmp\n'
+        'rewrite  {\n'
+        '  enable                  1\n'
+        '  autoLoadHtaccess        1\n'
+        '}\n'
+    )
+    with tempfile.NamedTemporaryFile('w+', delete=False) as fh:
+        path = fh.name
+        fh.write(bare)
+    try:
+        assert vhost.ensureSensitiveFileDenials(path) == 1
+        with open(path) as fh:
+            updated = fh.read()
+        assert '# BEGIN CyberPanel sensitive-file denials (#1859)' in updated
+        assert 'rules                   <<<END_rules' in updated
+        assert vhost.ensureSensitiveFileDenials(path) == 0  # idempotent
+    finally:
+        os.unlink(path)
+
+
+def test_ensure_prepends_existing_rules_block():
+    existing = (
+        'rewrite  {\n'
+        '  enable                  1\n'
+        '  autoLoadHtaccess        1\n'
+        '  rules                   <<<END_rules\n'
+        'RewriteRule ^/foo$ /bar [L]\n'
+        '  END_rules\n'
+        '}\n'
+    )
+    with tempfile.NamedTemporaryFile('w+', delete=False) as fh:
+        path = fh.name
+        fh.write(existing)
+    try:
+        assert vhost.ensureSensitiveFileDenials(path) == 1
+        with open(path) as fh:
+            updated = fh.read()
+        begin = updated.find('# BEGIN CyberPanel sensitive-file denials (#1859)')
+        foo = updated.find('RewriteRule ^/foo$ /bar [L]')
+        assert begin != -1 and foo != -1 and begin < foo
+    finally:
+        os.unlink(path)
+
+
+if __name__ == '__main__':
+    test_template_contains_rules()
+    test_ensure_injects_into_bare_rewrite()
+    test_ensure_prepends_existing_rules_block()
+    print('OK: sensitive-file denial checks passed')

--- a/plogical/vhost.py
+++ b/plogical/vhost.py
@@ -995,6 +995,89 @@ class vhost:
         return 1
 
     @staticmethod
+    def ensureSensitiveFileDenials(vhFile):
+        """
+        Inject CyberPanel default sensitive-file deny rules into an existing
+        OpenLiteSpeed vhost.conf (issue #1859). Idempotent via BEGIN/END markers.
+
+        Returns:
+            1 if the file was modified, 0 if unchanged or not applicable, -1 on error.
+        """
+        begin_marker = '# BEGIN CyberPanel sensitive-file denials (#1859)'
+        deny_block = vhostConfs.olsSensitiveFileDenyRules.rstrip('\n')
+
+        try:
+            if not vhFile or not os.path.exists(vhFile):
+                return 0
+
+            with open(vhFile, 'r') as fh:
+                content = fh.read()
+
+            if begin_marker in content:
+                return 0
+
+            # Prefer inserting at the start of an existing OLS rules heredoc so
+            # denials run before site-specific rewrites (front controllers, etc.).
+            rules_token = 'rules                   <<<END_rules'
+            if rules_token in content:
+                content = content.replace(
+                    rules_token,
+                    rules_token + '\n' + deny_block,
+                    1
+                )
+            else:
+                # Replace a bare rewrite { enable / autoLoadHtaccess } block.
+                bare = (
+                    'rewrite  {\n'
+                    ' enable                  1\n'
+                    '  autoLoadHtaccess        1\n'
+                    '}'
+                )
+                bare_alt = (
+                    'rewrite  {\n'
+                    '  enable                  1\n'
+                    '  autoLoadHtaccess        1\n'
+                    '}'
+                )
+                replacement = (
+                    'rewrite  {\n'
+                    '  enable                  1\n'
+                    '  autoLoadHtaccess        1\n'
+                    '  rules                   <<<END_rules\n'
+                    + deny_block + '\n'
+                    '  END_rules\n'
+                    '}'
+                )
+                if bare in content:
+                    content = content.replace(bare, replacement, 1)
+                elif bare_alt in content:
+                    content = content.replace(bare_alt, replacement, 1)
+                else:
+                    # Append a dedicated rewrite block before vhssl if present.
+                    append_block = (
+                        '\nrewrite  {\n'
+                        '  enable                  1\n'
+                        '  autoLoadHtaccess        1\n'
+                        '  rules                   <<<END_rules\n'
+                        + deny_block + '\n'
+                        '  END_rules\n'
+                        '}\n'
+                    )
+                    if 'vhssl' in content:
+                        content = content.replace('vhssl', append_block + 'vhssl', 1)
+                    else:
+                        content = content.rstrip() + append_block
+
+            with open(vhFile, 'w') as fh:
+                fh.write(content)
+
+            return 1
+        except BaseException as msg:
+            logging.CyberCPLogFileWriter.writeToFile(
+                str(msg) + ' [ensureSensitiveFileDenials]')
+            return -1
+
+    @staticmethod
     def checkIfRewriteEnabled(data):
         try:
             for items in data:

--- a/plogical/vhostConfs.py
+++ b/plogical/vhostConfs.py
@@ -1,5 +1,36 @@
 class vhostConfs:
 
+    # Shared OLS rewrite rules: forbid direct HTTP access to common secret paths (#1859).
+    # Must live inside `rules <<<END_rules` ... END_rules (OLS ignores RewriteRule outside that block).
+    olsSensitiveFileDenyRules = """# BEGIN CyberPanel sensitive-file denials (#1859)
+RewriteRule (^|/)\\.env - [F,L]
+RewriteRule (^|/)\\.git(/|$) - [F,L]
+RewriteRule (^|/)\\.htpasswd$ - [F,L]
+RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+RewriteRule (^|/)\\.htaccess$ - [F,L]
+# END CyberPanel sensitive-file denials (#1859)
+"""
+
+    # Apache / LiteSpeed Enterprise VirtualHost snippet (httpd style).
+    apacheSensitiveFileDeny = """
+    # BEGIN CyberPanel sensitive-file denials (#1859)
+    <IfModule mod_rewrite.c>
+        RewriteEngine On
+        RewriteRule (^|/)\\.env - [F,L]
+        RewriteRule (^|/)\\.git(/|$) - [F,L]
+        RewriteRule (^|/)\\.htpasswd$ - [F,L]
+        RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+        RewriteRule (^|/)\\.htaccess$ - [F,L]
+    </IfModule>
+    <FilesMatch "(^|/)(\\.env|\\.htpasswd|\\.htaccess|\\.user\\.ini)">
+        Require all denied
+    </FilesMatch>
+    <DirectoryMatch "/\\.git">
+        Require all denied
+    </DirectoryMatch>
+    # END CyberPanel sensitive-file denials (#1859)
+"""
+
     olsMasterMainConf = """virtualHost {virtualHostName} {
   vhRoot                  /home/$VH_NAME
   configFile              $SERVER_ROOT/conf/vhosts/$VH_NAME/vhost.conf
@@ -69,8 +100,17 @@ module cache {
 }
 
 rewrite  {
- enable                  1
+  enable                  1
   autoLoadHtaccess        1
+  rules                   <<<END_rules
+# BEGIN CyberPanel sensitive-file denials (#1859)
+RewriteRule (^|/)\\.env - [F,L]
+RewriteRule (^|/)\\.git(/|$) - [F,L]
+RewriteRule (^|/)\\.htpasswd$ - [F,L]
+RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+RewriteRule (^|/)\\.htaccess$ - [F,L]
+# END CyberPanel sensitive-file denials (#1859)
+  END_rules
 }
 
 context /.well-known/acme-challenge {
@@ -158,8 +198,17 @@ extprocessor {externalApp} {
 }
 
 rewrite  {
- enable                  1
+  enable                  1
   autoLoadHtaccess        1
+  rules                   <<<END_rules
+# BEGIN CyberPanel sensitive-file denials (#1859)
+RewriteRule (^|/)\\.env - [F,L]
+RewriteRule (^|/)\\.git(/|$) - [F,L]
+RewriteRule (^|/)\\.htpasswd$ - [F,L]
+RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+RewriteRule (^|/)\\.htaccess$ - [F,L]
+# END CyberPanel sensitive-file denials (#1859)
+  END_rules
 }
 
 context /.well-known/acme-challenge {
@@ -192,6 +241,22 @@ context /.well-known/acme-challenge {
         CacheRoot lscache
         CacheLookup on
     </IfModule>
+    # BEGIN CyberPanel sensitive-file denials (#1859)
+    <IfModule mod_rewrite.c>
+        RewriteEngine On
+        RewriteRule (^|/)\\.env - [F,L]
+        RewriteRule (^|/)\\.git(/|$) - [F,L]
+        RewriteRule (^|/)\\.htpasswd$ - [F,L]
+        RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+        RewriteRule (^|/)\\.htaccess$ - [F,L]
+    </IfModule>
+    <FilesMatch "(^|/)(\\.env|\\.htpasswd|\\.htaccess|\\.user\\.ini)">
+        Require all denied
+    </FilesMatch>
+    <DirectoryMatch "/\\.git">
+        Require all denied
+    </DirectoryMatch>
+    # END CyberPanel sensitive-file denials (#1859)
 
 </VirtualHost>
 """
@@ -210,6 +275,22 @@ context /.well-known/acme-challenge {
         CacheRoot lscache
         CacheLookup on
     </IfModule>
+    # BEGIN CyberPanel sensitive-file denials (#1859)
+    <IfModule mod_rewrite.c>
+        RewriteEngine On
+        RewriteRule (^|/)\\.env - [F,L]
+        RewriteRule (^|/)\\.git(/|$) - [F,L]
+        RewriteRule (^|/)\\.htpasswd$ - [F,L]
+        RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+        RewriteRule (^|/)\\.htaccess$ - [F,L]
+    </IfModule>
+    <FilesMatch "(^|/)(\\.env|\\.htpasswd|\\.htaccess|\\.user\\.ini)">
+        Require all denied
+    </FilesMatch>
+    <DirectoryMatch "/\\.git">
+        Require all denied
+    </DirectoryMatch>
+    # END CyberPanel sensitive-file denials (#1859)
 
 </VirtualHost>"""
 
@@ -236,6 +317,22 @@ context /.well-known/acme-challenge {
             Require all granted
             DirectoryIndex index.html index.php
         </Directory>
+        # BEGIN CyberPanel sensitive-file denials (#1859)
+        <IfModule mod_rewrite.c>
+            RewriteEngine On
+            RewriteRule (^|/)\\.env - [F,L]
+            RewriteRule (^|/)\\.git(/|$) - [F,L]
+            RewriteRule (^|/)\\.htpasswd$ - [F,L]
+            RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+            RewriteRule (^|/)\\.htaccess$ - [F,L]
+        </IfModule>
+        <FilesMatch "(^|/)(\\.env|\\.htpasswd|\\.htaccess|\\.user\\.ini)">
+            Require all denied
+        </FilesMatch>
+        <DirectoryMatch "/\\.git">
+            Require all denied
+        </DirectoryMatch>
+        # END CyberPanel sensitive-file denials (#1859)
 
 </VirtualHost>
 """
@@ -261,6 +358,22 @@ context /.well-known/acme-challenge {
             Require all granted
             DirectoryIndex index.html index.php
          </Directory>
+         # BEGIN CyberPanel sensitive-file denials (#1859)
+         <IfModule mod_rewrite.c>
+             RewriteEngine On
+             RewriteRule (^|/)\\.env - [F,L]
+             RewriteRule (^|/)\\.git(/|$) - [F,L]
+             RewriteRule (^|/)\\.htpasswd$ - [F,L]
+             RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+             RewriteRule (^|/)\\.htaccess$ - [F,L]
+         </IfModule>
+         <FilesMatch "(^|/)(\\.env|\\.htpasswd|\\.htaccess|\\.user\\.ini)">
+             Require all denied
+         </FilesMatch>
+         <DirectoryMatch "/\\.git">
+             Require all denied
+         </DirectoryMatch>
+         # END CyberPanel sensitive-file denials (#1859)
 
          SSLEngine on
          SSLVerifyClient none
@@ -291,6 +404,22 @@ context /.well-known/acme-challenge {
             Require all granted
             DirectoryIndex index.html index.php
         </Directory>
+        # BEGIN CyberPanel sensitive-file denials (#1859)
+        <IfModule mod_rewrite.c>
+            RewriteEngine On
+            RewriteRule (^|/)\\.env - [F,L]
+            RewriteRule (^|/)\\.git(/|$) - [F,L]
+            RewriteRule (^|/)\\.htpasswd$ - [F,L]
+            RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+            RewriteRule (^|/)\\.htaccess$ - [F,L]
+        </IfModule>
+        <FilesMatch "(^|/)(\\.env|\\.htpasswd|\\.htaccess|\\.user\\.ini)">
+            Require all denied
+        </FilesMatch>
+        <DirectoryMatch "/\\.git">
+            Require all denied
+        </DirectoryMatch>
+        # END CyberPanel sensitive-file denials (#1859)
 
 </VirtualHost>
 """
@@ -316,6 +445,22 @@ context /.well-known/acme-challenge {
             Require all granted
             DirectoryIndex index.html index.php
         </Directory>
+        # BEGIN CyberPanel sensitive-file denials (#1859)
+        <IfModule mod_rewrite.c>
+            RewriteEngine On
+            RewriteRule (^|/)\\.env - [F,L]
+            RewriteRule (^|/)\\.git(/|$) - [F,L]
+            RewriteRule (^|/)\\.htpasswd$ - [F,L]
+            RewriteRule (^|/)\\.user\\.ini$ - [F,L]
+            RewriteRule (^|/)\\.htaccess$ - [F,L]
+        </IfModule>
+        <FilesMatch "(^|/)(\\.env|\\.htpasswd|\\.htaccess|\\.user\\.ini)">
+            Require all denied
+        </FilesMatch>
+        <DirectoryMatch "/\\.git">
+            Require all denied
+        </DirectoryMatch>
+        # END CyberPanel sensitive-file denials (#1859)
         SSLEngine on
         SSLVerifyClient none
         SSLCertificateFile {SSLBase}.fullchain.pem


### PR DESCRIPTION
## Summary
- Default OpenLiteSpeed and LiteSpeed Enterprise / Apache vhost templates now return **403** for `.env`, `.git`, `.htpasswd`, `.user.ini`, and `.htaccess` so secrets are not served from the document root.
- Adds `vhost.ensureSensitiveFileDenials()` and `CPScripts/retrofit-sensitive-file-denials.sh` for existing sites (idempotent; restarts LSWS).
- Unit checks in `Test/test_sensitive_file_denials.py`.

Fixes https://github.com/usmannasir/cyberpanel/issues/1859

## Test plan
- [x] `python3 Test/test_sensitive_file_denials.py`
- [x] Dry-run + live retrofit on production vhosts
- [x] `curl -I https://seo.newstargeted.com/.env` → 403
- [x] `curl -I https://seo.newstargeted.com/.git/config` → 403
- [x] Homepage still 200 after LSWS restart