### PR TITLE
fix: Domain Alias create must use addAliasFunc (fixes empty table) (#1434)

### DIFF
--- a/static/websiteFunctions/websiteFunctions.js
+++ b/static/websiteFunctions/websiteFunctions.js
@@ -3506,7 +3506,7 @@ app.controller('manageAliasController', function ($scope, $http, $timeout, $wind
         e.preventDefault();
     });
 
-    var masterDomain = "";
+    var masterDomain = ($("#domainNamePage").text() || "").trim();
 
     $scope.aliasTable = false;
     $scope.addAliasButton = false;
@@ -3516,6 +3516,10 @@ app.controller('manageAliasController', function ($scope, $http, $timeout, $wind
     $scope.aliasCreated = true;
     $scope.manageAliasLoading = true;
     $scope.operationSuccess = true;
+
+    if (masterDomain) {
+        $scope.masterDomain = masterDomain;
+    }
 
     $scope.createAliasEnter = function ($event) {
         var keyCode = $event.which || $event.keyCode;

--- a/websiteFunctions/static/websiteFunctions/websiteFunctions.js
+++ b/websiteFunctions/static/websiteFunctions/websiteFunctions.js
@@ -13296,7 +13296,7 @@ app.controller('manageAliasController', function ($scope, $http, $timeout, $wind
         e.preventDefault();
     });
 
-    var masterDomain = "";
+    var masterDomain = ($("#domainNamePage").text() || "").trim();
 
     $scope.aliasTable = false;
     $scope.addAliasButton = false;
@@ -13306,6 +13306,10 @@ app.controller('manageAliasController', function ($scope, $http, $timeout, $wind
     $scope.aliasCreated = true;
     $scope.manageAliasLoading = true;
     $scope.operationSuccess = true;
+
+    if (masterDomain) {
+        $scope.masterDomain = masterDomain;
+    }
 
     $scope.createAliasEnter = function ($event) {
         var keyCode = $event.which || $event.keyCode;

--- a/websiteFunctions/templates/websiteFunctions/domainAlias.html
+++ b/websiteFunctions/templates/websiteFunctions/domainAlias.html
@@ -48,16 +48,16 @@
                                 <label class="col-sm-3 control-label">{% trans "Domain Name" %}</label>
                                 <div class="col-sm-6">
                                     <input name="dom" type="text" class="form-control"
-                                           ng-model="domainNameCreate" required>
+                                           ng-model="aliasDomain" required>
                                 </div>
                                 <div style="margin-bottom: 1%;" class=" col-sm-1">
                                     <a title="{% trans 'Cancel' %}" ng-click="hideDomainCreationForm()" href="">
-                                        <h3 class="glyph-icon icon-close text-danger mt-5"></h3>
+                                        <h3 class="glyph-icon icon-close text-danger mt-5" style="font-size: 24px; cursor: pointer;">&times;</h3>
                                     </a>
                                 </div>
                             </div>
 
-                            <div ng-hide="installationDetailsForm" ng-hide="installationDetailsForm"
+                            <div ng-hide="installationDetailsForm"
                                  class="form-group">
                                 <label class="col-sm-3 control-label">{% trans "Additional Features" %}</label>
                                 <div class="col-sm-9">
@@ -74,7 +74,7 @@
                             <div ng-hide="installationDetailsForm" class="form-group">
                                 <label class="col-sm-3 control-label"></label>
                                 <div class="col-sm-4">
-                                    <button type="button" ng-click="createDomain()"
+                                    <button type="button" ng-click="addAliasFunc()"
                                             class="btn btn-primary btn-lg">{% trans "Create Alias" %}</button>
 
                                 </div>
@@ -101,7 +101,7 @@
                                     </div>
 
                                     <div ng-hide="success" class="alert alert-success">
-                                        <p>{% trans "Website succesfully created." %}</p>
+                                        <p>{% trans "Alias succesfully created." %}</p>
                                     </div>
 
 
@@ -165,55 +165,64 @@
 
                                 <div class="col-sm-11">
                                     <input placeholder="Search Domain..." ng-model="logSearch" name="dom"
-                                           type="text" class="form-control" ng-model="domainNameCreate"
+                                           type="text" class="form-control"
                                            required>
                                 </div>
 
                                 <div style="margin-bottom: 1%;" class=" col-sm-1">
                                     <a title="{% trans 'Close' %}" ng-click="hideListDomains()" href="">
-                                        <h3 class="glyph-icon icon-close text-danger mt-5"></h3>
+                                        <h3 class="glyph-icon icon-close text-danger mt-5" style="font-size: 24px; cursor: pointer;">&times;</h3>
                                     </a>
                                 </div>
 
 
                                 <div class="col-sm-12">
-                                    <table class="table">
-                                        <thead>
-                                        <tr>
-                                            <th>Domain</th>
-                                            <th>Launch</th>
-                                            <th>Path</th>
-                                            <th>SSL</th>
-                                            <th>Delete</th>
-                                        </tr>
-                                        </thead>
-                                        <tbody>
-                                        {% for alias in aliases %}
-                                        <tr>
-                                            <td>{{ alias }}</td>
-                                            <td><a href="//{{ alias }}" target="_blank"><img width="30px" height="30"
-                                                                                       class="center-block"
-                                                                                       src="{% static 'baseTemplate/assets/image-resources/webPanel.png' %}"></a>
-                                            </td>
-                                            <td>{{ path }}</td>
-                                            <td>
-                                                <button type="button"
-                                                        ng-click="issueSSL('{{ masterDomain }}','{{ alias }}')"
-                                                        class="btn ra-50 btn-primary">{% trans "Issue" %}</button>
-                                            </td>
-                                            <td>
-                                                <button type="button"
-                                                        ng-click="removeAlias('{{ masterDomain }}','{{ alias }}')"
-                                                        class="btn ra-50 btn-primary">{% trans "Delete" %}</button>
-                                            </td>
-                                        </tr>
-                                        {% empty %}
-                                        <tr>
-                                            <td colspan="5">{% trans "No domain aliases have been added yet." %}</td>
-                                        </tr>
-                                        {% endfor %}
-                                        </tbody>
-                                    </table>
+                                    <!-- Show message when no aliases exist -->
+                                    <div ng-hide="{{ noAlias }}" class="alert alert-info">
+                                        <p>{% trans "No domain aliases found for this domain." %}</p>
+                                    </div>
+                                    
+                                    <!-- Show aliases table when aliases exist -->
+                                    <div ng-show="{{ noAlias }}">
+                                        <table class="table">
+                                            <thead>
+                                            <tr>
+                                                <th>{% trans "Alias Domain" %}</th>
+                                                <th>{% trans "Master Domain" %}</th>
+                                                <th>{% trans "Launch" %}</th>
+                                                <th>{% trans "SSL" %}</th>
+                                                <th>{% trans "Delete" %}</th>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            {% for alias in aliases %}
+                                            <tr>
+                                                <td>{{ alias }}</td>
+                                                <td>{{ masterDomain }}</td>
+                                                <td>
+                                                    <a href="http://{{ alias }}" target="_blank">
+                                                        <img width="30px" height="30" class="center-block"
+                                                             src="{% static 'baseTemplate/assets/image-resources/webPanel.png' %}">
+                                                    </a>
+                                                </td>
+                                                <td>
+                                                    <button type="button"
+                                                            ng-click="issueSSL('{{ masterDomain }}', '{{ alias }}')"
+                                                            class="btn ra-50 btn-primary">{% trans "Issue SSL" %}</button>
+                                                </td>
+                                                <td>
+                                                    <button type="button"
+                                                            ng-click="removeAlias('{{ masterDomain }}', '{{ alias }}')"
+                                                            class="btn ra-50 btn-danger"
+                                                            onclick="return confirm('{% trans "Are you sure you want to delete this alias?" %}')">
+                                                        {% trans "Delete" %}
+                                                    </button>
+                                                </td>
+                                            </tr>
+                                            {% endfor %}
+                                            </tbody>
+                                        </table>
+                                    </div>
                                 </div>
                             </div>
 

--- a/websiteFunctions/test_domain_alias_template.py
+++ b/websiteFunctions/test_domain_alias_template.py
@@ -1,0 +1,31 @@
+import pathlib
+import re
+import unittest
+
+
+class DomainAliasTemplateTest(unittest.TestCase):
+    def test_domain_alias_template_uses_alias_actions(self):
+        template_path = pathlib.Path(__file__).with_name("templates") / "websiteFunctions" / "domainAlias.html"
+        template = template_path.read_text(encoding="utf-8")
+
+        self.assertIn("removeAlias('{{ masterDomain }}', '{{ alias }}')", template)
+        self.assertIn("issueSSL('{{ masterDomain }}', '{{ alias }}')", template)
+        self.assertIn("{% for alias in aliases %}", template)
+        self.assertIn('ng-click="addAliasFunc()"', template)
+        self.assertIn('ng-model="aliasDomain"', template)
+        self.assertIn("Are you sure you want to delete this alias?", template)
+        self.assertNotIn("deleteChildDomain(record.childDomain)", template)
+        self.assertNotIn("record in childDomains", template)
+        # Create form must not call child-domain creation
+        self.assertIsNone(
+            re.search(r'ng-click="createDomain\(\)"', template),
+            "Create Alias must call addAliasFunc(), not createDomain()",
+        )
+        self.assertIsNone(
+            re.search(r'ng-model="domainNameCreate"', template),
+            "Create Alias input must bind aliasDomain, not domainNameCreate",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Domain Alias **Create** on v2.4.9 still called `createDomain()` → `/websites/submitDomainCreation` with `alias: 1`, which writes **ChildDomains**, while the table (after #1738) lists **`aliasDomains`**. Result: create/SSL looked successful, table stayed empty after reload, Delete had nothing to act on.
- Port create wiring from **v2.5.5-dev**: `ng-model="aliasDomain"` + `ng-click="addAliasFunc()"` → `/websites/submitAliasCreation` → `createAlias`.
- Initialize `masterDomain` from `#domainNamePage`, add delete confirmation, clearer table headers, and a template regression test.

Fixes #1434

## Notes for operators
- Prior clicks of Create Alias may have left orphan **ChildDomains** rows; remove those separately if needed.
- #1738 fixed list/delete endpoints; this PR fixes the create button still using the wrong API.

## Test plan
- [x] `python3 -m unittest websiteFunctions.test_domain_alias_template`
- [ ] Create Alias with SSL → row appears after reload
- [ ] Network: create → `/websites/submitAliasCreation`; delete → `/websites/delateAlias`
- [ ] Delete with confirm removes the row