### PR TITLE
fix: unclip List Domains open_basedir and PHP selects

### DIFF
--- a/Test/test_list_domains_child_basedir.py
+++ b/Test/test_list_domains_child_basedir.py
@@ -39,6 +39,12 @@ def main():
         # Global 600px table min-width regresses narrow viewports
         if re.search(r'\.table\s*\{[^}]*min-width:\s*600px', website_html):
             failures.append('website.html: global table min-width 600px still present')
+    if not re.search(r'#listDomains[\s\S]{0,1200}?padding:\s*0\s+36px\s+0\s+12px\s*!important', website_html):
+        failures.append('website.html: List Domains selects need horizontal-only padding (no vertical clip)')
+    if not re.search(r'#listDomains[\s\S]{0,1200}?line-height:\s*44px\s*!important', website_html):
+        failures.append('website.html: List Domains selects need line-height matching height')
+    if re.search(r'#listDomains \.ld-field select\.form-control\s*\{[^}]*padding:\s*6px', website_html):
+        failures.append('website.html: vertical padding on List Domains selects clips labels')
 
     acl_py = open(os.path.join(ROOT, 'plogical/acl.py'), encoding='utf-8').read()
     if 'def CachedAddonPermission' not in acl_py:

--- a/websiteFunctions/templates/websiteFunctions/website.html
+++ b/websiteFunctions/templates/websiteFunctions/website.html
@@ -1554,14 +1554,27 @@
         gap: 10px 12px;
         align-items: end;
     }
-    #listDomains .ld-field select.form-control {
+    /* Closed <select> labels clip if height + vertical padding fight (see harmonize.css). */
+    #listDomains .ld-field select.form-control,
+    #listDomains.form-horizontal select.form-control,
+    #listDomains .form-horizontal select.form-control,
+    #listDomains form.form-horizontal.bordered-row select.form-control {
         width: 100% !important;
         min-width: 0 !important;
-        min-height: 38px;
-        padding: 6px 28px 6px 10px !important;
+        height: 44px !important;
+        min-height: 44px !important;
+        max-height: none !important;
+        padding: 0 36px 0 12px !important;
+        line-height: 44px !important;
+        font-size: 14px !important;
+        box-sizing: border-box !important;
+        vertical-align: middle;
+        overflow: visible !important;
         color: var(--text-primary, #2f3640) !important;
-        background-color: var(--bg-primary, #fff) !important;
-        white-space: normal;
+        background-color: var(--bg-secondary, #fff) !important;
+        background-position: right 12px center !important;
+        background-size: 18px !important;
+        white-space: nowrap;
     }
     #listDomains .ld-actions {
         display: flex;


### PR DESCRIPTION
## Summary
- List Domains card selects had `padding: 6px …` inside a fixed height, so closed labels (Disable, PHP 8.3) rendered at ~50% height.
- Match the global select fix: `height`/`line-height` 44px and horizontal-only padding.

## Test plan
- [x] `Test/test_list_domains_child_basedir.py`
- [ ] Hard-refresh List Domains: full Disable and PHP 8.3 visible without opening the dropdown