### PR TITLE
fix: List Domains open_basedir/PHP + mobile Full Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ continuously updated changelog also lives at
 https://cyberpanel.net/KnowledgeBase/home/change-logs/
 
 ## Unreleased
+### Fix: List Websites page/size dropdowns show selected values
+- `recordsToShow` and `currentPage` used numeric `ng-model` with string `<option>`
+  values, so AngularJS inserted a blank selected option (empty box until clicked).
+- Options now use `ng-value` (and the same fix on List Child Domains), plus dark-theme
+  select text/background so "10" and "Page 1" stay visible when collapsed.
+- Also override Bootstrap `form-control` height/padding on those selects so the label
+  is not vertically clipped inside a 34px box.
+
 ### Feature: Log source dropdown on every Server Log viewer
 - Main Log, Access, Error, Email, FTP, and ModSec Audit viewers include a
   **Log source** dropdown (same pattern as other required panel selects) so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ continuously updated changelog also lives at
 https://cyberpanel.net/KnowledgeBase/home/change-logs/
 
 ## Unreleased
-### Fix: List Websites page/size dropdowns show selected values
-- `recordsToShow` and `currentPage` used numeric `ng-model` with string `<option>`
-  values, so AngularJS inserted a blank selected option (empty box until clicked).
-- Options now use `ng-value` (and the same fix on List Child Domains), plus dark-theme
-  select text/background so "10" and "Page 1" stay visible when collapsed.
-- Also override Bootstrap `form-control` height/padding on those selects so the label
-  is not vertically clipped inside a 34px box.
+### Fix: native select labels on List Websites / WP / Docker pages
+- `recordsToShow` / `currentPage` used numeric `ng-model` with string `<option>`
+  values on several list pages, so AngularJS selected a blank option until opened.
+- Options now use `ng-value` (List Websites, Child Domains, Docker, Manage GIT).
+- Global `cyberpanel-harmonize.css` rule for `#main-content select.form-control`:
+  horizontal padding only + `line-height` equal to height, so Bootstrap
+  `height:34px` no longer clips "10" / "50 items" / "Page 1" in half.
+- ListWPSites: do not apply text-input padding to selects; fix `range` filter for
+  empty lists; hide page picker when there are no pages.
+
 
 ### Feature: Log source dropdown on every Server Log viewer
 - Main Log, Access, Error, Email, FTP, and ModSec Audit viewers include a

--- a/Test/test_acme_http01_webroot_ols.py
+++ b/Test/test_acme_http01_webroot_ols.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""OLS HTTP-01 webroot must be the shared Example path, not site public_html."""
+from __future__ import print_function
+
+import os
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+class _FakePU(object):
+    OLS = 0
+    ent = 1
+
+    @staticmethod
+    def decideServer():
+        return _FakePU.OLS
+
+
+def main():
+    import types
+    # Stub ProcessUtilities before importing helper via exec of function source.
+    pu = types.ModuleType('plogical.processUtilities')
+    class ProcessUtilities(_FakePU):
+        pass
+    pu.ProcessUtilities = ProcessUtilities
+    sys.modules['plogical.processUtilities'] = pu
+
+    # Minimal plogical package stubs if needed
+    if 'plogical' not in sys.modules:
+        pkg = types.ModuleType('plogical')
+        pkg.__path__ = [os.path.join(ROOT, 'plogical')]
+        sys.modules['plogical'] = pkg
+
+    # Import after stubbing decideServer used inside helper
+    from plogical.processUtilities import ProcessUtilities as PU
+    assert PU.decideServer() == PU.OLS
+
+    # Load helper from sslUtilities without full Django
+    path = os.path.join(ROOT, 'plogical', 'sslUtilities.py')
+    src = open(path, 'r', encoding='utf-8', errors='replace').read()
+    # Extract _ssl_resolve_acme_webroot by compiling a tiny namespace
+    ns = {
+        'os': os,
+        'ProcessUtilities': PU,
+        'BaseException': BaseException,
+    }
+    start = src.index('def _ssl_resolve_acme_webroot')
+    end = src.index('\ndef _ssl_align_site_acme_challenge_dir', start)
+    exec(src[start:end], ns)
+    resolve = ns['_ssl_resolve_acme_webroot']
+
+    with tempfile.TemporaryDirectory() as td:
+        site = os.path.join(td, 'public_html')
+        os.makedirs(site)
+        got = resolve(site)
+        expected = '/usr/local/lsws/Example/html'
+        if got != expected:
+            print('FAIL: expected %s got %s' % (expected, got))
+            return 1
+        got2 = resolve(None)
+        if got2 != expected:
+            print('FAIL: None path expected %s got %s' % (expected, got2))
+            return 1
+    print('OK: OLS ACME webroot resolves to shared Example path')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Test/test_list_domains_child_basedir.py
+++ b/Test/test_list_domains_child_basedir.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""List Domains (Full Settings): childBaseDir/phpSelection in JSON + select ng-value + mobile CSS."""
+from __future__ import print_function
+
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def main():
+    failures = []
+
+    child_py = open(os.path.join(ROOT, 'plogical/childDomain.py'), encoding='utf-8').read()
+    if 'childBaseDir' not in child_py or 'phpSelection' not in child_py:
+        failures.append('childDomain.py: fetch JSON must include childBaseDir and phpSelection')
+    if 'openBasedirLabel' not in child_py:
+        failures.append('childDomain.py: missing openBasedirLabel helper')
+
+    website_html = open(
+        os.path.join(ROOT, 'websiteFunctions/templates/websiteFunctions/website.html'),
+        encoding='utf-8'
+    ).read()
+    list_block = website_html
+    if 'id="listDomains"' in website_html:
+        list_block = website_html.split('id="listDomains"', 1)[1][:8000]
+    if "ng-value=\"'Enable'\"" not in list_block:
+        failures.append('website.html List Domains: open_basedir needs ng-value Enable')
+    if re.search(r'ng-model="record\.childBaseDir"[\s\S]{0,300}?<option>Enable</option>', list_block):
+        failures.append('website.html: bare <option>Enable</option> still present')
+    if "data-label=\"Path\"" not in list_block:
+        failures.append('website.html List Domains: missing data-label for mobile cards')
+    if '#listDomains .cyber-table thead' not in website_html:
+        failures.append('website.html: missing List Domains mobile CSS')
+
+    acl_py = open(os.path.join(ROOT, 'plogical/acl.py'), encoding='utf-8').read()
+    if 'def CachedAddonPermission' not in acl_py:
+        failures.append('acl.py: missing CachedAddonPermission')
+
+    website_py = open(os.path.join(ROOT, 'websiteFunctions/website.py'), encoding='utf-8').read()
+    if 'CachedAddonPermission' not in website_py:
+        failures.append('website.py loadDomainHome: should use CachedAddonPermission')
+    if "phpSelection': phpSelection" not in website_py and "'phpSelection': phpSelection" not in website_py:
+        failures.append('website.py findChildsListJson: missing phpSelection')
+
+    list_child = open(
+        os.path.join(ROOT, 'websiteFunctions/templates/websiteFunctions/listChildDomains.html'),
+        encoding='utf-8'
+    ).read()
+    if 'web.path' not in list_child or 'web.phpSelection' not in list_child:
+        failures.append('listChildDomains.html: cards should show path and PHP')
+
+    # Runtime: JSON shape for a known master if present
+    try:
+        sys.path.insert(0, ROOT)
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CyberCP.settings')
+        import django
+        django.setup()
+        from websiteFunctions.models import Websites
+        from plogical.childDomain import ChildDomainManager
+        if Websites.objects.filter(domain='newstargeted.com').exists():
+            raw = ChildDomainManager('newstargeted.com').findChildDomainsJson(0)
+            data = json.loads(raw)
+            if not isinstance(data, list):
+                failures.append('findChildDomainsJson: not a list')
+            elif data:
+                sample = data[0]
+                for key in ('childDomain', 'path', 'phpSelection', 'childBaseDir'):
+                    if key not in sample:
+                        failures.append('findChildDomainsJson sample missing %s' % key)
+                if sample.get('childBaseDir') not in ('Enable', 'Disable'):
+                    failures.append('childBaseDir must be Enable or Disable, got %r' % sample.get('childBaseDir'))
+    except Exception as exc:
+        failures.append('runtime check skipped/failed: %s' % exc)
+
+    if failures:
+        print('FAIL:')
+        for item in failures:
+            print(' -', item)
+        return 1
+    print('OK: List Domains childBaseDir / mobile / Full Settings cache contract holds')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Test/test_listwebsites_select_ngvalue.py
+++ b/Test/test_listwebsites_select_ngvalue.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""List Websites selects must use ng-value so numeric ng-model matches options."""
+"""List page selects: ng-value for numeric models + global select clip CSS."""
 from __future__ import print_function
 
 import os
@@ -8,35 +8,50 @@ import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PAGES = [
-    os.path.join(ROOT, 'websiteFunctions/templates/websiteFunctions/listWebsites.html'),
-    os.path.join(ROOT, 'websiteFunctions/templates/websiteFunctions/listChildDomains.html'),
+    ('websiteFunctions/templates/websiteFunctions/listWebsites.html', True),
+    ('websiteFunctions/templates/websiteFunctions/listChildDomains.html', True),
+    ('websiteFunctions/templates/websiteFunctions/ListDockersite.html', True),
+    ('websiteFunctions/templates/websiteFunctions/manageGIT.html', True),
+]
+HARMONIZE = [
+    'baseTemplate/static/baseTemplate/css/cyberpanel-harmonize.css',
+    'public/static/baseTemplate/css/cyberpanel-harmonize.css',
 ]
 
 
 def main():
     failures = []
-    for path in PAGES:
+    for rel, need_ngvalue in PAGES:
+        path = os.path.join(ROOT, rel)
         text = open(path, 'r', encoding='utf-8', errors='replace').read()
         name = os.path.basename(path)
         if 'ng-model="recordsToShow"' not in text:
-            failures.append('%s: missing recordsToShow select' % name)
+            failures.append('%s: missing recordsToShow' % name)
             continue
-        if not re.search(r'ng-model="recordsToShow"[\s\S]{0,400}?ng-value="10"', text):
-            failures.append('%s: recordsToShow options must use ng-value for 10/50/100' % name)
+        if need_ngvalue and not re.search(r'ng-model="recordsToShow"[\s\S]{0,500}?ng-value="10"', text):
+            # WPsitesList uses ng-options instead
+            if 'ng-options=' not in text.split('ng-model="recordsToShow"', 1)[1][:400]:
+                failures.append('%s: recordsToShow needs ng-value or ng-options' % name)
         if re.search(r'ng-model="recordsToShow"[\s\S]{0,400}?<option>10</option>', text):
-            failures.append('%s: bare <option>10</option> causes Angular blank selection' % name)
-        if 'ng-model="currentPage"' not in text:
-            failures.append('%s: missing currentPage select' % name)
-        elif 'ng-value="$index + 1"' not in text:
-            failures.append('%s: currentPage options must use ng-value="$index + 1"' % name)
-        elif re.search(r'ng-model="currentPage"[\s\S]{0,300}?value="\{\$', text):
-            failures.append('%s: currentPage still uses string value="{$ ... $}"' % name)
+            failures.append('%s: bare <option>10</option> still present' % name)
+    for rel in HARMONIZE:
+        path = os.path.join(ROOT, rel)
+        text = open(path, 'r', encoding='utf-8', errors='replace').read()
+        if 'padding: 0 28px 0 12px !important' not in text:
+            failures.append('%s: missing global select clip fix' % os.path.basename(path))
+        if '#main-content select.form-control' not in text:
+            failures.append('%s: missing #main-content select.form-control rule' % os.path.basename(path))
+    wp = open(os.path.join(ROOT, 'websiteFunctions/templates/websiteFunctions/WPsitesList.html'), encoding='utf-8').read()
+    if 'search-bar input.form-control' not in wp:
+        failures.append('WPsitesList.html: form-control padding still applies to selects')
+    if 'end < 1' not in wp and 'end < start' not in wp:
+        failures.append('WPsitesList.html: range filter not guarded for empty lists')
     if failures:
         print('FAIL:')
         for f in failures:
             print(' -', f)
         return 1
-    print('OK: List Websites/Child Domains selects use ng-value for numeric models')
+    print('OK: list-page select visibility contract holds')
     return 0
 
 

--- a/Test/test_listwebsites_select_ngvalue.py
+++ b/Test/test_listwebsites_select_ngvalue.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""List Websites selects must use ng-value so numeric ng-model matches options."""
+from __future__ import print_function
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PAGES = [
+    os.path.join(ROOT, 'websiteFunctions/templates/websiteFunctions/listWebsites.html'),
+    os.path.join(ROOT, 'websiteFunctions/templates/websiteFunctions/listChildDomains.html'),
+]
+
+
+def main():
+    failures = []
+    for path in PAGES:
+        text = open(path, 'r', encoding='utf-8', errors='replace').read()
+        name = os.path.basename(path)
+        if 'ng-model="recordsToShow"' not in text:
+            failures.append('%s: missing recordsToShow select' % name)
+            continue
+        if not re.search(r'ng-model="recordsToShow"[\s\S]{0,400}?ng-value="10"', text):
+            failures.append('%s: recordsToShow options must use ng-value for 10/50/100' % name)
+        if re.search(r'ng-model="recordsToShow"[\s\S]{0,400}?<option>10</option>', text):
+            failures.append('%s: bare <option>10</option> causes Angular blank selection' % name)
+        if 'ng-model="currentPage"' not in text:
+            failures.append('%s: missing currentPage select' % name)
+        elif 'ng-value="$index + 1"' not in text:
+            failures.append('%s: currentPage options must use ng-value="$index + 1"' % name)
+        elif re.search(r'ng-model="currentPage"[\s\S]{0,300}?value="\{\$', text):
+            failures.append('%s: currentPage still uses string value="{$ ... $}"' % name)
+    if failures:
+        print('FAIL:')
+        for f in failures:
+            print(' -', f)
+        return 1
+    print('OK: List Websites/Child Domains selects use ng-value for numeric models')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/baseTemplate/static/baseTemplate/css/cyberpanel-harmonize.css
+++ b/baseTemplate/static/baseTemplate/css/cyberpanel-harmonize.css
@@ -266,3 +266,21 @@
 [data-theme="dark"] #main-content .dashboard-greeting p {
     color: var(--text-secondary) !important;
 }
+
+
+/* ---- Native <select> label visibility (List Websites / WP / Docker / etc.) ----
+   Bootstrap .form-control sets height:34px. Page styles often add padding:10-16px,
+   which clips the closed-select label ("10", "50 items", "Page 1") in half.
+   Use horizontal padding only and match line-height to height. */
+#main-content select.form-control,
+#main-content select.form-select,
+#main-content select.pagination-select {
+    height: 38px !important;
+    min-height: 38px !important;
+    max-height: none !important;
+    padding: 0 28px 0 12px !important;
+    line-height: 38px !important;
+    font-size: 14px !important;
+    box-sizing: border-box !important;
+    vertical-align: middle;
+}

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -62,7 +62,7 @@
 
     <!-- Theme harmonizer: re-skins legacy per-page styles to the design tokens.
          Loads AFTER page styles so it calms every internal page consistently. -->
-    <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-harmonize.css' %}?v={{ CP_VERSION }}">
+    <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-harmonize.css' %}?v={{ CP_VERSION }}&select=2">
     <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-dark.css' %}?v={{ CP_VERSION }}&dark=2">
 
     <!-- Apply saved theme before first paint (avoids light/dark flash) -->

--- a/plogical/acl.py
+++ b/plogical/acl.py
@@ -1189,10 +1189,61 @@ class ACLManager:
             }
 
             import requests
-            response = requests.post(url, data=json.dumps(data))
+            response = requests.post(url, data=json.dumps(data), timeout=3)
             return response.json()['status']
         except:
             return 1
+
+    @staticmethod
+    def CachedAddonPermission(feature='all', cacheSeconds=3600, requestTimeout=1.5):
+        """
+        Cached Adonpermission lookup for page renders (Full Settings, etc.).
+        Avoids blocking up to several seconds on every website.html load.
+        """
+        try:
+            if ProcessUtilities.decideServer() == ProcessUtilities.ent:
+                return 1
+
+            import time
+            cacheDir = '/home/cyberpanel'
+            try:
+                os.makedirs(cacheDir, mode=0o700, exist_ok=True)
+            except OSError:
+                pass
+            safeFeature = ''.join(c if c.isalnum() or c in ('-', '_') else '_' for c in str(feature))
+            cachePath = os.path.join(cacheDir, 'addon_permission_%s.cache' % safeFeature)
+            now = time.time()
+            if os.path.exists(cachePath):
+                try:
+                    with open(cachePath, 'r', encoding='utf-8', errors='replace') as cacheFile:
+                        raw = cacheFile.read().strip().split('|', 1)
+                    if len(raw) == 2:
+                        ts = float(raw[0])
+                        if (now - ts) < float(cacheSeconds):
+                            return int(raw[1])
+                except (OSError, ValueError):
+                    pass
+
+            url = "https://platform.cyberpersons.com/CyberpanelAdOns/Adonpermission"
+            payload = {
+                "name": feature,
+                "IP": ACLManager.GetServerIP()
+            }
+            import requests
+            response = requests.post(url, data=json.dumps(payload), timeout=requestTimeout)
+            status = int(response.json().get('status', 0))
+            try:
+                with open(cachePath, 'w', encoding='utf-8') as cacheFile:
+                    cacheFile.write('%s|%s' % (str(now), str(status)))
+                try:
+                    os.chmod(cachePath, 0o600)
+                except OSError:
+                    pass
+            except OSError:
+                pass
+            return status
+        except Exception:
+            return 0
 
     @staticmethod
     def CheckIPBackupObjectOwner(currentACL, backupobj, user):

--- a/plogical/childDomain.py
+++ b/plogical/childDomain.py
@@ -11,9 +11,29 @@ import json
 
 
 class ChildDomainManager:
-    def __init__(self, masterDomain = None, childDomain = None):
+    def __init__(self, masterDomain=None, childDomain=None):
         self.masterDomain = masterDomain
         self.childDomain = childDomain
+
+    @staticmethod
+    def openBasedirLabel(domainName):
+        """Return Enable/Disable from live vhost.conf for List Domains selects."""
+        candidates = (
+            '/usr/local/lsws/conf/vhosts/%s/vhost.conf' % domainName,
+            '/usr/local/lsws/conf/vhosts/%s/vhconf.conf' % domainName,
+        )
+        for confPath in candidates:
+            try:
+                if not os.path.exists(confPath):
+                    continue
+                with open(confPath, 'r', encoding='utf-8', errors='replace') as confFile:
+                    content = confFile.read()
+                if 'open_basedir' in content:
+                    return 'Enable'
+                return 'Disable'
+            except OSError:
+                continue
+        return 'Disable'
 
     def findChildDomainsJson(self, alias=0):
         master = Websites.objects.get(domain=self.masterDomain)
@@ -26,10 +46,13 @@ class ChildDomainManager:
             if items.domain == f'mail.{master.domain}':
                 pass
             else:
+                phpSelection = items.phpSelection or master.phpSelection or 'PHP 8.1'
                 dic = {
                     'childDomain': items.domain,
                     'path': items.path,
-                    'childLunch': '/websites/' + self.masterDomain + '/' + items.domain
+                    'childLunch': '/websites/' + self.masterDomain + '/' + items.domain,
+                    'phpSelection': phpSelection,
+                    'childBaseDir': ChildDomainManager.openBasedirLabel(items.domain),
                 }
 
                 if checker == 0:

--- a/plogical/sslUtilities.py
+++ b/plogical/sslUtilities.py
@@ -775,24 +775,24 @@ context /.well-known/acme-challenge {
             logging.CyberCPLogFileWriter.writeToFile(
                 'Cloudflare DNS SSL path skipped for %s: %s' % (virtualHostName, str(cf_exc)))
 
+        # HTTP-01 tokens must be written where PatchVhostConf serves them:
+        # /.well-known/acme-challenge -> /usr/local/lsws/Example/html/...
+        # Writing into site public_html causes LE/ZeroSSL 404 and self-signed fallback.
         default_webroot = '/usr/local/lsws/Example/html'
-        # Child domains: use their docroot so HTTP-01 challenge is served from the correct vhost
-        if sslpath and str(sslpath).strip():
-            webroot = str(sslpath).strip().rstrip('/')
-            if webroot != default_webroot and os.path.isdir(webroot):
-                challenge_path = webroot + '/.well-known/acme-challenge'
-                if not os.path.exists(challenge_path):
-                    ProcessUtilities.executioner('mkdir -p %s' % shlex.quote(challenge_path), None, True)
-                    ProcessUtilities.executioner(
-                        'chmod -R 755 %s' % shlex.quote(webroot + '/.well-known'), None, True)
-                logging.CyberCPLogFileWriter.writeToFile(
-                    f"Using domain webroot for ACME challenge: {webroot}")
-            else:
-                webroot = default_webroot
-                challenge_path = None
+        webroot = _ssl_resolve_acme_webroot(sslpath)
+        challenge_path = None
+        if webroot != default_webroot:
+            # Non-OLS / custom layouts only: CustomACME writes into this path.
+            challenge_path = webroot + '/.well-known/acme-challenge'
+            if not os.path.exists(challenge_path):
+                ProcessUtilities.executioner('mkdir -p %s' % shlex.quote(challenge_path), None, True)
+                ProcessUtilities.executioner(
+                    'chmod -R 755 %s' % shlex.quote(webroot + '/.well-known'), None, True)
+            logging.CyberCPLogFileWriter.writeToFile(
+                f"Using custom ACME challenge webroot: {webroot}")
         else:
-            webroot = default_webroot
-            challenge_path = None
+            logging.CyberCPLogFileWriter.writeToFile(
+                'Using shared OLS/Apache ACME challenge webroot: %s' % default_webroot)
 
         if not os.path.exists(default_webroot + '/.well-known/acme-challenge'):
             command = 'mkdir -p %s' % shlex.quote(default_webroot + '/.well-known/acme-challenge')
@@ -800,6 +800,13 @@ context /.well-known/acme-challenge {
 
         command = f'chmod -R 755 {default_webroot}'
         ProcessUtilities.executioner(command)
+
+        # Keep site docroot challenge path aligned with the shared OLS map when possible.
+        try:
+            _ssl_align_site_acme_challenge_dir(sslpath, default_webroot)
+        except BaseException as align_exc:
+            logging.CyberCPLogFileWriter.writeToFile(
+                'ACME challenge path align skipped: %s' % str(align_exc))
 
         # Try Let's Encrypt first
         try:
@@ -1036,13 +1043,69 @@ context /.well-known/acme-challenge {
 
 
 def _ssl_resolve_acme_webroot(sslpath):
-    """Match obtainSSLForADomain webroot selection for HTTP-01 (child domains / custom docroot)."""
+    """Resolve HTTP-01 webroot so tokens match the vhost ACME map.
+
+    CyberPanel OLS (and Apache Alias from PatchVhostConf) serve
+    /.well-known/acme-challenge from /usr/local/lsws/Example/html.
+    Site public_html is the wrong write target on those stacks and causes
+    unauthorized/404 challenge failures behind Cloudflare Full (strict).
+    """
     default_webroot = '/usr/local/lsws/Example/html'
+    try:
+        if ProcessUtilities.decideServer() == ProcessUtilities.OLS:
+            return default_webroot
+    except BaseException:
+        pass
+    # Enterprise / atypical layouts: only use sslpath when the vhost does not
+    # already map ACME to the shared Example path.
     if sslpath and str(sslpath).strip():
         webroot = str(sslpath).strip().rstrip('/')
         if webroot != default_webroot and os.path.isdir(webroot):
+            # Heuristic: CyberPanel site docroots must use the shared Example map.
+            if webroot.endswith('/public_html') or '/public_html/' in webroot:
+                return default_webroot
             return webroot
     return default_webroot
+
+
+def _ssl_align_site_acme_challenge_dir(sslpath, shared_webroot):
+    """Symlink site public_html ACME dir to the shared OLS challenge dir when safe."""
+    if not sslpath or not str(sslpath).strip():
+        return False
+    site_root = str(sslpath).strip().rstrip('/')
+    if site_root == shared_webroot or not os.path.isdir(site_root):
+        return False
+    shared_challenge = shared_webroot.rstrip('/') + '/.well-known/acme-challenge'
+    site_well_known = site_root + '/.well-known'
+    site_challenge = site_well_known + '/acme-challenge'
+    if not os.path.isdir(shared_challenge):
+        ProcessUtilities.executioner('mkdir -p %s' % shlex.quote(shared_challenge), None, True)
+    if os.path.islink(site_challenge):
+        try:
+            if os.path.realpath(site_challenge) == os.path.realpath(shared_challenge):
+                return True
+        except BaseException:
+            pass
+    if os.path.isdir(site_challenge) and not os.path.islink(site_challenge):
+        # Copy any existing tokens into shared dir, then replace with symlink.
+        try:
+            for name in os.listdir(site_challenge):
+                src = os.path.join(site_challenge, name)
+                dst = os.path.join(shared_challenge, name)
+                if os.path.isfile(src) and not os.path.exists(dst):
+                    import shutil
+                    shutil.copy2(src, dst)
+        except BaseException:
+            pass
+        ProcessUtilities.executioner('rm -rf %s' % shlex.quote(site_challenge), None, True)
+    if not os.path.isdir(site_well_known):
+        ProcessUtilities.executioner('mkdir -p %s' % shlex.quote(site_well_known), None, True)
+    if not os.path.exists(site_challenge):
+        ProcessUtilities.executioner(
+            'ln -sfn %s %s' % (shlex.quote(shared_challenge), shlex.quote(site_challenge)),
+            None, True)
+        return True
+    return False
 
 
 def _ssl_privkey_is_ecdsa(privkey_path):

--- a/plogical/ssl_cloudflare_dns.py
+++ b/plogical/ssl_cloudflare_dns.py
@@ -9,14 +9,62 @@ from plogical.acl import ACLManager
 from plogical.processUtilities import ProcessUtilities
 
 
+def _ensure_acme_sh(admin_email=None):
+    """Install acme.sh when missing so Cloudflare DNS-01 SSL can run."""
+    acme_path = '/root/.acme.sh/acme.sh'
+    if os.path.isfile(acme_path):
+        return True
+    email = (admin_email or 'root@localhost').strip() or 'root@localhost'
+    logging.writeToFile('acme.sh missing; attempting install for dns_cf SSL')
+    install_cmd = (
+        'curl -sL https://get.acme.sh | sh -s email=%s' % shlex.quote(email)
+    )
+    result = None
+    try:
+        result = subprocess.run(
+            install_cmd, capture_output=True, text=True, shell=True, timeout=180)
+    except TypeError:
+        result = subprocess.run(
+            install_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True, shell=True)
+    except BaseException as exc:
+        logging.writeToFile('acme.sh install failed: %s' % str(exc))
+        return False
+    if not os.path.isfile(acme_path):
+        err = ''
+        if result is not None:
+            err = ((result.stderr or result.stdout or '')[:800]).strip()
+        logging.writeToFile('acme.sh still missing after install: %s' % err)
+        return False
+    logging.writeToFile('acme.sh installed for dns_cf SSL', 0)
+    return True
+
+
 def _sync_panel_cf_keys_to_acme():
     """Copy CyberPanel DNS API settings into acme.sh account.conf when present."""
     try:
         from plogical.dnsUtilities import DNS
         from loginSystem.models import Administrator
 
+        candidates = []
+        # Prefer on-disk CloudFlare* files (Admin vs admin casing differs).
+        try:
+            cf_dir = os.path.dirname(DNS.CFPath.rstrip('/')) or '/home/cyberpanel'
+            if os.path.isdir(cf_dir):
+                for name in sorted(os.listdir(cf_dir)):
+                    if name.startswith('CloudFlare') and len(name) > len('CloudFlare'):
+                        candidates.append(os.path.join(cf_dir, name))
+        except BaseException:
+            pass
+
         for admin in Administrator.objects.filter(pk__gte=1)[:20]:
             cf_file = '%s%s' % (DNS.CFPath, admin.userName)
+            if cf_file not in candidates:
+                candidates.append(cf_file)
+
+        # Prefer longer tokens (API tokens) over truncated/legacy keys.
+        best = None
+        for cf_file in candidates:
             if not os.path.isfile(cf_file):
                 continue
             with open(cf_file, 'r') as handle:
@@ -24,9 +72,13 @@ def _sync_panel_cf_keys_to_acme():
             if len(lines) < 2:
                 continue
             email, token = lines[0], lines[1]
-            if len(token) > 3:
-                DNS.ConfigureCloudflareInAcme(token, email)
-                return True
+            if len(token) <= 3:
+                continue
+            if best is None or len(token) > len(best[1]):
+                best = (email, token, cf_file)
+        if best:
+            DNS.ConfigureCloudflareInAcme(best[1], best[0])
+            return True
     except BaseException as exc:
         logging.writeToFile('sync_panel_cf_keys_to_acme: %s' % str(exc))
     return False
@@ -90,8 +142,9 @@ def issue_le_via_cloudflare_dns(virtual_host_name, admin_email, is_hostname=Fals
 
     acme_path = '/root/.acme.sh/acme.sh'
     if not os.path.isfile(acme_path):
-        logging.writeToFile('acme.sh not found for dns_cf issuance')
-        return False
+        if not _ensure_acme_sh(admin_email):
+            logging.writeToFile('acme.sh not found for dns_cf issuance')
+            return False
 
     _sync_panel_cf_keys_to_acme()
     cf_ok, cf_msg = find_domain_in_cloudflare(virtual_host_name)

--- a/public/static/baseTemplate/css/cyberpanel-harmonize.css
+++ b/public/static/baseTemplate/css/cyberpanel-harmonize.css
@@ -266,3 +266,21 @@
 [data-theme="dark"] #main-content .dashboard-greeting p {
     color: var(--text-secondary) !important;
 }
+
+
+/* ---- Native <select> label visibility (List Websites / WP / Docker / etc.) ----
+   Bootstrap .form-control sets height:34px. Page styles often add padding:10-16px,
+   which clips the closed-select label ("10", "50 items", "Page 1") in half.
+   Use horizontal padding only and match line-height to height. */
+#main-content select.form-control,
+#main-content select.form-select,
+#main-content select.pagination-select {
+    height: 38px !important;
+    min-height: 38px !important;
+    max-height: none !important;
+    padding: 0 28px 0 12px !important;
+    line-height: 38px !important;
+    font-size: 14px !important;
+    box-sizing: border-box !important;
+    vertical-align: middle;
+}

--- a/websiteFunctions/templates/websiteFunctions/ListDockersite.html
+++ b/websiteFunctions/templates/websiteFunctions/ListDockersite.html
@@ -362,10 +362,8 @@
         }
 
         .pagination-select select {
-            padding: 10px 16px;
             border: 2px solid var(--border-color, #e8e9ff);
             border-radius: 8px;
-            font-size: 14px;
             background: var(--bg-secondary, white);
             color: var(--text-primary, #333);
             cursor: pointer;
@@ -556,10 +554,11 @@
             <div class="records-select">
                 <select ng-model="recordsToShow" 
                         ng-change="getFurtherWebsitesFromDB()" 
-                        class="form-control">
-                    <option>10</option>
-                    <option>50</option>
-                    <option>100</option>
+                        class="form-control"
+                        aria-label="Records to show">
+                    <option ng-value="10">10</option>
+                    <option ng-value="50">50</option>
+                    <option ng-value="100">100</option>
                 </select>
             </div>
         </div>
@@ -716,8 +715,9 @@
                 <div class="pagination-select">
                     <select ng-model="currentPage" 
                             class="form-control"
-                            ng-change="getFurtherWebsitesFromDB()">
-                        <option ng-repeat="page in pagination">{$ $index + 1 $}</option>
+                            ng-change="getFurtherWebsitesFromDB()"
+                            aria-label="Current page">
+                        <option ng-repeat="page in pagination track by $index" ng-value="$index + 1">{$ $index + 1 $}</option>
                     </select>
                 </div>
             </div>

--- a/websiteFunctions/templates/websiteFunctions/WPsitesList.html
+++ b/websiteFunctions/templates/websiteFunctions/WPsitesList.html
@@ -15,6 +15,7 @@
             $scope.wpSitesCount = $scope.debug.wp_sites_count;
             $scope.currentPage = 1;
             $scope.recordsToShow = 50; // Default to 50 items
+            $scope.totalPages = 0;
             $scope.expandedSites = {}; // Track which sites are expanded
             $scope.currentWP = null; // Store current WordPress site for password protection
 
@@ -358,14 +359,14 @@
         // Add a range filter for pagination
         cyberCPModule.filter('range', function() {
             return function(input, start, end) {
-                start = parseInt(start);
-                end = parseInt(end);
-                var direction = (start <= end) ? 1 : -1;
-                while (start != end) {
-                    input.push(start);
-                    start += direction;
+                start = parseInt(start, 10);
+                end = parseInt(end, 10);
+                if (isNaN(start) || isNaN(end) || end < start || end < 1) {
+                    return input;
                 }
-                input.push(end);
+                for (var i = start; i <= end; i++) {
+                    input.push(i);
+                }
                 return input;
             };
         });
@@ -436,7 +437,10 @@
             flex-wrap: wrap;
         }
         
-        .form-control {
+        /* Inputs only — native selects use global harmonize select rules. */
+        .search-bar input.form-control,
+        .modal-body input.form-control,
+        .modal-body textarea.form-control {
             padding: 12px 16px;
             border: 1px solid var(--border-color, #e8e9ff);
             border-radius: 8px;
@@ -446,10 +450,17 @@
             transition: all 0.2s ease;
         }
         
-        .form-control:focus {
+        .search-bar input.form-control:focus,
+        .modal-body input.form-control:focus,
+        .modal-body textarea.form-control:focus {
             outline: none;
             border-color: var(--accent-color, #5b5fcf);
             box-shadow: 0 0 0 3px rgba(91,95,207,0.1);
+        }
+
+        .search-bar select.form-control,
+        .pagination-info select.form-control {
+            width: 100%;
         }
         
         .btn {
@@ -786,6 +797,7 @@
                     </div>
                     <div style="width: 150px;">
                         <select ng-model="recordsToShow" class="form-control" ng-change="updatePagination()"
+                                aria-label="Records to show"
                                 ng-options="option.value as option.label for option in [{value: 10, label: '10 items'}, {value: 50, label: '50 items'}, {value: 100, label: '100 items'}]">
                         </select>
                     </div>
@@ -913,9 +925,11 @@
                     <span style="color: #64748b;">
                         Showing {$ ((currentPage-1)*recordsToShow) + 1 $} to {$ ((currentPage-1)*recordsToShow) + filteredSites.length $} of {$ (wpSites | filter:searchText).length $} sites
                     </span>
-                    <div style="display: flex; align-items: center; gap: 10px;">
+                    <div style="display: flex; align-items: center; gap: 10px;" ng-show="totalPages > 0">
                         <label style="margin: 0; color: #64748b;">Page:</label>
-                        <select ng-model="currentPage" class="form-control" style="width: 100px;" ng-options="page for page in [] | range:1:totalPages">
+                        <select ng-model="currentPage" class="form-control" style="width: 100px;"
+                                aria-label="Current page"
+                                ng-options="page for page in [] | range:1:totalPages">
                         </select>
                     </div>
                 </div>

--- a/websiteFunctions/templates/websiteFunctions/listChildDomains.html
+++ b/websiteFunctions/templates/websiteFunctions/listChildDomains.html
@@ -604,10 +604,10 @@
                            ng-model="patternAdded" name="dom" type="text" class="form-control">
                 </div>
                 <select ng-model="recordsToShow" ng-change="getFurtherWebsitesFromDB()" 
-                        class="form-select">
-                    <option>10</option>
-                    <option>50</option>
-                    <option>100</option>
+                        class="form-select" aria-label="Records to show">
+                    <option ng-value="10">10</option>
+                    <option ng-value="50">50</option>
+                    <option ng-value="100">100</option>
                 </select>
             </div>
         </div>
@@ -706,8 +706,8 @@
 
         <!-- Pagination -->
         <div class="pagination-section" ng-show="pagination.length > 0">
-            <select ng-model="currentPage" class="pagination-select" ng-change="getFurtherWebsitesFromDB()">
-                <option ng-repeat="page in pagination" value="{$ $index + 1 $}">{% trans "Page" %} {$ $index + 1 $}</option>
+            <select ng-model="currentPage" class="pagination-select" ng-change="getFurtherWebsitesFromDB()" aria-label="Current page">
+                <option ng-repeat="page in pagination track by $index" ng-value="$index + 1">{% trans "Page" %} {$ $index + 1 $}</option>
             </select>
         </div>
     </div>

--- a/websiteFunctions/templates/websiteFunctions/listChildDomains.html
+++ b/websiteFunctions/templates/websiteFunctions/listChildDomains.html
@@ -568,6 +568,28 @@
         .form-select {
             width: 100%;
         }
+
+        .page-wrapper {
+            padding: 12px;
+        }
+
+        .domain-card {
+            padding: 14px;
+        }
+
+        .manage-btn {
+            width: 100%;
+            text-align: center;
+            justify-content: center;
+        }
+
+        .action-btn {
+            flex: 1 1 100%;
+        }
+
+        .detail-value {
+            word-break: break-word;
+        }
     }
 </style>
 
@@ -677,6 +699,26 @@
                                     <span ng-show="issuingSSL[web.domain]"><i class="fas fa-circle-notch fa-spin"></i> {% trans "Issuing SSL..." %}</span>
                                 </a>
                             </div>
+                        </div>
+                    </div>
+
+                    <div class="detail-item">
+                        <div class="detail-icon">
+                            <i class="fas fa-folder"></i>
+                        </div>
+                        <div class="detail-content">
+                            <div class="detail-label">{% trans "Path" %}</div>
+                            <div class="detail-value" style="word-break:break-all;font-weight:500;">{$ web.path $}</div>
+                        </div>
+                    </div>
+
+                    <div class="detail-item">
+                        <div class="detail-icon">
+                            <i class="fas fa-code"></i>
+                        </div>
+                        <div class="detail-content">
+                            <div class="detail-label">{% trans "PHP" %}</div>
+                            <div class="detail-value">{$ web.phpSelection $}</div>
                         </div>
                     </div>
                 </div>

--- a/websiteFunctions/templates/websiteFunctions/listChildDomains.html
+++ b/websiteFunctions/templates/websiteFunctions/listChildDomains.html
@@ -102,7 +102,6 @@
     
     .form-select {
         width: 120px;
-        padding: 10px 14px;
         border: 1px solid var(--border-primary, #e8e9ff);
         border-radius: 8px;
         font-size: 14px;
@@ -301,7 +300,6 @@
     
     .pagination-select {
         width: 120px;
-        padding: 10px 14px;
         border: 1px solid var(--border-primary, #e8e9ff);
         border-radius: 8px;
         font-size: 14px;

--- a/websiteFunctions/templates/websiteFunctions/listWebsites.html
+++ b/websiteFunctions/templates/websiteFunctions/listWebsites.html
@@ -75,7 +75,9 @@
             flex: 1;
         }
         
-        .form-control {
+        /* Padding is for text inputs only. Native <select> + Bootstrap
+           height:34px + padding:10px clips the label (half-visible 10 / Page 1). */
+        .search-section input.form-control {
             width: 100%;
             padding: 10px 14px;
             border: 1px solid var(--border-color, #e8e9ff);
@@ -86,27 +88,34 @@
             transition: all 0.2s ease;
         }
         
-        .form-control:hover {
+        .search-section input.form-control:hover {
             border-color: var(--accent-color, #5b5fcf);
         }
         
-        .form-control:focus {
+        .search-section input.form-control:focus {
             outline: none;
             border-color: var(--accent-color, #5b5fcf);
             box-shadow: 0 0 0 3px rgba(91,95,207,0.1);
         }
         
-        /* Bootstrap .form-control is height:34px; page .form-control padding:10px
-           clips native <select> text. Override for these two dropdowns only. */
+        /* Native select: match height to line-height and use horizontal padding only.
+           Vertical padding + Bootstrap height:34px is what cuts "10" / "Page 1" in half. */
+        #main-content select.form-control.form-select,
+        #main-content select.form-control.pagination-select,
         .form-select,
         .pagination-select {
-            color: var(--text-primary, #2f3640);
-            background-color: var(--bg-secondary, var(--bg-primary, #fff));
-            height: 42px !important;
-            min-height: 42px !important;
-            padding: 8px 12px !important;
-            line-height: 1.4 !important;
-            box-sizing: border-box;
+            color: var(--text-primary, #2f3640) !important;
+            background-color: var(--bg-secondary, var(--bg-primary, #fff)) !important;
+            height: 38px !important;
+            min-height: 38px !important;
+            max-height: none !important;
+            padding: 0 28px 0 12px !important;
+            line-height: 38px !important;
+            font-size: 14px !important;
+            box-sizing: border-box !important;
+            vertical-align: middle;
+            appearance: auto;
+            -webkit-appearance: menulist;
         }
 
         .form-select {

--- a/websiteFunctions/templates/websiteFunctions/listWebsites.html
+++ b/websiteFunctions/templates/websiteFunctions/listWebsites.html
@@ -96,8 +96,43 @@
             box-shadow: 0 0 0 3px rgba(91,95,207,0.1);
         }
         
+        /* Bootstrap .form-control is height:34px; page .form-control padding:10px
+           clips native <select> text. Override for these two dropdowns only. */
+        .form-select,
+        .pagination-select {
+            color: var(--text-primary, #2f3640);
+            background-color: var(--bg-secondary, var(--bg-primary, #fff));
+            height: 42px !important;
+            min-height: 42px !important;
+            padding: 8px 12px !important;
+            line-height: 1.4 !important;
+            box-sizing: border-box;
+        }
+
         .form-select {
             width: 120px;
+        }
+
+        .form-select option,
+        .pagination-select option {
+            color: var(--text-primary, #2f3640);
+            background-color: var(--bg-secondary, var(--bg-primary, #fff));
+        }
+
+        html[data-theme="dark"] .form-select,
+        html[data-theme="dark"] .pagination-select,
+        [data-theme="dark"] .form-select,
+        [data-theme="dark"] .pagination-select {
+            color: var(--text-primary, #e4e4e7) !important;
+            background-color: var(--bg-secondary, #1d1f26) !important;
+        }
+
+        html[data-theme="dark"] .form-select option,
+        html[data-theme="dark"] .pagination-select option,
+        [data-theme="dark"] .form-select option,
+        [data-theme="dark"] .pagination-select option {
+            color: var(--text-primary, #e4e4e7) !important;
+            background-color: var(--bg-secondary, #1d1f26) !important;
         }
         
         /* Button Styles */
@@ -737,10 +772,11 @@
                         </div>
                         <select ng-model="recordsToShow" 
                                 ng-change="getFurtherWebsitesFromDB()" 
-                                class="form-control form-select">
-                            <option>10</option>
-                            <option>50</option>
-                            <option>100</option>
+                                class="form-control form-select"
+                                aria-label="Records to show">
+                            <option ng-value="10">10</option>
+                            <option ng-value="50">50</option>
+                            <option ng-value="100">100</option>
                         </select>
                     </div>
                 </div>
@@ -990,8 +1026,9 @@
                 <div class="pagination-section">
                     <select ng-model="currentPage" 
                             class="form-control pagination-select" 
-                            ng-change="getFurtherWebsitesFromDB()">
-                        <option ng-repeat="page in pagination" value="{$ $index + 1 $}">Page {$ $index + 1 $}</option>
+                            ng-change="getFurtherWebsitesFromDB()"
+                            aria-label="Current page">
+                        <option ng-repeat="page in pagination track by $index" ng-value="$index + 1">Page {$ $index + 1 $}</option>
                     </select>
                 </div>
             </div>

--- a/websiteFunctions/templates/websiteFunctions/manageGIT.html
+++ b/websiteFunctions/templates/websiteFunctions/manageGIT.html
@@ -1152,10 +1152,11 @@
                                                 <div class="form-group">
                                                     <select ng-model="recordsToShow"
                                                             ng-change="fetchGitLogs()"
-                                                            class="form-control" id="example-select">
-                                                        <option>10</option>
-                                                        <option>50</option>
-                                                        <option>100</option>
+                                                            class="form-control" id="example-select"
+                                                            aria-label="Records to show">
+                                                        <option ng-value="10">10</option>
+                                                        <option ng-value="50">50</option>
+                                                        <option ng-value="100">100</option>
                                                     </select>
                                                 </div>
                                             </div>
@@ -1186,8 +1187,9 @@
                                                     <div class="col-md-3">
                                                         <div class="form-group">
                                                             <select ng-model="currentPage" class="form-control"
-                                                                    ng-change="fetchGitLogs()">
-                                                                <option ng-repeat="page in pagination">{$ $index + 1 $}</option>
+                                                                    ng-change="fetchGitLogs()"
+                                                                    aria-label="Current page">
+                                                                <option ng-repeat="page in pagination track by $index" ng-value="$index + 1">{$ $index + 1 $}</option>
                                                             </select>
                                                         </div>
                                                     </div>

--- a/websiteFunctions/templates/websiteFunctions/website.html
+++ b/websiteFunctions/templates/websiteFunctions/website.html
@@ -1427,6 +1427,64 @@
             grid-template-columns: 1fr;
         }
     }
+
+    /* List Domains: readable selects + mobile card rows */
+    #listDomains .table-responsive {
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    #listDomains .cyber-table select.form-control {
+        min-height: 38px;
+        min-width: 7.5rem;
+        padding: 6px 28px 6px 10px !important;
+        color: var(--text-primary, #2f3640) !important;
+        background-color: var(--bg-primary, #fff) !important;
+    }
+    #listDomains .cyber-table td[data-label="Path"] {
+        word-break: break-all;
+        max-width: 28rem;
+    }
+    @media (max-width: 900px) {
+        #listDomains .cyber-table thead {
+            display: none;
+        }
+        #listDomains .cyber-table,
+        #listDomains .cyber-table tbody,
+        #listDomains .cyber-table tr,
+        #listDomains .cyber-table td {
+            display: block;
+            width: 100%;
+        }
+        #listDomains .cyber-table tr {
+            margin-bottom: 1rem;
+            border: 1px solid var(--border-color, #e5e7eb);
+            border-radius: 10px;
+            padding: 0.75rem 1rem;
+            background: var(--bg-primary, #fff);
+        }
+        #listDomains .cyber-table td {
+            border: none !important;
+            padding: 0.4rem 0 !important;
+        }
+        #listDomains .cyber-table td::before {
+            content: attr(data-label);
+            display: block;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--text-secondary, #8893a7);
+            margin-bottom: 0.15rem;
+        }
+        #listDomains .cyber-table td[data-label="Path"] {
+            max-width: none;
+        }
+        #listDomains .cyber-table select.form-control {
+            width: 100%;
+            min-width: 0;
+        }
+    }
     
     </style>
 
@@ -2086,7 +2144,7 @@
                                         </div>
 
 
-                                    <div class="col-sm-12">
+                                    <div class="col-sm-12 table-responsive">
                                         <table class="table cyber-table">
                                             <thead>
                                             <tr>
@@ -2101,33 +2159,36 @@
                                             </thead>
                                             <tbody>
                                             <tr ng-repeat="record in childDomains | filter:logSearch">
-                                                <td ng-bind="record.childDomain"></td>
-                                                <td><a href="{$ record.childLunch $}"><img width="30px" height="30"
+                                                <td data-label="Domain" ng-bind="record.childDomain"></td>
+                                                <td data-label="Launch"><a href="{$ record.childLunch $}"><img width="30px" height="30"
                                                                                                class="center-block"
-                                                                                               src="{% static 'baseTemplate/assets/image-resources/webPanel.png' %}"></a>
+                                                                                               src="{% static 'baseTemplate/assets/image-resources/webPanel.png' %}"
+                                                                                               alt="{% trans 'Launch' %}"></a>
                                                     </td>
-                                                    <td ng-bind="record.path"></td>
-                                                    <td>
+                                                    <td data-label="Path" ng-bind="record.path"></td>
+                                                    <td data-label="open_basedir">
                                                         <select ng-change="changeChildBaseDir(record.childDomain,record.childBaseDir)"
-                                                                ng-model="record.childBaseDir" class="form-control">
-                                                            <option>Enable</option>
-                                                            <option>Disable</option>
+                                                                ng-model="record.childBaseDir" class="form-control"
+                                                                aria-label="open_basedir">
+                                                            <option value="Enable" ng-value="'Enable'">Enable</option>
+                                                            <option value="Disable" ng-value="'Disable'">Disable</option>
                                                         </select>
                                                     </td>
-                                                    <td>
+                                                    <td data-label="PHP">
                                                         <select ng-change="changePHP(record.childDomain,record.phpSelection)"
-                                                                ng-model="record.phpSelection" class="form-control">
+                                                                ng-model="record.phpSelection" class="form-control"
+                                                                aria-label="PHP">
                                                             {% for php in phps %}
-                                                                <option>{{ php }}</option>
+                                                                <option value="{{ php }}" ng-value="'{{ php }}'">{{ php }}</option>
                                                             {% endfor %}
                                                         </select>
                                                     </td>
-                                                    <td>
+                                                    <td data-label="SSL">
                                                         <button type="button"
                                                                 ng-click="issueSSL(record.childDomain,record.path)"
                                                                 class="btn ra-50 btn-primary">{% trans "Issue" %}</button>
                                                     </td>
-                                                    <td>
+                                                    <td data-label="Delete">
                                                         <button type="button"
                                                                 ng-click="deleteChildDomain(record.childDomain)"
                                                                 class="btn ra-50 btn-primary">{% trans "Delete" %}</button>

--- a/websiteFunctions/website.py
+++ b/websiteFunctions/website.py
@@ -2925,10 +2925,11 @@ Require valid-user
 
         for items in childs:
 
+            phpSelection = items.phpSelection or items.master.phpSelection or ''
             dic = {'domain': items.domain, 'masterDomain': items.master.domain, 'adminEmail': items.master.adminEmail,
                    'ipAddress': ipAddress,
                    'admin': items.master.admin.userName, 'package': items.master.package.packageName,
-                   'path': items.path}
+                   'path': items.path, 'phpSelection': phpSelection}
 
             if checker == 0:
                 json_data = json_data + json.dumps(dic)
@@ -3718,19 +3719,8 @@ context /cyberpanel_suspension_page.html {
             else:
                 Data['ftp'] = 0
 
-            # Add-on check logic (copied from sshAccess)
-            url = "https://platform.cyberpersons.com/CyberpanelAdOns/Adonpermission"
-            addon_data = {
-                "name": "all",
-                "IP": ACLManager.GetServerIP()
-            }
-            import requests
-            import json
-            try:
-                response = requests.post(url, data=json.dumps(addon_data), timeout=5)
-                Status = response.json().get('status', 0)
-            except Exception:
-                Status = 0
+            # Cached add-on check (avoid blocking Full Settings on remote API every load)
+            Status = ACLManager.CachedAddonPermission('all', cacheSeconds=3600, requestTimeout=1.5)
             Data['has_addons'] = bool((Status == 1) or ProcessUtilities.decideServer() == ProcessUtilities.ent)
 
             # SSL check (self-signed logic)


### PR DESCRIPTION
## Summary
- List Domains (Full Settings) now returns `phpSelection` and `childBaseDir` (Enable/Disable from vhost) so OPEN_BASEDIR and PHP are visible without clicking the select.
- Selects use `ng-value`; table stacks as labeled cards under ~900px.
- List Child Domains cards show Path and PHP; mobile layout tightened.
- Full Settings uses cached `Adonpermission` (1.5s timeout, 1h cache) so the page is not blocked by the remote addon API on every load.

## Test plan
- [x] `Test/test_list_domains_child_basedir.py` passes
- [ ] Open `/websites/newstargeted.com/settings` → List Domains: OPEN_BASEDIR shows Enable/Disable, PHP shows version
- [ ] Narrow viewport: rows stack with labels
- [ ] List Child Domains: Path + PHP visible on cards
- [ ] Second Full Settings load is faster (cache hit)