### PR TITLE
fix: honor HidePromotions on dashboard and backup notif

### DIFF
--- a/baseTemplate/templates/baseTemplate/homePage.html
+++ b/baseTemplate/templates/baseTemplate/homePage.html
@@ -42,10 +42,12 @@
             <span class="cp-qa-text"><span class="cp-qa-title">{% trans "Back Up" %}</span><span class="cp-qa-sub">{% trans "Protect your data" %}</span></span>
         </a>
         {% endif %}
+        {% if not cosmetic.HidePromotions %}
         <a class="cp-qa-card" href="{% url 'buildServices' %}">
             <span class="cp-qa-ic" style="background:linear-gradient(135deg,#6366f1,#a855f7);color:#fff;"><i class="fas fa-rocket"></i></span>
             <span class="cp-qa-text"><span class="cp-qa-title">{% trans "Build Services" %}</span><span class="cp-qa-sub">{% trans "Let us build it" %}</span></span>
         </a>
+        {% endif %}
     </div>
 
     <!-- Onboarding checklist (shown when there are no websites yet) -->
@@ -87,6 +89,7 @@
         </div>
     </div>
 
+    {% if not cosmetic.HidePromotions %}
     <!-- Dismissible Build Services promo card -->
     <div class="cp-build-card" id="cp-build-card" hidden>
         <button class="cp-build-x" type="button" id="cp-build-card-x" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times"></i></button>
@@ -110,6 +113,7 @@
         } catch (e) {}
     })();
     </script>
+    {% endif %}
 
     <!-- Overview Section -->
     <div class="overview-section">

--- a/baseTemplate/templates/baseTemplate/hub.html
+++ b/baseTemplate/templates/baseTemplate/hub.html
@@ -12,6 +12,7 @@
 
     {# ============================ EMAIL ============================ #}
     {% if section == 'email' %}
+        {% if not cosmetic.HidePromotions %}
         <!-- Managed Email Delivery service promo -->
         <div class="cp-service-banner">
             <i class="fas fa-paper-plane cp-sb-deco" aria-hidden="true"></i>
@@ -24,6 +25,7 @@
                 <i class="fas fa-arrow-right" aria-hidden="true"></i> {% trans "Learn more" %}
             </a>
         </div>
+        {% endif %}
 
         <h2 class="section-title">{% trans "EMAIL" %}</h2>
         <div class="cp-tile-grid">

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -124,7 +124,6 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
-                        {% endif %}
                         <div class="cp-notif-item" data-key="backup" data-storekey="backupNotificationDismissed" data-store="session">
                             <div class="cp-notif-ic ic-warn"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -134,7 +133,6 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
-                        {% if not cosmetic.HidePromotions %}
                         <div class="cp-notif-item" data-key="ai" data-storekey="aiScannerNotificationDismissed" data-store="session">
                             <div class="cp-notif-ic ic-accent"><i class="fas fa-brain" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">

--- a/baseTemplate/templates/baseTemplate/siteWorkspace.html
+++ b/baseTemplate/templates/baseTemplate/siteWorkspace.html
@@ -120,6 +120,7 @@
                 {% if admin or suspendWebsite %}<a class="cp-tile" href="{% url 'siteState' %}"><span class="cp-tile-ic"><i class="fas fa-pause"></i></span><span><div class="cp-tile-title">{% trans "Suspend Website" %}</div><div class="cp-tile-sub">{% trans "Suspend or unsuspend this site" %}</div></span></a>{% endif %}
                 {% if admin or deleteWebsite %}<a class="cp-tile" href="{% url 'deleteWebsite' %}"><span class="cp-tile-ic"><i class="fas fa-trash"></i></span><span><div class="cp-tile-title">{% trans "Delete Website" %}</div><div class="cp-tile-sub">{% trans "Permanently remove this site" %}</div></span></a>{% endif %}
             </div>
+            {% if not cosmetic.HidePromotions %}
             <div class="cp-empty-nudge" style="margin-top:18px;">
                 <div class="cp-empty-ic"><i class="fas fa-rocket"></i></div>
                 <h3>{% trans "Want this site built or customized for you?" %}</h3>
@@ -128,6 +129,7 @@
                     <a class="cp-build-link" href="{% url 'buildServices' %}"><i class="fas fa-arrow-right"></i> {% trans "Explore Build Services" %}</a>
                 </div>
             </div>
+            {% endif %}
         </div>
 
     </div>


### PR DESCRIPTION
## Summary
- `HidePromotions` (Design → Hide promotional content) already hid the sidebar HIRE US item and AI/email notifs.
- Also gate dashboard Build Services cards, site workspace nudge, email hub managed-SMTP banner, and the backup notification so self-hosters get a clean UI when the flag is on.

## Test plan
- [x] `HidePromotions=1` on this panel
- [ ] Dashboard: no Build Services quick action / promo card
- [ ] Bell: no backup/AI/email promo items when promotions hidden
- [ ] With flag off, promos return