### PR TITLE
Settings: hide promotional content (port of #1841 to v2.5.5-dev)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ https://cyberpanel.net/KnowledgeBase/home/change-logs/
 - Existing sites: run `CPScripts/retrofit-sensitive-file-denials.sh` (restarts LSWS).
 - Helper: `vhost.ensureSensitiveFileDenials()` for idempotent injection into OLS configs.
 
+### Settings: option to hide promotional content (port of #1841)
+- New **Hide promotional content** checkbox under Settings → Design (`HidePromotions`
+  on `CyberPanelCosmetic`, default off).
+- When enabled, hides Build Services / HIRE US sidebar entry, Build Services command
+  palette group, and Email Delivery / AI Scanner / .htaccess promo notifications.
+- Backup-not-configured notification stays visible (status warning, not a promo).
+- Upgrade path: `ALTER TABLE ... ADD HidePromotions` in `plogical/upgrade.py`.
+
 ### Build metadata
 - `version.txt` and panel `BUILD` advanced to **2.5.5 build 1** (still the 2.5.5-dev line; not a 2.4.9 backport of release notes).
 

--- a/baseTemplate/models.py
+++ b/baseTemplate/models.py
@@ -13,6 +13,7 @@ class version(models.Model):
 
 class CyberPanelCosmetic(models.Model):
     MainDashboardCSS = models.TextField(default='')
+    HidePromotions = models.IntegerField(default=0)
 
 class UserNotificationPreferences(models.Model):
     """Model to store user notification dismissal preferences"""

--- a/baseTemplate/templates/baseTemplate/design.html
+++ b/baseTemplate/templates/baseTemplate/design.html
@@ -213,6 +213,15 @@
                         <textarea id="appendthemedata" name="MainDashboardCSS" rows="12" class="form-control">{{ cosmetic.MainDashboardCSS }}</textarea>
                     </div>
 
+                    <div class="form-group" style="margin-top: 1.5rem;">
+                        <label for="HidePromotions" style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+                            <input type="checkbox" id="HidePromotions" name="HidePromotions" value="1"
+                                   {% if cosmetic.HidePromotions %}checked{% endif %}>
+                            <span>{% trans "Hide promotional content" %}</span>
+                        </label>
+                        <p class="page-subtitle" style="margin: 6px 0 0 26px;">{% trans "Removes Build Services / \"Hire Us\" entries and service advertisements from the menu, command palette, and notifications." %}</p>
+                    </div>
+
                     <div class="form-group" style="margin-top: 2rem;">
                         <button type="submit" class="btn btn-primary">
                             <i class="fa fa-save"></i> {% trans "Save Changes" %}

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -114,6 +114,7 @@
                         <button type="button" class="cp-notif-clear" id="cp-notif-clear">{% trans "Dismiss all" %}</button>
                     </div>
                     <div class="cp-notif-list" id="cp-notif-list">
+                        {% if not cosmetic.HidePromotions %}
                         <div class="cp-notif-item" data-key="emaildelivery" data-storekey="emailDeliveryNotificationDismissed" data-store="local">
                             <div class="cp-notif-ic ic-accent"><i class="fas fa-paper-plane" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -123,6 +124,7 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
+                        {% endif %}
                         <div class="cp-notif-item" data-key="backup" data-storekey="backupNotificationDismissed" data-store="session">
                             <div class="cp-notif-ic ic-warn"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -132,6 +134,7 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
+                        {% if not cosmetic.HidePromotions %}
                         <div class="cp-notif-item" data-key="ai" data-storekey="aiScannerNotificationDismissed" data-store="session">
                             <div class="cp-notif-ic ic-accent"><i class="fas fa-brain" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -150,6 +153,7 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
+                        {% endif %}
                     </div>
                     <div class="cp-notif-empty" id="cp-notif-empty" hidden>{% trans "You're all caught up." %}</div>
                 </div>
@@ -236,12 +240,14 @@
             <span>{% trans "Backups" %}</span>
         </a>
 
+        {% if not cosmetic.HidePromotions %}
         <!-- Build Services: prominent, available to everyone -->
         <a href="{% url 'buildServices' %}" class="menu-item menu-item-promo">
             <div class="icon-wrapper"><i class="fas fa-rocket"></i></div>
             <span>{% trans "Build Services" %}</span>
             <span class="badge badge-promo">{% trans "HIRE US" %}</span>
         </a>
+        {% endif %}
 
         <!-- ============================ ACCOUNT ============================ -->
         <div class="section-header">{% trans "ACCOUNT" %}</div>
@@ -323,6 +329,7 @@
             {l:'{% trans "Deploy WordPress" %}', h:'{% url "createWordpress" %}', i:'fa-circle-plus', g:'{% trans "Quick actions" %}'},
             {% if admin or createEmail %}{l:'{% trans "Create Email Account" %}', h:'{% url "createEmailAccount" %}', i:'fa-circle-plus', g:'{% trans "Quick actions" %}'},{% endif %}
             {% if admin or createDatabase %}{l:'{% trans "Create Database" %}', h:'{% url "createDatabase" %}', i:'fa-circle-plus', g:'{% trans "Quick actions" %}'},{% endif %}
+            {% if not cosmetic.HidePromotions %}
             {l:'{% trans "Build Services" %}', h:'{% url "buildServices" %}', i:'fa-rocket', g:'{% trans "Quick actions" %}'},
             // Build services (open the marketing pages on cyberpanel.net)
             {l:'{% trans "Website Development" %}', h:'https://cyberpanel.net/custom-development/web?utm_source=cyberpanel&utm_medium=panel&utm_campaign=build_services', i:'fa-globe', g:'{% trans "Build services" %}', t:'_blank'},
@@ -334,6 +341,7 @@
             {l:'{% trans "UI / UX Design" %}', h:'https://cyberpanel.net/custom-development/design?utm_source=cyberpanel&utm_medium=panel&utm_campaign=build_services', i:'fa-pen-ruler', g:'{% trans "Build services" %}', t:'_blank'},
             {l:'{% trans "DevOps & Server Management" %}', h:'https://cyberpanel.net/custom-development/devops?utm_source=cyberpanel&utm_medium=panel&utm_campaign=build_services', i:'fa-server', g:'{% trans "Build services" %}', t:'_blank'},
             {l:'{% trans "Maintenance & Support" %}', h:'https://cyberpanel.net/custom-development/support?utm_source=cyberpanel&utm_medium=panel&utm_campaign=build_services', i:'fa-life-ring', g:'{% trans "Build services" %}', t:'_blank'},
+            {% endif %}
             // Sites
             {l:'{% trans "Dashboard" %}', h:'{% url "index" %}', i:'fa-gauge-high', g:'{% trans "Sites" %}'},
             {l:'{% trans "Websites" %}', h:'{% url "listWebsites" %}', i:'fa-globe', g:'{% trans "Sites" %}'},

--- a/baseTemplate/views.py
+++ b/baseTemplate/views.py
@@ -584,6 +584,7 @@ def design(request):
     if request.method == 'POST':
         MainDashboardCSS = request.POST.get('MainDashboardCSS', '')
         cosmetic.MainDashboardCSS = MainDashboardCSS
+        cosmetic.HidePromotions = 1 if request.POST.get('HidePromotions') else 0
         cosmetic.save()
         finalData['saved'] = 1
 

--- a/plogical/upgrade.py
+++ b/plogical/upgrade.py
@@ -2273,6 +2273,12 @@ $cfg['Servers'][$i]['port'] = '3306';
             except:
                 pass
 
+            try:
+                cursor.execute(
+                    'ALTER TABLE baseTemplate_cyberpanelcosmetic ADD HidePromotions integer NOT NULL DEFAULT 0')
+            except:
+                pass
+
             # AI Scanner Tables
             try:
                 cursor.execute('''


### PR DESCRIPTION
## Summary
Port of https://github.com/usmannasir/cyberpanel/pull/1841 (which targets `v2.4.8`) onto **v2.5.5-dev**.

- Adds `HidePromotions` (default 0) on `CyberPanelCosmetic`
- Settings → Design checkbox to hide Build Services / HIRE US, command-palette marketing entries, and Email Delivery / AI Scanner / .htaccess promo notifications
- Keeps the backups-not-configured notification (genuine status warning)
- `ALTER TABLE ... ADD HidePromotions` in `plogical/upgrade.py`

Credit: original work by @jeremiahbeasley in #1841.

## Test plan
- [x] Schema ALTER applied locally; column present
- [x] Templates gate Build Services + promo notifications behind `cosmetic.HidePromotions`
- [ ] Enable checkbox in Design UI and confirm sidebar / palette / notifs hide; backup warning remains
- [ ] Disable checkbox and confirm promos return