### PR TITLE
v2.5.5-dev: firewall UX, HidePromotions gaps, sidebar search, fluid scaling (vs 2.4.9 overview)

### DIFF
--- a/CyberCP/secMiddleware.py
+++ b/CyberCP/secMiddleware.py
@@ -57,7 +57,7 @@ class secMiddleware:
                         'error_message': "This request need session.",
                         "errorMessage": "This request need session."}
                     final_json = json.dumps(final_dic)
-                    return HttpResponse(final_json)
+                    return HttpResponse(final_json, content_type='application/json')
                 else:
                     from django.shortcuts import redirect
                     from loginSystem.views import loadLoginPage
@@ -73,31 +73,39 @@ class secMiddleware:
         try:
             uID = request.session['userID']
             admin = Administrator.objects.get(pk=uID)
-            ipAddr = secMiddleware.get_client_ip(request)
-
-            if ipAddr.find('.') > -1:
-                if request.session['ipAddr'] == ipAddr or admin.securityLevel == secMiddleware.LOW:
-                    pass
-                else:
-                    del request.session['userID']
-                    del request.session['ipAddr']
-                    logging.writeToFile(secMiddleware.get_client_ip(request))
-                    final_dic = {'error_message': "Session reuse detected, IPAddress logged.",
-                                 "errorMessage": "Session reuse detected, IPAddress logged."}
-                    final_json = json.dumps(final_dic)
-                    return HttpResponse(final_json)
+            raw_ip = secMiddleware.get_client_ip(request) or ''
+            # Normalize the same way loginSystem stores ipAddr (IPv6: first 3 hextets)
+            if raw_ip.find(':') > -1:
+                session_ip = ':'.join(raw_ip.split(':')[:3])
             else:
-                ipAddr = ':'.join(secMiddleware.get_client_ip(request).split(':')[:3])
-                if request.session['ipAddr'] == ipAddr or admin.securityLevel == secMiddleware.LOW:
-                    pass
+                session_ip = raw_ip
+
+            stored_ip = request.session.get('ipAddr')
+            # Missing/empty bind: seed from current client (avoids false need-session after IP key loss)
+            if not stored_ip and session_ip:
+                request.session['ipAddr'] = session_ip
+                stored_ip = session_ip
+
+            if admin.securityLevel == secMiddleware.LOW or stored_ip == session_ip:
+                pass
+            else:
+                # Also accept REMOTE_ADDR if CF header/proxy briefly disagrees with login-time IP
+                alt_ip = request.META.get('REMOTE_ADDR') or ''
+                if alt_ip.find(':') > -1:
+                    alt_norm = ':'.join(alt_ip.split(':')[:3])
+                else:
+                    alt_norm = alt_ip
+                if stored_ip == alt_norm:
+                    request.session['ipAddr'] = session_ip or alt_norm
                 else:
                     del request.session['userID']
-                    del request.session['ipAddr']
-                    logging.writeToFile(secMiddleware.get_client_ip(request))
+                    if 'ipAddr' in request.session:
+                        del request.session['ipAddr']
+                    logging.writeToFile(raw_ip)
                     final_dic = {'error_message': "Session reuse detected, IPAddress logged.",
                                  "errorMessage": "Session reuse detected, IPAddress logged."}
                     final_json = json.dumps(final_dic)
-                    return HttpResponse(final_json)
+                    return HttpResponse(final_json, content_type='application/json')
         except:
             pass
 

--- a/baseTemplate/static/baseTemplate/css/cyberpanel-ui.css
+++ b/baseTemplate/static/baseTemplate/css/cyberpanel-ui.css
@@ -1519,7 +1519,7 @@ textarea:focus-visible,
 }
 
 /* ============================================================
-   Sidebar quick-filter / jump-to search
+   Sidebar feature/site search (near server-info / uptime)
    ============================================================ */
 .sidebar-search {
     position: relative;
@@ -1527,21 +1527,31 @@ textarea:focus-visible,
     display: flex;
     align-items: center;
 }
+#sidebar .server-info .sidebar-search--server {
+    flex: 1 1 100%;
+    width: 100%;
+    margin: 8px 0 0;
+    order: 3;
+}
+#sidebar .server-info {
+    flex-wrap: wrap;
+}
 .sidebar-search > i {
     position: absolute;
     left: 12px;
     color: var(--text-secondary);
     font-size: 13px;
     pointer-events: none;
+    z-index: 1;
 }
 .sidebar-search input {
     width: 100%;
-    padding: 10px 32px 10px 32px;
+    padding: 9px 32px 9px 32px;
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    background: var(--bg-secondary);
+    background: var(--bg-primary, var(--bg-secondary));
     color: var(--text-primary);
-    font-size: 13px;
+    font-size: 12.5px;
     outline: none;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -1553,6 +1563,8 @@ textarea:focus-visible,
 #sidebar-search-clear {
     position: absolute;
     right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
     background: transparent;
     border: none;
     color: var(--text-secondary);
@@ -1560,13 +1572,62 @@ textarea:focus-visible,
     padding: 4px;
     border-radius: 5px;
     line-height: 1;
+    z-index: 2;
 }
 #sidebar-search-clear:hover { color: var(--danger-color); background: var(--bg-hover); }
 #sidebar-search-clear[hidden] { display: none; }
 
+.sidebar-search-results {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: calc(100% + 4px);
+    z-index: 40;
+    max-height: min(50vh, 320px);
+    overflow-y: auto;
+    background: var(--bg-secondary, #1e1e2e);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    box-shadow: 0 12px 28px rgba(0,0,0,0.35);
+    padding: 4px;
+}
+.sidebar-search-results[hidden] { display: none; }
+.sidebar-search-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    width: 100%;
+    text-align: left;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    padding: 8px 10px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+.sidebar-search-item:hover,
+.sidebar-search-item.active {
+    background: var(--bg-hover, rgba(88,86,214,0.18));
+}
+.sidebar-search-ic {
+    width: 22px;
+    flex: 0 0 22px;
+    color: var(--accent-color, #7c7cff);
+    margin-top: 2px;
+}
+.sidebar-search-label {
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.25;
+}
+.sidebar-search-sub {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
 .sidebar-search-empty {
-    margin: 6px 15px;
-    padding: 10px 12px;
+    margin-top: 6px;
+    padding: 8px 10px;
     font-size: 12px;
     color: var(--text-secondary);
     text-align: center;
@@ -1575,6 +1636,11 @@ textarea:focus-visible,
     border-radius: 8px;
 }
 .sidebar-search-empty[hidden] { display: none; }
+@media (max-width: 768px) {
+    .sidebar-search-results {
+        max-height: min(40vh, 260px);
+    }
+}
 
 /* ============================================================
    Breadcrumb / page context strip

--- a/baseTemplate/static/baseTemplate/css/cyberpanel-ui.css
+++ b/baseTemplate/static/baseTemplate/css/cyberpanel-ui.css
@@ -41,6 +41,26 @@
             --skeleton-base: #e9ebef;
             --skeleton-shine: #f4f5f7;
             --focus-ring: #5856d6;
+            /* Fluid UI scale (viewport-aware; no transform zoom) */
+            --cp-root-font: clamp(15px, 0.28vw + 14.1px, 17.5px);
+            --cp-sidebar-width: clamp(272px, 17vw, 300px);
+            --cp-content-max: min(1680px, 100%);
+            --cp-pad-main-x: clamp(1rem, 2.2vw, 2rem);
+            --cp-pad-main-y: clamp(1.25rem, 2vw, 2rem);
+            --cp-header-height: clamp(4.25rem, 5.5vw, 5rem);
+            --cp-font-xs: 0.75rem;
+            --cp-font-sm: 0.875rem;
+            --cp-font-md: 1rem;
+            --cp-font-lg: 1.125rem;
+            --cp-space-xs: 0.25rem;
+            --cp-space-sm: 0.5rem;
+            --cp-space-md: 1rem;
+            --cp-space-lg: 1.5rem;
+            --cp-space-xl: 2rem;
+        }
+
+        html {
+            font-size: var(--cp-root-font);
         }
         
         /* Dark Theme Colors */
@@ -92,6 +112,7 @@
         
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            font-size: var(--cp-font-md);
             background: var(--bg-primary);
             color: var(--text-primary);
             overflow-x: hidden;
@@ -111,14 +132,14 @@
         /* Header */
         #header {
             background: var(--bg-secondary);
-            height: 80px;
+            height: var(--cp-header-height);
             display: flex;
             align-items: center;
-            padding: 0 30px;
+            padding: 0 var(--cp-pad-main-x);
             box-shadow: 0 2px 12px var(--shadow-color);
             position: fixed;
             top: 0;
-            left: 260px;
+            left: var(--cp-sidebar-width);
             right: 0;
             z-index: 1000;
             transition: background-color 0.12s ease;
@@ -258,7 +279,7 @@
         
         /* Sidebar */
         #sidebar {
-            width: 260px;
+            width: var(--cp-sidebar-width);
             background: var(--bg-sidebar);
             height: 100vh;
             position: fixed;
@@ -595,8 +616,8 @@
         
         /* Main Content */
         #main-content {
-            margin-left: 260px;
-            padding: 110px 30px 30px;
+            margin-left: var(--cp-sidebar-width);
+            padding: calc(var(--cp-header-height) + 1.75rem) var(--cp-pad-main-x) var(--cp-pad-main-y);
             min-height: 100vh;
             background: var(--bg-primary);
             transition: background-color 0.3s ease;
@@ -605,8 +626,8 @@
         /* Notification Banner */
         .notification-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
             border-bottom: 1px solid #f59e0b;
@@ -689,8 +710,8 @@
         /* AI Scanner Security Banner */
         .ai-scanner-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a855f7 100%);
             border-bottom: 2px solid #4f46e5;
@@ -832,8 +853,8 @@
         /* .htaccess Feature Banner */
         .htaccess-feature-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #10b981 0%, #059669 50%, #047857 100%);
             border-bottom: 2px solid #065f46;
@@ -2123,9 +2144,9 @@ button[aria-busy="true"] { opacity: 0.75; cursor: progress; }
 :root { --accent-soft-bg: rgba(88,86,214,0.10); }
 [data-theme="dark"] { --accent-soft-bg: rgba(124,127,243,0.16); }
 
-/* Comfortable base typography */
+/* Comfortable base typography (tracks fluid html root) */
 body {
-    font-size: 14px;
+    font-size: var(--cp-font-md);
     line-height: 1.55;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -2177,7 +2198,7 @@ body {
     color: var(--text-secondary);
     margin: 16px 18px 6px;
     padding: 0;
-    font-size: 10.5px;
+    font-size: clamp(0.7rem, 0.15vw + 0.65rem, 0.78rem);
     letter-spacing: 0.7px;
     font-weight: 700;
     text-align: left;
@@ -2190,10 +2211,10 @@ body {
     background: transparent;
     box-shadow: none;
     margin: 1px 10px;
-    padding: 9px 12px;
+    padding: 0.65rem 0.85rem;
     border-radius: 8px;
-    gap: 11px;
-    font-size: 13.5px;
+    gap: 0.7rem;
+    font-size: clamp(0.9rem, 0.12vw + 0.86rem, 1rem);
     font-weight: 500;
     color: var(--text-secondary);
 }
@@ -2219,7 +2240,7 @@ body {
     height: 22px;
     border-radius: 6px;
 }
-#sidebar .menu-item i { font-size: 15px; color: var(--text-secondary); }
+#sidebar .menu-item i { font-size: 1.05rem; color: var(--text-secondary); }
 #sidebar .menu-item:hover i { color: var(--accent-color); }
 
 /* Keep the promo entry distinctive but a touch softer */
@@ -2259,7 +2280,7 @@ body {
 }
 
 /* Breadcrumb: quieter */
-.cp-breadcrumb { font-size: 12.5px; }
+.cp-breadcrumb { font-size: var(--cp-font-sm); }
 
 /* =================================================================
    v2.4.8 — Service promo banner (e.g. managed Email Delivery)
@@ -2454,4 +2475,92 @@ html[data-theme="light"] #sidebar .menu-item.active,
 html.cp-theme-light #sidebar .menu-item.active {
     background-color: var(--accent-soft-bg);
     color: var(--accent-color);
+}
+
+/* =================================================================
+   Fluid UI scale — readable desktop chrome, adaptive hubs
+   (rem + clamp; no page transform zoom)
+   ================================================================= */
+#main-content .modern-container,
+#main-content .page-container {
+    max-width: var(--cp-content-max);
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: var(--cp-pad-main-x);
+    padding-right: var(--cp-pad-main-x);
+    box-sizing: border-box;
+}
+
+#main-content .form-label,
+#main-content label.form-label {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content .form-control,
+#main-content select.form-control,
+#main-content textarea.form-control,
+#main-content .select-control {
+    font-size: var(--cp-font-md);
+    min-height: 2.65rem;
+}
+
+#main-content .btn,
+#main-content .control-btn,
+#main-content .btn-add,
+#main-content .tab-button {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content table th,
+#main-content .rules-table th {
+    font-size: var(--cp-font-xs);
+}
+
+#main-content table td,
+#main-content .rules-table td {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content .rules-table-section {
+    display: block;
+    visibility: visible;
+    overflow-x: auto;
+}
+
+#sidebar .server-info .info-line {
+    font-size: var(--cp-font-sm);
+}
+
+#sidebar .logo-text .brand {
+    font-size: var(--cp-font-lg);
+}
+
+#sidebar .logo-text .tagline {
+    font-size: var(--cp-font-xs);
+}
+
+.sidebar-search input,
+#sidebar .sidebar-search input {
+    font-size: var(--cp-font-sm);
+}
+
+@media (max-width: 768px) {
+    :root {
+        --cp-sidebar-width: 280px;
+        --cp-root-font: 15.5px;
+        --cp-pad-main-x: 0.9rem;
+    }
+
+    #main-content .modern-container,
+    #main-content .page-container {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
+@media (min-width: 1400px) {
+    :root {
+        --cp-content-max: min(1760px, 100%);
+    }
 }

--- a/baseTemplate/static/baseTemplate/custom-js/system-status.js
+++ b/baseTemplate/static/baseTemplate/custom-js/system-status.js
@@ -18,6 +18,15 @@ function getCookie(name) {
             }
         }
     }
+    // Fallback: CSRF seed form in base template (cookie may be missing briefly after login)
+    if (!cookieValue && name === 'csrftoken') {
+        try {
+            var el = document.querySelector('#cp-csrf-seed input[name="csrfmiddlewaretoken"], input[name="csrfmiddlewaretoken"]');
+            if (el && el.value) {
+                cookieValue = el.value;
+            }
+        } catch (e) {}
+    }
     return cookieValue;
 }
 

--- a/baseTemplate/templates/baseTemplate/homePage.html
+++ b/baseTemplate/templates/baseTemplate/homePage.html
@@ -42,10 +42,12 @@
             <span class="cp-qa-text"><span class="cp-qa-title">{% trans "Back Up" %}</span><span class="cp-qa-sub">{% trans "Protect your data" %}</span></span>
         </a>
         {% endif %}
+        {% if not cosmetic.HidePromotions %}
         <a class="cp-qa-card" href="{% url 'buildServices' %}">
             <span class="cp-qa-ic" style="background:linear-gradient(135deg,#6366f1,#a855f7);color:#fff;"><i class="fas fa-rocket"></i></span>
             <span class="cp-qa-text"><span class="cp-qa-title">{% trans "Build Services" %}</span><span class="cp-qa-sub">{% trans "Let us build it" %}</span></span>
         </a>
+        {% endif %}
     </div>
 
     <!-- Onboarding checklist (shown when there are no websites yet) -->
@@ -87,6 +89,7 @@
         </div>
     </div>
 
+    {% if not cosmetic.HidePromotions %}
     <!-- Dismissible Build Services promo card -->
     <div class="cp-build-card" id="cp-build-card" hidden>
         <button class="cp-build-x" type="button" id="cp-build-card-x" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times"></i></button>
@@ -110,6 +113,7 @@
         } catch (e) {}
     })();
     </script>
+    {% endif %}
 
     <!-- Overview Section -->
     <div class="overview-section">

--- a/baseTemplate/templates/baseTemplate/hub.html
+++ b/baseTemplate/templates/baseTemplate/hub.html
@@ -12,6 +12,7 @@
 
     {# ============================ EMAIL ============================ #}
     {% if section == 'email' %}
+        {% if not cosmetic.HidePromotions %}
         <!-- Managed Email Delivery service promo -->
         <div class="cp-service-banner">
             <i class="fas fa-paper-plane cp-sb-deco" aria-hidden="true"></i>
@@ -24,6 +25,7 @@
                 <i class="fas fa-arrow-right" aria-hidden="true"></i> {% trans "Learn more" %}
             </a>
         </div>
+        {% endif %}
 
         <h2 class="section-title">{% trans "EMAIL" %}</h2>
         <div class="cp-tile-grid">

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -57,7 +57,7 @@
     <script src="{% static 'baseTemplate/vendor/select2/select2.full.min.js' %}?v={{ CP_VERSION }}" data-cfasync="false"></script>
     
     <!-- Modern Design System -->
-    <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-ui.css' %}?v={{ CP_VERSION }}&ui=3">
+    <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-ui.css' %}?v={{ CP_VERSION }}&ui=4">
     <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-tokens.css' %}?v={{ CP_VERSION }}">
 
     {% block header_scripts %}{% endblock %}

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -9,6 +9,8 @@
     <title>{% block title %}CyberPanel{% endblock %}</title>
     
     {% load static %}
+    <!-- Hide Angular templates until compiled (prevents {$ $} flash) -->
+    <style>[ng\:cloak],[ng-cloak],[data-ng-cloak],[x-ng-cloak],.ng-cloak,.x-ng-cloak{display:none!important;}</style>
     <link rel="icon" type="image/x-icon" href="{% static 'baseTemplate/assets/finalBase/favicon.png' %}?v={{ CP_VERSION }}">
 
     <!-- Speed up third-party asset fetches (DNS + TLS handshake up front) -->
@@ -124,7 +126,6 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
-                        {% endif %}
                         <div class="cp-notif-item" data-key="backup" data-storekey="backupNotificationDismissed" data-store="session">
                             <div class="cp-notif-ic ic-warn"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -134,7 +135,6 @@
                             </div>
                             <button class="cp-notif-x" type="button" aria-label="{% trans 'Dismiss' %}"><i class="fas fa-times" aria-hidden="true"></i></button>
                         </div>
-                        {% if not cosmetic.HidePromotions %}
                         <div class="cp-notif-item" data-key="ai" data-storekey="aiScannerNotificationDismissed" data-store="session">
                             <div class="cp-notif-ic ic-accent"><i class="fas fa-brain" aria-hidden="true"></i></div>
                             <div class="cp-notif-body">
@@ -292,7 +292,7 @@
     </nav>
 
     <!-- Main Content -->
-    <main id="main-content" role="main" tabindex="-1">
+    <main id="main-content" role="main" tabindex="-1" ng-cloak>
         <nav id="cp-breadcrumb" class="cp-breadcrumb" aria-label="{% trans 'Breadcrumb' %}" hidden>
             <a href="{% url 'index' %}"><i class="fas fa-house" aria-hidden="true"></i> {% trans "Dashboard" %}</a>
             <span class="cp-bc-sep" id="cp-bc-group-wrap" hidden><span class="cp-bc-chevron" aria-hidden="true">/</span><span id="cp-bc-group" class="cp-bc-group"></span></span>
@@ -537,6 +537,7 @@
     <script defer src="{% static 'serverStatus/serverStatus.js' %}?v={{ CP_VERSION }}"></script>
     <script defer src="{% static 'firewall/firewall.js' %}?v={{ CP_VERSION }}"></script>
     <script defer src="{% static 'emailPremium/emailPremium.js' %}?v={{ CP_VERSION }}"></script>
+    <script defer src="{% static 'emailMarketing/emailMarketing.js' %}?v={{ CP_VERSION }}"></script>
     <script defer src="{% static 'manageServices/manageServices.js' %}?v={{ CP_VERSION }}"></script>
     <script defer src="{% static 'CLManager/CLManager.js' %}?v={{ CP_VERSION }}"></script>
     {% endblock %}

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -57,7 +57,7 @@
     <script src="{% static 'baseTemplate/vendor/select2/select2.full.min.js' %}?v={{ CP_VERSION }}" data-cfasync="false"></script>
     
     <!-- Modern Design System -->
-    <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-ui.css' %}?v={{ CP_VERSION }}&ui=2">
+    <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-ui.css' %}?v={{ CP_VERSION }}&ui=3">
     <link rel="stylesheet" type="text/css" href="{% static 'baseTemplate/css/cyberpanel-tokens.css' %}?v={{ CP_VERSION }}">
 
     {% block header_scripts %}{% endblock %}
@@ -180,16 +180,6 @@
             </div>
         </div>
 
-        <div class="sidebar-search">
-            <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
-            <input type="text" id="sidebar-search-input" autocomplete="off"
-                   placeholder="{% trans 'Search menu…' %}" aria-label="{% trans 'Search navigation menu' %}">
-            <button type="button" id="sidebar-search-clear" aria-label="{% trans 'Clear search' %}" hidden>
-                <i class="fas fa-times" aria-hidden="true"></i>
-            </button>
-        </div>
-        <div class="sidebar-search-empty" id="sidebar-search-empty" hidden>{% trans "No matching menu items" %}</div>
-
         <div class="server-info" ng-controller="systemStatusInfo" ng-init="getSystemStatus()">
             <div class="server-icon">
                 <i class="fas fa-desktop"></i>
@@ -209,6 +199,18 @@
                         <span ng-show="uptimeLoaded">{$ uptime $}</span>
                     </span>
                 </div>
+            </div>
+            <div class="sidebar-search sidebar-search--server" id="sidebar-feature-search">
+                <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
+                <input type="text" id="sidebar-search-input" autocomplete="off" spellcheck="false"
+                       placeholder="{% trans 'Search features & sites…' %}"
+                       aria-label="{% trans 'Search panel features and websites' %}"
+                       aria-autocomplete="list" aria-controls="sidebar-search-results" aria-expanded="false">
+                <button type="button" id="sidebar-search-clear" aria-label="{% trans 'Clear search' %}" hidden>
+                    <i class="fas fa-times" aria-hidden="true"></i>
+                </button>
+                <div class="sidebar-search-results" id="sidebar-search-results" role="listbox" hidden></div>
+                <div class="sidebar-search-empty" id="sidebar-search-empty" hidden>{% trans "No matching results" %}</div>
             </div>
         </div>
 
@@ -323,7 +325,7 @@
 
         // Comprehensive page index — the palette is the universal fast path now
         // that the sidebar is intentionally shallow. ACL-gated server-side.
-        var CP_PAGES = [
+        window.CP_PAGES = [
             // Quick actions
             {% if admin or createWebsite %}{l:'{% trans "Create Website" %}', h:'{% url "createWebsite" %}', i:'fa-circle-plus', g:'{% trans "Quick actions" %}'},{% endif %}
             {l:'{% trans "Deploy WordPress" %}', h:'{% url "createWordpress" %}', i:'fa-circle-plus', g:'{% trans "Quick actions" %}'},
@@ -418,11 +420,28 @@
             {% endif %}
         ];
 
+        var sitesLoaded = false;
+        var sitesLoading = false;
+
+        function getCookie(name) {
+            var cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = (cookies[i] || '').trim();
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+
         function buildIndex() {
-            items = CP_PAGES.map(function (p) {
+            items = (window.CP_PAGES || []).map(function (p) {
                 return {label: p.l, href: p.h, icon: (p.i.indexOf('fa-') === 0 ? 'fas ' + p.i : p.i), group: p.g, target: p.t || ''};
             });
-            // Normalize icon prefix (CP_PAGES uses bare fa-* or full "fab fa-*")
             // Supplement with any sidebar links not already indexed (e.g. plugin items)
             var sidebar = document.getElementById('sidebar');
             if (!sidebar) { return; }
@@ -436,6 +455,51 @@
                 var label = (lbl ? lbl.textContent : a.textContent).trim();
                 if (!label) { return; }
                 items.push({label: label, href: href, icon: 'fas fa-arrow-right', group: '{% trans "Pages" %}', target: a.getAttribute('target') || ''});
+            });
+        }
+
+        function mergeSiteItems(list, groupLabel, iconClass) {
+            if (!Array.isArray(list)) { return; }
+            var seen = {};
+            items.forEach(function (it) { seen[it.href] = 1; });
+            list.forEach(function (row) {
+                var domain = (row && row.domain) ? String(row.domain) : '';
+                if (!domain) { return; }
+                var href = '/websites/' + encodeURIComponent(domain) + '/settings';
+                if (seen[href]) { return; }
+                seen[href] = 1;
+                var label = domain;
+                if (row.masterDomain) { label = domain + ' (' + row.masterDomain + ')'; }
+                items.push({label: label, href: href, icon: iconClass, group: groupLabel, target: ''});
+            });
+        }
+
+        function ensureSites(done) {
+            if (sitesLoaded || sitesLoading) { if (done) done(); return; }
+            sitesLoading = true;
+            var csrf = getCookie('csrftoken') || '';
+            var headers = {'Content-Type': 'application/json', 'X-CSRFToken': csrf};
+            var bodySites = JSON.stringify({page: 1, recordsToShow: 100});
+            var bodyChild = JSON.stringify({page: 1, recordsToShow: 100});
+            function parseList(resp) {
+                return resp.json().then(function (data) {
+                    if (!data || data.listWebSiteStatus !== 1) { return []; }
+                    try {
+                        return (typeof data.data === 'string') ? JSON.parse(data.data) : (data.data || []);
+                    } catch (e) { return []; }
+                }).catch(function () { return []; });
+            }
+            Promise.all([
+                fetch('/websites/fetchWebsitesList', {method: 'POST', credentials: 'same-origin', headers: headers, body: bodySites}).then(parseList),
+                fetch('/websites/fetchChildDomainsMain', {method: 'POST', credentials: 'same-origin', headers: headers, body: bodyChild}).then(parseList)
+            ]).then(function (pair) {
+                if (!items.length) { buildIndex(); }
+                mergeSiteItems(pair[0], '{% trans "Websites" %}', 'fas fa-globe');
+                mergeSiteItems(pair[1], '{% trans "Subdomains" %}', 'fas fa-diagram-project');
+                sitesLoaded = true;
+            }).catch(function () { /* ACL / network: keep static index */ }).then(function () {
+                sitesLoading = false;
+                if (done) done();
             });
         }
 
@@ -473,10 +537,12 @@
             else { filtered = items.filter(function (it) { return it.label.toLowerCase().indexOf(term) !== -1 || (it.group || '').toLowerCase().indexOf(term) !== -1; }); }
             activeIdx = 0; render();
         }
-        function open() {
+        function open(initialTerm) {
             if (!items.length) { buildIndex(); }
             overlay.hidden = false;
-            input.value = ''; search('');
+            input.value = initialTerm || '';
+            ensureSites(function () { search(input.value); });
+            search(input.value);
             setTimeout(function () { input.focus(); }, 10);
             document.addEventListener('keydown', onKey, true);
         }
@@ -484,6 +550,31 @@
             overlay.hidden = true;
             document.removeEventListener('keydown', onKey, true);
         }
+        function queryItems(term, limit) {
+            if (!items.length) { buildIndex(); }
+            term = (term || '').trim().toLowerCase();
+            var out;
+            if (!term) { out = items.slice(0, limit || 8); }
+            else {
+                out = items.filter(function (it) {
+                    return it.label.toLowerCase().indexOf(term) !== -1 || (it.group || '').toLowerCase().indexOf(term) !== -1;
+                });
+                if (limit) { out = out.slice(0, limit); }
+            }
+            return out;
+        }
+        window.CPSearch = {
+            open: open,
+            close: close,
+            ensureIndex: function () { if (!items.length) buildIndex(); },
+            ensureSites: ensureSites,
+            query: queryItems,
+            go: function (it) {
+                if (!it) { return; }
+                if (it.target === '_blank') { window.open(it.href, '_blank'); }
+                else { window.location.href = it.href; }
+            }
+        };
         function go() {
             var it = filtered[activeIdx];
             if (!it) { return; }
@@ -681,82 +772,109 @@
             initSidebarSearch();
         });
 
-        // Sidebar quick-filter / jump-to
+        // Sidebar typeahead: same index as Ctrl/Cmd-K (pages + websites/subdomains).
         function initSidebarSearch() {
             var input = document.getElementById('sidebar-search-input');
             if (!input) { return; }
             var clearBtn = document.getElementById('sidebar-search-clear');
             var emptyMsg = document.getElementById('sidebar-search-empty');
-            var sidebar  = document.getElementById('sidebar');
-            var sectionHeaders = Array.prototype.slice.call(sidebar.querySelectorAll('.section-header'));
-            var serverInfo = sidebar.querySelector('.server-info');
+            var resultsEl = document.getElementById('sidebar-search-results');
+            var activeIdx = 0;
+            var current = [];
+            var debounceTimer = null;
 
-            function inSubmenu(el) {
-                var p = el.parentElement;
-                while (p && p !== sidebar) {
-                    if (p.classList && p.classList.contains('submenu')) { return true; }
-                    p = p.parentElement;
+            function hideDropdown() {
+                if (resultsEl) { resultsEl.hidden = true; resultsEl.innerHTML = ''; }
+                if (emptyMsg) { emptyMsg.hidden = true; }
+                input.setAttribute('aria-expanded', 'false');
+                activeIdx = 0;
+                current = [];
+            }
+            function paintActive() {
+                if (!resultsEl) { return; }
+                var rows = resultsEl.querySelectorAll('.sidebar-search-item');
+                rows.forEach(function (r, i) { r.classList.toggle('active', i === activeIdx); });
+            }
+            function render(list) {
+                current = list || [];
+                if (!resultsEl) { return; }
+                resultsEl.innerHTML = '';
+                if (!current.length) {
+                    resultsEl.hidden = true;
+                    if (emptyMsg) { emptyMsg.hidden = false; }
+                    input.setAttribute('aria-expanded', 'false');
+                    return;
                 }
-                return false;
-            }
-            function topItems() {
-                return Array.prototype.slice.call(sidebar.querySelectorAll('.menu-item')).filter(function (el) {
-                    return !inSubmenu(el);
+                if (emptyMsg) { emptyMsg.hidden = true; }
+                resultsEl.hidden = false;
+                input.setAttribute('aria-expanded', 'true');
+                current.forEach(function (it, i) {
+                    var row = document.createElement('button');
+                    row.type = 'button';
+                    row.className = 'sidebar-search-item' + (i === activeIdx ? ' active' : '');
+                    row.setAttribute('role', 'option');
+                    row.innerHTML = '<span class="sidebar-search-ic"><i class="' + (it.icon || 'fas fa-arrow-right') + '"></i></span>' +
+                        '<span><div class="sidebar-search-label"></div><div class="sidebar-search-sub"></div></span>';
+                    row.querySelector('.sidebar-search-label').textContent = it.label;
+                    row.querySelector('.sidebar-search-sub').textContent = it.group || '';
+                    row.addEventListener('mouseenter', function () { activeIdx = i; paintActive(); });
+                    row.addEventListener('click', function () {
+                        if (window.CPSearch) { window.CPSearch.go(it); }
+                        else { window.location.href = it.href; }
+                    });
+                    resultsEl.appendChild(row);
                 });
             }
-            function reset() {
-                sidebar.querySelectorAll('.menu-item').forEach(function (el) { el.style.display = ''; el.classList.remove('expanded'); });
-                sidebar.querySelectorAll('.submenu').forEach(function (s) { s.style.display = ''; s.classList.remove('show'); });
-                sectionHeaders.forEach(function (h) { h.style.display = ''; });
-                if (serverInfo) { serverInfo.style.display = ''; }
-                emptyMsg.hidden = true;
-                clearBtn.hidden = true;
-                if (typeof setActiveMenuState === 'function') { setActiveMenuState(); }
-            }
-            function filter(term) {
-                clearBtn.hidden = false;
-                sectionHeaders.forEach(function (h) { h.style.display = 'none'; });
-                if (serverInfo) { serverInfo.style.display = 'none'; }
-                var anyVisible = false;
-                topItems().forEach(function (item) {
-                    var sib = item.nextElementSibling;
-                    var submenu = (sib && sib.classList && sib.classList.contains('submenu')) ? sib : null;
-                    var label = (item.textContent || '').toLowerCase();
-                    if (submenu) {
-                        var groupMatch = label.indexOf(term) !== -1;
-                        var childVisible = false;
-                        Array.prototype.slice.call(submenu.querySelectorAll('.menu-item')).forEach(function (c) {
-                            var m = groupMatch || (c.textContent || '').toLowerCase().indexOf(term) !== -1;
-                            c.style.display = m ? '' : 'none';
-                            if (m) { childVisible = true; }
-                        });
-                        if (groupMatch || childVisible) {
-                            item.style.display = '';
-                            submenu.style.display = '';
-                            submenu.classList.add('show');
-                            item.classList.add('expanded');
-                            anyVisible = true;
-                        } else {
-                            item.style.display = 'none';
-                            submenu.style.display = 'none';
-                            submenu.classList.remove('show');
-                            item.classList.remove('expanded');
-                        }
-                    } else {
-                        var match = label.indexOf(term) !== -1;
-                        item.style.display = match ? '' : 'none';
-                        if (match) { anyVisible = true; }
-                    }
+            function runSearch() {
+                var term = input.value.trim();
+                clearBtn.hidden = !term;
+                if (!term) { hideDropdown(); return; }
+                if (!window.CPSearch) { return; }
+                window.CPSearch.ensureIndex();
+                window.CPSearch.ensureSites(function () {
+                    render(window.CPSearch.query(term, 12));
                 });
-                emptyMsg.hidden = anyVisible;
+                render(window.CPSearch.query(term, 12));
             }
             input.addEventListener('input', function () {
-                var t = input.value.trim().toLowerCase();
-                if (!t) { reset(); } else { filter(t); }
+                if (debounceTimer) { clearTimeout(debounceTimer); }
+                debounceTimer = setTimeout(runSearch, 120);
             });
-            clearBtn.addEventListener('click', function () { input.value = ''; reset(); input.focus(); });
+            input.addEventListener('focus', function () {
+                if (input.value.trim()) { runSearch(); }
+            });
+            clearBtn.addEventListener('click', function () {
+                input.value = '';
+                hideDropdown();
+                clearBtn.hidden = true;
+                input.focus();
+            });
             input.addEventListener('keydown', function (e) {
-                if (e.key === 'Escape') { input.value = ''; reset(); }
+                if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    if (!current.length) { runSearch(); return; }
+                    activeIdx = Math.min(activeIdx + 1, current.length - 1);
+                    paintActive();
+                } else if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    activeIdx = Math.max(activeIdx - 1, 0);
+                    paintActive();
+                } else if (e.key === 'Enter') {
+                    e.preventDefault();
+                    if (current[activeIdx] && window.CPSearch) { window.CPSearch.go(current[activeIdx]); }
+                    else if (window.CPSearch) { window.CPSearch.open(input.value); }
+                } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    if (input.value) { input.value = ''; hideDropdown(); clearBtn.hidden = true; }
+                    else { hideDropdown(); input.blur(); }
+                } else if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+                    e.preventDefault();
+                    if (window.CPSearch) { window.CPSearch.open(input.value); }
+                }
+            });
+            document.addEventListener('click', function (e) {
+                var wrap = document.getElementById('sidebar-feature-search');
+                if (wrap && !wrap.contains(e.target)) { hideDropdown(); }
             });
         }
 

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -626,7 +626,7 @@
     <script defer src="{% static 'managePHP/managePHP.js' %}?v={{ CP_VERSION }}"></script>
     <script defer src="{% static 'serverLogs/serverLogs.js' %}?v={{ CP_VERSION }}"></script>
     <script defer src="{% static 'serverStatus/serverStatus.js' %}?v={{ CP_VERSION }}"></script>
-    <script defer src="{% static 'firewall/firewall.js' %}?v={{ CP_VERSION }}"></script>
+    <script defer src="{% static 'firewall/firewall.js' %}?v={{ CP_VERSION }}-fwdel1"></script>
     <script defer src="{% static 'emailPremium/emailPremium.js' %}?v={{ CP_VERSION }}"></script>
     <script defer src="{% static 'emailMarketing/emailMarketing.js' %}?v={{ CP_VERSION }}"></script>
     <script defer src="{% static 'manageServices/manageServices.js' %}?v={{ CP_VERSION }}"></script>

--- a/baseTemplate/templates/baseTemplate/siteWorkspace.html
+++ b/baseTemplate/templates/baseTemplate/siteWorkspace.html
@@ -120,6 +120,7 @@
                 {% if admin or suspendWebsite %}<a class="cp-tile" href="{% url 'siteState' %}"><span class="cp-tile-ic"><i class="fas fa-pause"></i></span><span><div class="cp-tile-title">{% trans "Suspend Website" %}</div><div class="cp-tile-sub">{% trans "Suspend or unsuspend this site" %}</div></span></a>{% endif %}
                 {% if admin or deleteWebsite %}<a class="cp-tile" href="{% url 'deleteWebsite' %}"><span class="cp-tile-ic"><i class="fas fa-trash"></i></span><span><div class="cp-tile-title">{% trans "Delete Website" %}</div><div class="cp-tile-sub">{% trans "Permanently remove this site" %}</div></span></a>{% endif %}
             </div>
+            {% if not cosmetic.HidePromotions %}
             <div class="cp-empty-nudge" style="margin-top:18px;">
                 <div class="cp-empty-ic"><i class="fas fa-rocket"></i></div>
                 <h3>{% trans "Want this site built or customized for you?" %}</h3>
@@ -128,6 +129,7 @@
                     <a class="cp-build-link" href="{% url 'buildServices' %}"><i class="fas fa-arrow-right"></i> {% trans "Explore Build Services" %}</a>
                 </div>
             </div>
+            {% endif %}
         </div>
 
     </div>

--- a/baseTemplate/urls.py
+++ b/baseTemplate/urls.py
@@ -31,4 +31,8 @@ urlpatterns = [
     re_path(r'^dismiss_backup_notification$', views.dismiss_backup_notification, name='dismiss_backup_notification'),
     re_path(r'^dismiss_ai_scanner_notification$', views.dismiss_ai_scanner_notification, name='dismiss_ai_scanner_notification'),
     re_path(r'^get_notification_preferences$', views.get_notification_preferences, name='get_notification_preferences'),
+    re_path(r'^sshSecurityWhitelistList$', views.sshSecurityWhitelistList, name='sshSecurityWhitelistList'),
+    re_path(r'^sshSecurityWhitelistAdd$', views.sshSecurityWhitelistAdd, name='sshSecurityWhitelistAdd'),
+    re_path(r'^sshSecurityWhitelistRemove$', views.sshSecurityWhitelistRemove, name='sshSecurityWhitelistRemove'),
+    re_path(r'^sshSecurityWhitelistUpdate$', views.sshSecurityWhitelistUpdate, name='sshSecurityWhitelistUpdate'),
 ]

--- a/baseTemplate/views.py
+++ b/baseTemplate/views.py
@@ -1878,3 +1878,176 @@ def get_notification_preferences(request):
         
     except Exception as e:
         return HttpResponse(json.dumps({'status': 0, 'error': str(e)}), content_type='application/json', status=500)
+
+
+def _ssh_whitelist_admin_gate(request):
+    """Return (user_id, error_response). error_response is HttpResponse or None."""
+    user_id = request.session.get('userID')
+    if not user_id:
+        return None, HttpResponse(
+            json.dumps({'status': 0, 'error': 'Not logged in'}),
+            content_type='application/json',
+            status=403,
+        )
+    currentACL = ACLManager.loadedACL(user_id)
+    if not currentACL.get('admin', 0):
+        return None, HttpResponse(
+            json.dumps({'status': 0, 'error': 'Admin only'}),
+            content_type='application/json',
+            status=403,
+        )
+    return user_id, None
+
+
+def _ssh_whitelist_parse_body(request):
+    try:
+        if not request.body:
+            return {}, None
+        body_str = request.body.decode('utf-8')
+        if not body_str or not body_str.strip():
+            return {}, None
+        data = json.loads(body_str)
+        if not isinstance(data, dict):
+            return None, HttpResponse(
+                json.dumps({'status': 0, 'error': 'Invalid request format'}),
+                content_type='application/json',
+                status=400,
+            )
+        return data, None
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        return None, HttpResponse(
+            json.dumps({'status': 0, 'error': 'Invalid request format: %s' % str(e)}),
+            content_type='application/json',
+            status=400,
+        )
+
+
+@require_POST
+def sshSecurityWhitelistList(request):
+    """List Trusted IPs (SSH security whitelist)."""
+    try:
+        _, err = _ssh_whitelist_admin_gate(request)
+        if err:
+            return err
+        from plogical.sshSecurityWhitelistUtilities import SSHSecurityWhitelistUtilities
+        entries = SSHSecurityWhitelistUtilities.load_entries()
+        return HttpResponse(
+            json.dumps({'status': 1, 'entries': entries}, ensure_ascii=False),
+            content_type='application/json',
+        )
+    except Exception as e:
+        logging.CyberCPLogFileWriter.writeToFile('sshSecurityWhitelistList: %s' % str(e))
+        return HttpResponse(
+            json.dumps({'status': 0, 'error': 'Could not load trusted IPs'}),
+            content_type='application/json',
+            status=500,
+        )
+
+
+@require_POST
+def sshSecurityWhitelistAdd(request):
+    """Add IP to Trusted IPs whitelist."""
+    try:
+        _, err = _ssh_whitelist_admin_gate(request)
+        if err:
+            return err
+        data, perr = _ssh_whitelist_parse_body(request)
+        if perr:
+            return perr
+        ip = (data.get('ip') or '').strip()
+        label = (data.get('label') or '').strip()
+        from plogical.sshSecurityWhitelistUtilities import SSHSecurityWhitelistUtilities
+        ok, result = SSHSecurityWhitelistUtilities.add_entry(ip, label)
+        if ok:
+            return HttpResponse(
+                json.dumps({'status': 1, 'ip': result}),
+                content_type='application/json',
+            )
+        return HttpResponse(
+            json.dumps({'status': 0, 'error': result}),
+            content_type='application/json',
+            status=400,
+        )
+    except Exception as e:
+        logging.CyberCPLogFileWriter.writeToFile('sshSecurityWhitelistAdd: %s' % str(e))
+        return HttpResponse(
+            json.dumps({'status': 0, 'error': 'Could not add trusted IP'}),
+            content_type='application/json',
+            status=500,
+        )
+
+
+@require_POST
+def sshSecurityWhitelistRemove(request):
+    """Remove IP from Trusted IPs whitelist."""
+    try:
+        _, err = _ssh_whitelist_admin_gate(request)
+        if err:
+            return err
+        data, perr = _ssh_whitelist_parse_body(request)
+        if perr:
+            return perr
+        ip = (data.get('ip') or '').strip()
+        from plogical.sshSecurityWhitelistUtilities import SSHSecurityWhitelistUtilities
+        ok, result = SSHSecurityWhitelistUtilities.remove_entry(ip)
+        if ok:
+            return HttpResponse(
+                json.dumps({'status': 1, 'ip': result}),
+                content_type='application/json',
+            )
+        return HttpResponse(
+            json.dumps({'status': 0, 'error': result}),
+            content_type='application/json',
+            status=400,
+        )
+    except Exception as e:
+        logging.CyberCPLogFileWriter.writeToFile('sshSecurityWhitelistRemove: %s' % str(e))
+        return HttpResponse(
+            json.dumps({'status': 0, 'error': 'Could not remove trusted IP'}),
+            content_type='application/json',
+            status=500,
+        )
+
+
+@require_POST
+def sshSecurityWhitelistUpdate(request):
+    """Update Trusted IP row (IP and/or label)."""
+    try:
+        _, err = _ssh_whitelist_admin_gate(request)
+        if err:
+            return err
+        data, perr = _ssh_whitelist_parse_body(request)
+        if perr:
+            return perr
+        ip = (data.get('ip') or '').strip()
+        new_ip = data.get('new_ip')
+        label = data.get('label')
+        from plogical.sshSecurityWhitelistUtilities import SSHSecurityWhitelistUtilities
+        ok, result, unchanged = SSHSecurityWhitelistUtilities.update_entry(
+            ip,
+            new_ip=new_ip,
+            label=label,
+        )
+        if ok:
+            msg = 'No changes to save.' if unchanged else 'Entry updated'
+            return HttpResponse(
+                json.dumps({
+                    'status': 1,
+                    'ip': result,
+                    'unchanged': bool(unchanged),
+                    'message': msg,
+                }),
+                content_type='application/json',
+            )
+        return HttpResponse(
+            json.dumps({'status': 0, 'error': result}),
+            content_type='application/json',
+            status=400,
+        )
+    except Exception as e:
+        logging.CyberCPLogFileWriter.writeToFile('sshSecurityWhitelistUpdate: %s' % str(e))
+        return HttpResponse(
+            json.dumps({'status': 0, 'error': 'Could not update trusted IP'}),
+            content_type='application/json',
+            status=500,
+        )

--- a/baseTemplate/views.py
+++ b/baseTemplate/views.py
@@ -31,7 +31,7 @@ import re
 # Create your views here.
 
 VERSION = '2.5.5'
-BUILD = 1
+BUILD = 2
 
 
 def _version_compare(a, b):

--- a/databases/templates/databases/mysqlmanager.html
+++ b/databases/templates/databases/mysqlmanager.html
@@ -510,13 +510,44 @@
         .page-title {
             font-size: 2rem;
         }
+
+        .page-header {
+            text-align: left;
+        }
+
+        .header-actions {
+            flex-direction: column;
+            width: 100%;
+        }
+
+        .header-actions a {
+            width: 100%;
+            justify-content: center;
+        }
+
+        .stats-grid {
+            grid-template-columns: 1fr !important;
+            gap: 0.75rem;
+        }
+
+        .stat-card {
+            width: 100%;
+        }
         
         .stat-value {
             font-size: 2rem;
         }
+
+        .table-responsive {
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            margin: 0 -0.5rem;
+            padding: 0 0.5rem;
+        }
         
         .processes-table {
-            font-size: 1rem;
+            font-size: 0.875rem;
+            min-width: 720px;
         }
         
         .processes-table th,
@@ -526,6 +557,55 @@
         
         .info-text {
             max-width: 150px;
+        }
+
+        /* Card-style process rows when very narrow */
+        .processes-table thead {
+            display: none;
+        }
+
+        .processes-table,
+        .processes-table tbody,
+        .processes-table tr,
+        .processes-table td {
+            display: block;
+            width: 100%;
+        }
+
+        .processes-table {
+            min-width: 0;
+        }
+
+        .processes-table tr {
+            background: var(--bg-secondary, #f8f9ff);
+            border: 1px solid var(--border-color, #e5e7eb);
+            border-radius: 10px;
+            margin-bottom: 0.75rem;
+            padding: 0.75rem;
+        }
+
+        .processes-table td {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.75rem;
+            padding: 0.35rem 0;
+            border: none;
+        }
+
+        .processes-table td::before {
+            content: attr(data-label);
+            font-weight: 600;
+            color: var(--text-secondary, #64748b);
+            flex-shrink: 0;
+        }
+
+        .processes-table tr.empty-row td {
+            display: block;
+            text-align: center;
+        }
+
+        .processes-table tr.empty-row td::before {
+            content: none;
         }
     }
 </style>
@@ -616,10 +696,10 @@
                     </thead>
                     <tbody>
                         <tr ng-repeat="process in processes">
-                            <td>
+                            <td data-label="{% trans 'ID' %}">
                                 <span class="process-id" ng-bind="process.id"></span>
                             </td>
-                            <td>
+                            <td data-label="{% trans 'User' %}">
                                 <div class="process-user">
                                     <div class="user-icon">
                                         <i class="fas fa-user"></i>
@@ -627,34 +707,34 @@
                                     <span ng-bind="process.user"></span>
                                 </div>
                             </td>
-                            <td>
+                            <td data-label="{% trans 'Database' %}">
                                 <i class="fas fa-database" style="color: var(--text-muted); margin-right: 0.5rem;"></i>
                                 <span ng-bind="process.database || 'None'"></span>
                             </td>
-                            <td>
+                            <td data-label="{% trans 'Command' %}">
                                 <span class="command-badge" ng-bind="process.command"></span>
                             </td>
-                            <td>
+                            <td data-label="{% trans 'Time' %}">
                                 <span class="time-badge" ng-bind="process.time + 's'"></span>
                             </td>
-                            <td>
+                            <td data-label="{% trans 'State' %}">
                                 <span class="state-badge" 
                                       ng-class="{'state-active': process.state === 'executing', 'state-idle': process.state !== 'executing'}"
                                       ng-bind="process.state || 'Idle'"></span>
                             </td>
-                            <td>
+                            <td data-label="{% trans 'Query Info' %}">
                                 <span class="info-text" 
                                       ng-bind="(process.info && process.info !== 'NULL') ? process.info : 'No query'"
                                       ng-attr-title="{$ (process.info && process.info !== 'NULL') ? process.info : 'No query' $}"></span>
                             </td>
-                            <td>
+                            <td data-label="{% trans 'Progress' %}">
                                 <div class="progress-bar">
                                     <div class="progress-fill" 
                                          ng-style="{'width': (process.progress || 0) + '%'}"></div>
                                 </div>
                             </td>
                         </tr>
-                        <tr ng-if="processes.length === 0">
+                        <tr ng-if="processes.length === 0" class="empty-row">
                             <td colspan="8" class="empty-state">
                                 <i class="fas fa-check-circle"></i>
                                 <p>{% trans "No active processes found" %}</p>

--- a/emailMarketing/__init__.py
+++ b/emailMarketing/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'emailMarketing.apps.EmailmarketingConfig'

--- a/emailMarketing/admin.py
+++ b/emailMarketing/admin.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+
+from django.contrib import admin
+
+# Register your models here.

--- a/emailMarketing/apps.py
+++ b/emailMarketing/apps.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+
+from django.apps import AppConfig
+
+
+class EmailmarketingConfig(AppConfig):
+    name = 'emailMarketing'
+    def ready(self):
+        from . import signals

--- a/emailMarketing/emACL.py
+++ b/emailMarketing/emACL.py
@@ -1,0 +1,66 @@
+from .models import EmailMarketing, EmailTemplate, SMTPHosts, EmailLists, EmailJobs
+from websiteFunctions.models import Websites
+
+class emACL:
+
+    @staticmethod
+    def checkIfEMEnabled(userName):
+        try:
+            user = EmailMarketing.objects.get(userName=userName)
+            return 0
+        except:
+            return 1
+
+    @staticmethod
+    def getEmailsLists(domain):
+        website = Websites.objects.get(domain=domain)
+        emailLists = website.emaillists_set.all()
+        listNames = []
+
+        for items in emailLists:
+            listNames.append(items.listName)
+
+        return listNames
+
+    @staticmethod
+    def allTemplates(currentACL, admin):
+        if currentACL['admin'] == 1:
+            allTemplates = EmailTemplate.objects.all()
+        else:
+            allTemplates = admin.emailtemplate_set.all()
+
+        templateNames = []
+        for items in allTemplates:
+            templateNames.append(items.name)
+        return templateNames
+
+    @staticmethod
+    def allSMTPHosts(currentACL, admin):
+        if currentACL['admin'] == 1:
+            allHosts = SMTPHosts.objects.all()
+        else:
+            allHosts = admin.smtphosts_set.all()
+        hostNames = []
+
+        for items in allHosts:
+            hostNames.append(items.host)
+
+        return hostNames
+
+    @staticmethod
+    def allEmailsLists(currentACL, admin):
+        listNames = []
+        emailLists = EmailLists.objects.all()
+
+        if currentACL['admin'] == 1:
+            for items in emailLists:
+                listNames.append(items.listName)
+        else:
+            for items in emailLists:
+                if items.owner.admin == admin:
+                    listNames.append(items.listName)
+
+        return listNames
+
+
+

--- a/emailMarketing/emailMarketing.py
+++ b/emailMarketing/emailMarketing.py
@@ -1,0 +1,427 @@
+#!/usr/local/CyberCP/bin/python
+
+import os
+import time
+import csv
+import re
+import plogical.CyberCPLogFileWriter as logging
+from .models import EmailLists, EmailsInList, EmailTemplate, EmailJobs, SMTPHosts, ValidationLog
+from plogical.backupSchedule import backupSchedule
+from websiteFunctions.models import Websites
+import threading as multi
+import socket, smtplib
+import DNS
+from random import randint
+from plogical.processUtilities import ProcessUtilities
+
+class emailMarketing(multi.Thread):
+    def __init__(self, function, extraArgs):
+        multi.Thread.__init__(self)
+        self.function = function
+        self.extraArgs = extraArgs
+
+    def run(self):
+        try:
+            if self.function == 'createEmailList':
+                self.createEmailList()
+            elif self.function == 'verificationJob':
+                self.verificationJob()
+            elif self.function == 'startEmailJob':
+                self.startEmailJob()
+        except BaseException as msg:
+            logging.CyberCPLogFileWriter.writeToFile(str(msg) + ' [emailMarketing.run]')
+
+    def createEmailList(self):
+        try:
+            website = Websites.objects.get(domain=self.extraArgs['domain'])
+            try:
+                newList = EmailLists(owner=website, listName=self.extraArgs['listName'], dateCreated=time.strftime("%I-%M-%S-%a-%b-%Y"))
+                newList.save()
+            except:
+                newList = EmailLists.objects.get(listName=self.extraArgs['listName'])
+
+            counter = 0
+
+            if self.extraArgs['path'].endswith('.csv'):
+                with open(self.extraArgs['path'], 'r') as emailsList:
+                    data = csv.reader(emailsList, delimiter=',')
+                    for items in data:
+                        try:
+                            for value in items:
+                                if re.match('^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$', value) != None:
+                                    try:
+                                        getEmail = EmailsInList.objects.get(owner=newList, email=value)
+                                    except:
+                                        try:
+                                            newEmail = EmailsInList(owner=newList, email=value,
+                                                                    verificationStatus='NOT CHECKED',
+                                                                    dateCreated=time.strftime("%I-%M-%S-%a-%b-%Y"))
+                                            newEmail.save()
+                                        except:
+                                            pass
+                                    logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'], str(counter) + ' emails read.')
+                                    counter = counter + 1
+                        except BaseException as msg:
+                            logging.CyberCPLogFileWriter.writeToFile('%s. [createEmailList]' % (str(msg)))
+                            continue
+            elif self.extraArgs['path'].endswith('.txt'):
+                with open(self.extraArgs['path'], 'r') as emailsList:
+                    emails = emailsList.readline()
+                    while emails:
+                        email = emails.strip('\n')
+                        if re.match('^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$', email) != None:
+                            try:
+                                getEmail = EmailsInList.objects.get(owner=newList, email=email)
+                            except BaseException as msg:
+                                newEmail = EmailsInList(owner=newList, email=email, verificationStatus='NOT CHECKED',
+                                                        dateCreated=time.strftime("%I-%M-%S-%a-%b-%Y"))
+                                newEmail.save()
+                            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'],str(counter) + ' emails read.')
+                            counter = counter + 1
+                        emails = emailsList.readline()
+
+            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'], str(counter) + 'Successfully read all emails. [200]')
+        except BaseException as msg:
+            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'], str(msg) +'. [404]')
+            return 0
+
+    def findNextIP(self):
+        try:
+            if self.delayData['rotation'] == 'Disable':
+                return None
+            elif self.delayData['rotation'] == 'IPv4':
+                if self.delayData['ipv4'].find(',') == -1:
+                    return self.delayData['ipv4']
+                else:
+                    ipv4s = self.delayData['ipv4'].split(',')
+
+                    if self.currentIP == '':
+                        return ipv4s[0]
+                    else:
+                        returnCheck = 0
+
+                        for items in ipv4s:
+                            if returnCheck == 1:
+                                return items
+                            if items == self.currentIP:
+                                returnCheck = 1
+
+                        return ipv4s[0]
+            else:
+                if self.delayData['ipv6'].find(',') == -1:
+                    return self.delayData['ipv6']
+                else:
+                    ipv6 = self.delayData['ipv6'].split(',')
+
+                    if self.currentIP == '':
+                        return ipv6[0]
+                    else:
+                        returnCheck = 0
+
+                        for items in ipv6:
+                            if returnCheck == 1:
+                                return items
+                            if items == self.currentIP:
+                                returnCheck = 1
+                    return ipv6[0]
+        except BaseException as msg:
+            logging.CyberCPLogFileWriter.writeToFile(str(msg))
+            return None
+
+    def verificationJob(self):
+        try:
+
+            verificationList = EmailLists.objects.get(listName=self.extraArgs['listName'])
+            domain = verificationList.owner.domain
+
+            if not os.path.exists('/home/cyberpanel/' + domain):
+                os.mkdir('/home/cyberpanel/' + domain)
+
+            tempStatusPath = '/home/cyberpanel/' + domain + "/" + self.extraArgs['listName']
+            logging.CyberCPLogFileWriter.statusWriter(tempStatusPath, 'Starting verification job..')
+
+            counter = 1
+            counterGlobal = 0
+
+            allEmailsInList = verificationList.emailsinlist_set.all()
+
+            configureVerifyPath = '/home/cyberpanel/configureVerify'
+            finalPath = '%s/%s' % (configureVerifyPath, domain)
+
+
+            import json
+            if os.path.exists(finalPath):
+                self.delayData = json.loads(open(finalPath, 'r').read())
+
+            self.currentIP = ''
+
+            ValidationLog(owner=verificationList, status=backupSchedule.INFO, message='Starting email verification..').save()
+
+            for items in allEmailsInList:
+                if items.verificationStatus != 'Verified':
+                    try:
+
+                        email = items.email
+                        self.currentEmail = email
+                        domainName = email.split('@')[1]
+                        records = DNS.dnslookup(domainName, 'MX', 15)
+
+                        counterGlobal = counterGlobal + 1
+
+                        for mxRecord in records:
+
+                            # Get local server hostname
+                            host = socket.gethostname()
+
+                            ## Only fetching smtp object
+
+                            if os.path.exists(finalPath):
+                                try:
+                                    delay = self.delayData['delay']
+                                    if delay == 'Enable':
+                                        if counterGlobal == int(self.delayData['delayAfter']):
+                                            ValidationLog(owner=verificationList, status=backupSchedule.INFO,
+                                                          message='Sleeping for %s seconds...' % (self.delayData['delayTime'])).save()
+
+                                            time.sleep(int(self.delayData['delayTime']))
+                                            counterGlobal = 0
+                                            self.currentIP = self.findNextIP()
+
+                                            ValidationLog(owner=verificationList, status=backupSchedule.INFO,
+                                                          message='IP being used for validation until next sleep: %s.' % (str(self.currentIP))).save()
+
+                                            if self.currentIP == None:
+                                                server = smtplib.SMTP(timeout=10)
+                                            else:
+                                                server = smtplib.SMTP(self.currentIP, timeout=10)
+                                        else:
+
+                                            if self.currentIP == '':
+                                                self.currentIP = self.findNextIP()
+                                                ValidationLog(owner=verificationList, status=backupSchedule.INFO,
+                                                              message='IP being used for validation until next sleep: %s.' % (
+                                                                  str(self.currentIP))).save()
+
+                                            if self.currentIP == None:
+                                                server = smtplib.SMTP(timeout=10)
+                                            else:
+                                                server = smtplib.SMTP(self.currentIP, timeout=10)
+                                    else:
+                                        logging.CyberCPLogFileWriter.writeToFile(
+                                            'Delay not configured..')
+
+                                        ValidationLog(owner=verificationList, status=backupSchedule.INFO,
+                                                      message='Delay not configured..').save()
+
+                                        server = smtplib.SMTP(timeout=10)
+                                except BaseException as msg:
+
+                                    ValidationLog(owner=verificationList, status=backupSchedule.ERROR,
+                                                  message='Delay not configured. Error message: %s' % (str(msg))).save()
+
+                                    server = smtplib.SMTP(timeout=10)
+                            else:
+                                server = smtplib.SMTP(timeout=10)
+
+                            ###
+
+                            server.set_debuglevel(0)
+
+                            # SMTP Conversation
+                            server.connect(mxRecord[1])
+                            server.helo(host)
+                            server.mail('host' + "@" + host)
+                            code, message = server.rcpt(str(email))
+                            server.quit()
+
+                            # Assume 250 as Success
+                            if code == 250:
+                                items.verificationStatus = 'Verified'
+                                items.save()
+                                break
+                            else:
+                                ValidationLog(owner=verificationList, status=backupSchedule.ERROR,
+                                              message='Failed to verify %s. Error message %s' % (email, message.decode())).save()
+                                items.verificationStatus = 'Verification Failed'
+                                items.save()
+
+                        logging.CyberCPLogFileWriter.statusWriter(tempStatusPath, str(counter) + ' emails verified so far..')
+                        counter = counter + 1
+                    except BaseException as msg:
+                        items.verificationStatus = 'Verification Failed'
+                        items.save()
+                        counter = counter + 1
+                        ValidationLog(owner=verificationList, status=backupSchedule.ERROR,
+                                      message='Failed to verify %s. Error message %s' % (
+                                      self.currentEmail , str(msg))).save()
+
+
+                verificationList.notVerified = verificationList.emailsinlist_set.filter(verificationStatus='Verification Failed').count()
+                verificationList.verified = verificationList.emailsinlist_set.filter(verificationStatus='Verified').count()
+                verificationList.save()
+
+            ValidationLog(owner=verificationList, status=backupSchedule.ERROR, message=str(counter) + ' emails successfully verified. [200]').save()
+
+            logging.CyberCPLogFileWriter.statusWriter(tempStatusPath, str(counter) + ' emails successfully verified. [200]')
+        except BaseException as msg:
+            verificationList = EmailLists.objects.get(listName=self.extraArgs['listName'])
+            domain = verificationList.owner.domain
+            tempStatusPath = '/home/cyberpanel/' + domain + "/" + self.extraArgs['listName']
+            logging.CyberCPLogFileWriter.statusWriter(tempStatusPath, str(msg) +'. [404]')
+            logging.CyberCPLogFileWriter.writeToFile(str(msg))
+            return 0
+
+    def setupSMTPConnection(self):
+        try:
+            if self.extraArgs['host'] == 'localhost':
+                self.smtpServer = smtplib.SMTP('127.0.0.1')
+                return 1
+            else:
+                self.verifyHost = SMTPHosts.objects.get(host=self.extraArgs['host'])
+                self.smtpServer = smtplib.SMTP(str(self.verifyHost.host), int(self.verifyHost.port))
+
+                if int(self.verifyHost.port) == 587:
+                    self.smtpServer.starttls()
+
+                self.smtpServer.login(str(self.verifyHost.userName), str(self.verifyHost.password))
+                return 1
+        except smtplib.SMTPHeloError:
+            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'],
+                                                      'The server didnt reply properly to the HELO greeting.')
+            return 0
+        except smtplib.SMTPAuthenticationError:
+            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'],
+                                                      'Username and password combination not accepted.')
+            return 0
+        except smtplib.SMTPException:
+            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'],
+                                                      'No suitable authentication method was found.')
+            return 0
+
+    def startEmailJob(self):
+        try:
+
+            if self.setupSMTPConnection() == 0:
+                logging.CyberCPLogFileWriter.writeToFile('SMTP Connection failed. [301]')
+                return 0
+
+            emailList = EmailLists.objects.get(listName=self.extraArgs['listName'])
+            allEmails = emailList.emailsinlist_set.all()
+            emailMessage = EmailTemplate.objects.get(name=self.extraArgs['selectedTemplate'])
+
+            totalEmails = allEmails.count()
+            sent = 0
+            failed = 0
+
+            ipFile = "/etc/cyberpanel/machineIP"
+            f = open(ipFile)
+            ipData = f.read()
+            ipAddress = ipData.split('\n', 1)[0]
+
+            ## Compose Message
+            from email.mime.multipart import MIMEMultipart
+            from email.mime.text import MIMEText
+            import re
+
+            tempPath = "/home/cyberpanel/" + str(randint(1000, 9999))
+
+            emailJob = EmailJobs(owner=emailMessage, date=time.strftime("%I-%M-%S-%a-%b-%Y"),
+                                 host=self.extraArgs['host'], totalEmails=totalEmails,
+                                 sent=sent, failed=failed
+                                 )
+            emailJob.save()
+
+            for items in allEmails:
+                try:
+                    message = MIMEMultipart('alternative')
+                    message['Subject'] = emailMessage.subject
+                    message['From'] = emailMessage.fromEmail
+                    message['reply-to'] = emailMessage.replyTo
+
+                    if (items.verificationStatus == 'Verified' or self.extraArgs[
+                        'verificationCheck']) and not items.verificationStatus == 'REMOVED':
+                        try:
+                            port = ProcessUtilities.fetchCurrentPort()
+                            removalLink = "https:\/\/" + ipAddress + ":%s\/emailMarketing\/remove\/" % (port) + self.extraArgs[
+                                'listName'] + "\/" + items.email
+                            messageText = emailMessage.emailMessage.encode('utf-8', 'replace')
+                            message['To'] = items.email
+
+                            if re.search(b'<html', messageText, re.IGNORECASE) and re.search(b'<body', messageText,
+                                                                                             re.IGNORECASE):
+                                finalMessage = messageText.decode()
+
+                                self.extraArgs['unsubscribeCheck'] = 0
+                                if self.extraArgs['unsubscribeCheck']:
+                                    messageFile = open(tempPath, 'w')
+                                    messageFile.write(finalMessage)
+                                    messageFile.close()
+
+                                    command = "sudo sed -i 's/{{ unsubscribeCheck }}/" + removalLink + "/g' " + tempPath
+                                    ProcessUtilities.executioner(command, 'cyberpanel')
+
+                                    messageFile = open(tempPath, 'r')
+                                    finalMessage = messageFile.read()
+                                    messageFile.close()
+
+                                html = MIMEText(finalMessage, 'html')
+                                message.attach(html)
+
+                            else:
+                                finalMessage = messageText
+
+                                if self.extraArgs['unsubscribeCheck']:
+                                    finalMessage = finalMessage.replace('{{ unsubscribeCheck }}', removalLink)
+
+                                html = MIMEText(finalMessage, 'plain')
+                                message.attach(html)
+
+                            try:
+                                status = self.smtpServer.noop()[0]
+                                self.smtpServer.sendmail(message['From'], items.email, message.as_string())
+                            except:  # smtplib.SMTPServerDisconnected
+                                if self.setupSMTPConnection() == 0:
+                                    logging.CyberCPLogFileWriter.writeToFile('SMTP Connection failed. [301]')
+                                    return 0
+                                self.smtpServer.sendmail(message['From'], items.email, message.as_string())
+
+
+                            sent = sent + 1
+                            emailJob.sent = sent
+                            emailJob.save()
+                            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'],
+                                                                      'Successfully sent: ' + str(
+                                                                          sent) + ' Failed: ' + str(
+                                                                          failed))
+                        except BaseException as msg:
+                            failed = failed + 1
+                            emailJob.failed = failed
+                            emailJob.save()
+                            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'],
+                                                                      'Successfully sent: ' + str(
+                                                                          sent) + ', Failed: ' + str(failed))
+                            if self.setupSMTPConnection() == 0:
+                                logging.CyberCPLogFileWriter.writeToFile(
+                                    'SMTP Connection failed. Error: %s. [392]' % (str(msg)))
+                                return 0
+                except BaseException as msg:
+                            failed = failed + 1
+                            emailJob.failed = failed
+                            emailJob.save()
+                            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'],
+                                                                      'Successfully sent: ' + str(
+                                                                          sent) + ', Failed: ' + str(failed))
+                            if self.setupSMTPConnection() == 0:
+                                logging.CyberCPLogFileWriter.writeToFile('SMTP Connection failed. Error: %s. [399]' % (str(msg)))
+                                return 0
+
+
+            emailJob.sent = sent
+            emailJob.failed = failed
+            emailJob.save()
+
+            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'],
+                                                      'Email job completed. [200]')
+        except BaseException as msg:
+            logging.CyberCPLogFileWriter.statusWriter(self.extraArgs['tempStatusPath'], str(msg) + '. [404]')
+            return 0

--- a/emailMarketing/emailMarketingManager.py
+++ b/emailMarketing/emailMarketingManager.py
@@ -1,0 +1,899 @@
+from django.shortcuts import render, HttpResponse, redirect
+from plogical.acl import ACLManager
+from loginSystem.views import loadLoginPage
+import json
+from random import randint
+import time
+from plogical.httpProc import httpProc
+from .models import EmailMarketing, EmailLists, EmailsInList, EmailJobs
+from websiteFunctions.models import Websites
+from .emailMarketing import emailMarketing as EM
+from math import ceil
+import smtplib
+from .models import SMTPHosts, EmailTemplate
+from loginSystem.models import Administrator
+from .emACL import emACL
+
+class EmailMarketingManager:
+
+    def __init__(self, request = None, domain = None):
+        self.request = request
+        self.domain = domain
+
+    def emailMarketing(self):
+        proc = httpProc(self.request, 'emailMarketing/emailMarketing.html', None, 'admin')
+        return proc.render()
+
+    def fetchUsers(self):
+        try:
+
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                pass
+            else:
+                return ACLManager.loadError()
+
+            allUsers = ACLManager.findAllUsers()
+            disabledUsers = EmailMarketing.objects.all()
+            disabled = []
+            for items in disabledUsers:
+                disabled.append(items.userName)
+
+            json_data = "["
+            checker = 0
+            counter = 1
+
+            for items in allUsers:
+                if items in disabled:
+                    status = 0
+                else:
+                    status = 1
+
+                dic = {'id': counter, 'userName': items, 'status': status}
+
+                if checker == 0:
+                    json_data = json_data + json.dumps(dic)
+                    checker = 1
+                else:
+                    json_data = json_data + ',' + json.dumps(dic)
+
+                counter = counter + 1
+
+            json_data = json_data + ']'
+            data_ret = {"status": 1, 'data': json_data}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def enableDisableMarketing(self):
+        try:
+
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                pass
+            else:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+            userName = data['userName']
+
+            try:
+                disableMarketing = EmailMarketing.objects.get(userName=userName)
+                disableMarketing.delete()
+            except:
+                enableMarketing = EmailMarketing(userName=userName)
+                enableMarketing.save()
+
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def createEmailList(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            admin = Administrator.objects.get(pk=userID)
+
+            if ACLManager.checkOwnership(self.domain, admin, currentACL) == 1:
+                pass
+            else:
+                return ACLManager.loadError()
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadError()
+
+            proc = httpProc(self.request, 'emailMarketing/createEmailList.html', {'domain': self.domain})
+            return proc.render()
+        except KeyError as msg:
+            return redirect(loadLoginPage)
+
+    def submitEmailList(self):
+        try:
+
+            data = json.loads(self.request.body)
+
+            extraArgs = {}
+            extraArgs['domain'] = data['domain']
+            extraArgs['path'] = data['path']
+            extraArgs['listName'] = data['listName'].replace(' ', '')
+            extraArgs['tempStatusPath'] = "/home/cyberpanel/" + str(randint(1000, 9999))
+
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            admin = Administrator.objects.get(pk=userID)
+
+            if ACLManager.checkOwnership(data['domain'], admin, currentACL) == 1:
+                pass
+            else:
+                return ACLManager.loadErrorJson()
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            # em = EM('createEmailList', extraArgs)
+            # em.start()
+
+            time.sleep(2)
+
+            data_ret = {"status": 1, 'tempStatusPath': extraArgs['tempStatusPath']}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def manageLists(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            admin = Administrator.objects.get(pk=userID)
+
+            if ACLManager.checkOwnership(self.domain, admin, currentACL) == 1:
+                pass
+            else:
+                return ACLManager.loadError()
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadError()
+
+            listNames = emACL.getEmailsLists(self.domain)
+
+            proc = httpProc(self.request, 'emailMarketing/manageLists.html', {'listNames': listNames, 'domain': self.domain})
+            return proc.render()
+
+        except KeyError as msg:
+            return redirect(loadLoginPage)
+
+    def configureVerify(self):
+        try:
+
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            admin = Administrator.objects.get(pk=userID)
+
+            if ACLManager.checkOwnership(self.domain, admin, currentACL) == 1:
+                pass
+            else:
+                return ACLManager.loadError()
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadError()
+
+            proc = httpProc(self.request, 'emailMarketing/configureVerify.html',
+                            {'domain': self.domain})
+            return proc.render()
+
+        except KeyError as msg:
+            return redirect(loadLoginPage)
+
+    def fetchVerifyLogs(self):
+        try:
+
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            admin = Administrator.objects.get(pk=userID)
+
+            data = json.loads(self.request.body)
+
+            self.listName = data['listName']
+            recordsToShow = int(data['recordsToShow'])
+            page = int(str(data['page']).strip('\n'))
+
+            emailList = EmailLists.objects.get(listName=self.listName)
+
+            if ACLManager.checkOwnership(emailList.owner.domain, admin, currentACL) == 1:
+                pass
+            else:
+                return ACLManager.loadErrorJson('status', 0)
+
+            logsLen = emailList.validationlog_set.all().count()
+
+            from s3Backups.s3Backups import S3Backups
+
+            pagination = S3Backups.getPagination(logsLen, recordsToShow)
+            endPageNumber, finalPageNumber = S3Backups.recordsPointer(page, recordsToShow)
+            finalLogs = emailList.validationlog_set.all()[finalPageNumber:endPageNumber]
+
+            json_data = "["
+            checker = 0
+            counter = 0
+
+            from plogical.backupSchedule import backupSchedule
+
+            for log in emailList.validationlog_set.all()[finalPageNumber:endPageNumber]:
+                if log.status == backupSchedule.INFO:
+                    status = 'INFO'
+                else:
+                    status = 'ERROR'
+
+                dic = {
+                    'status': status, "message": log.message
+                }
+
+                if checker == 0:
+                    json_data = json_data + json.dumps(dic)
+                    checker = 1
+                else:
+                    json_data = json_data + ',' + json.dumps(dic)
+
+                counter = counter + 1
+
+            json_data = json_data + ']'
+
+            totalEmail = emailList.emailsinlist_set.all().count()
+            verified = emailList.verified
+            notVerified = emailList.notVerified
+
+            data_ret = {'status': 1, 'logs': json_data, 'pagination': pagination, 'totalEmails': totalEmail, 'verified': verified, 'notVerified': notVerified}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
+
+        except BaseException as msg:
+            data_ret = {'status': 0, 'error_message': str(msg)}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+
+    def saveConfigureVerify(self):
+        try:
+
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+
+            domain = data['domain']
+
+            configureVerifyPath = '/home/cyberpanel/configureVerify'
+
+            import os
+
+            if not os.path.exists(configureVerifyPath):
+                os.mkdir(configureVerifyPath)
+
+            finalPath = '%s/%s' % (configureVerifyPath, domain)
+
+            writeToFile = open(finalPath, 'w')
+            writeToFile.write(self.request.body.decode())
+            writeToFile.close()
+
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def fetchEmails(self):
+        try:
+
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+
+            listName = data['listName']
+            recordstoShow = int(data['recordstoShow'])
+            page = int(data['page'])
+
+            finalPageNumber = ((page * recordstoShow)) - recordstoShow
+            endPageNumber = finalPageNumber + recordstoShow
+
+            emailList = EmailLists.objects.get(listName=listName)
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                pass
+            elif emailList.owner.id != userID:
+                return ACLManager.loadErrorJson()
+
+            emails = emailList.emailsinlist_set.all()
+
+            ## Pagination value
+
+            pages = float(len(emails)) / float(recordstoShow)
+            pagination = []
+            counter = 1
+
+            if pages <= 1.0:
+                pages = 1
+                pagination.append(counter)
+            else:
+                pages = ceil(pages)
+                finalPages = int(pages) + 1
+
+                for i in range(1, finalPages):
+                    pagination.append(counter)
+                    counter = counter + 1
+
+            ## Pagination value
+
+            emails = emails[finalPageNumber:endPageNumber]
+
+            json_data = "["
+            checker = 0
+            counter = 1
+
+            for items in emails:
+
+                dic = {'id': items.id, 'email': items.email, 'verificationStatus': items.verificationStatus,
+                       'dateCreated': items.dateCreated}
+
+                if checker == 0:
+                    json_data = json_data + json.dumps(dic)
+                    checker = 1
+                else:
+                    json_data = json_data + ',' + json.dumps(dic)
+
+                counter = counter + 1
+
+            json_data = json_data + ']'
+            data_ret = {"status": 1, 'data': json_data, 'pagination': pagination}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def deleteList(self):
+        try:
+
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+
+            listName = data['listName']
+
+            delList = EmailLists.objects.get(listName=listName)
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] == 1:
+                pass
+            elif delList.owner.id != userID:
+                return ACLManager.loadErrorJson()
+
+            delList.delete()
+
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def emailVerificationJob(self):
+        try:
+
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+            extraArgs = {}
+            extraArgs['listName'] = data['listName']
+
+            delList = EmailLists.objects.get(listName=extraArgs['listName'])
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] == 1:
+                pass
+            elif delList.owner.id != userID:
+                return ACLManager.loadErrorJson()
+
+            em = EM('verificationJob', extraArgs)
+            em.start()
+
+            time.sleep(2)
+
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def deleteEmail(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+
+            id = data['id']
+
+            delEmail = EmailsInList.objects.get(id=id)
+
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] == 1:
+                pass
+            elif delEmail.owner.owner.id != userID:
+                return ACLManager.loadErrorJson()
+
+            delEmail.delete()
+
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def manageSMTP(self):
+        try:
+            userID = self.request.session['userID']
+            currentACL = ACLManager.loadedACL(userID)
+            admin = Administrator.objects.get(pk=userID)
+
+            if ACLManager.checkOwnership(self.domain, admin, currentACL) == 1:
+                pass
+            else:
+                return ACLManager.loadError()
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadError()
+
+            website = Websites.objects.get(domain=self.domain)
+            emailLists = website.emaillists_set.all()
+            listNames = []
+
+            for items in emailLists:
+                listNames.append(items.listName)
+
+            proc = httpProc(self.request, 'emailMarketing/manageSMTPHosts.html',
+                            {'listNames': listNames, 'domain': self.domain})
+            return proc.render()
+        except KeyError as msg:
+            return redirect(loadLoginPage)
+
+    def saveSMTPHost(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+
+            data = json.loads(self.request.body)
+
+            smtpHost = data['smtpHost']
+            smtpPort = data['smtpPort']
+            smtpUserName = data['smtpUserName']
+            smtpPassword = data['smtpPassword']
+
+            if SMTPHosts.objects.count() == 0:
+                admin = Administrator.objects.get(userName='admin')
+                defaultHost = SMTPHosts(owner=admin, host='localhost', port=25, userName='None', password='None')
+                defaultHost.save()
+
+            try:
+                verifyLogin = smtplib.SMTP(str(smtpHost), int(smtpPort))
+
+                if int(smtpPort) == 587:
+                    verifyLogin.starttls()
+
+                verifyLogin.login(str(smtpUserName), str(smtpPassword))
+
+                admin = Administrator.objects.get(pk=userID)
+
+                newHost = SMTPHosts(owner=admin, host=smtpHost, port=smtpPort, userName=smtpUserName,
+                                    password=smtpPassword)
+                newHost.save()
+
+            except smtplib.SMTPHeloError:
+                data_ret = {"status": 0, 'error_message': 'The server did not reply properly to the HELO greeting.'}
+                json_data = json.dumps(data_ret)
+                return HttpResponse(json_data)
+            except smtplib.SMTPAuthenticationError:
+                data_ret = {"status": 0, 'error_message': 'Username and password combination not accepted.'}
+                json_data = json.dumps(data_ret)
+                return HttpResponse(json_data)
+            except smtplib.SMTPException:
+                data_ret = {"status": 0, 'error_message': 'No suitable authentication method was found.'}
+                json_data = json.dumps(data_ret)
+                return HttpResponse(json_data)
+
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def fetchSMTPHosts(self):
+        try:
+
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                allHosts = SMTPHosts.objects.all()
+            else:
+                admin = Administrator.objects.get(pk=userID)
+                allHosts = admin.smtphosts_set.all()
+
+            json_data = "["
+            checker = 0
+            counter = 1
+
+            for items in allHosts:
+
+                dic = {'id': items.id, 'owner': items.owner.userName, 'host': items.host, 'port': items.port,
+                       'userName': items.userName}
+
+                if checker == 0:
+                    json_data = json_data + json.dumps(dic)
+                    checker = 1
+                else:
+                    json_data = json_data + ',' + json.dumps(dic)
+
+                counter = counter + 1
+
+            json_data = json_data + ']'
+            data_ret = {"status": 1, 'data': json_data}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def smtpHostOperations(self):
+        try:
+
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+            currentACL = ACLManager.loadedACL(userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+
+            id = data['id']
+            operation = data['operation']
+
+            if operation == 'delete':
+                delHost = SMTPHosts.objects.get(id=id)
+
+                if ACLManager.VerifySMTPHost(currentACL, delHost.owner, admin) == 0:
+                    return ACLManager.loadErrorJson()
+
+                currentACL = ACLManager.loadedACL(userID)
+                if currentACL['admin'] == 1:
+                    pass
+                elif delHost.owner.id != userID:
+                    return ACLManager.loadErrorJson()
+                delHost.delete()
+                data_ret = {"status": 1, 'message': 'Successfully deleted.'}
+                json_data = json.dumps(data_ret)
+                return HttpResponse(json_data)
+            else:
+                try:
+                    verifyHost = SMTPHosts.objects.get(id=id)
+
+                    if ACLManager.VerifySMTPHost(currentACL, verifyHost.owner, admin) == 0:
+                        return ACLManager.loadErrorJson()
+
+                    verifyLogin = smtplib.SMTP(str(verifyHost.host), int(verifyHost.port))
+
+                    if int(verifyHost.port) == 587:
+                        verifyLogin.starttls()
+
+                    verifyLogin.login(str(verifyHost.userName), str(verifyHost.password))
+
+                    data_ret = {"status": 1, 'message': 'Login successful.'}
+                    json_data = json.dumps(data_ret)
+                    return HttpResponse(json_data)
+                except smtplib.SMTPHeloError:
+                    data_ret = {"status": 0, 'error_message': 'The server did not reply properly to the HELO greeting.'}
+                    json_data = json.dumps(data_ret)
+                    return HttpResponse(json_data)
+                except smtplib.SMTPAuthenticationError:
+                    data_ret = {"status": 0, 'error_message': 'Username and password combination not accepted.'}
+                    json_data = json.dumps(data_ret)
+                    return HttpResponse(json_data)
+                except smtplib.SMTPException:
+                    data_ret = {"status": 0, 'error_message': 'No suitable authentication method was found.'}
+                    json_data = json.dumps(data_ret)
+                    return HttpResponse(json_data)
+
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def composeEmailMessage(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            proc = httpProc(self.request, 'emailMarketing/composeMessages.html',
+                            None)
+            return proc.render()
+        except KeyError as msg:
+            return redirect(loadLoginPage)
+
+    def saveEmailTemplate(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+
+            name = data['name']
+            subject = data['subject']
+            fromName = data['fromName']
+            fromEmail = data['fromEmail']
+            replyTo = data['replyTo']
+            emailMessage = data['emailMessage']
+
+            if ACLManager.CheckRegEx('[\w\d\s]+$', name) == 0:
+                return ACLManager.loadErrorJson()
+
+            admin = Administrator.objects.get(pk=userID)
+            newTemplate = EmailTemplate(owner=admin, name=name.replace(' ', ''), subject=subject, fromName=fromName, fromEmail=fromEmail,
+                                        replyTo=replyTo, emailMessage=emailMessage)
+            newTemplate.save()
+
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def sendEmails(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            currentACL = ACLManager.loadedACL(userID)
+            templateNames = emACL.allTemplates(currentACL, admin)
+            hostNames = emACL.allSMTPHosts(currentACL, admin)
+            listNames = emACL.allEmailsLists(currentACL, admin)
+
+
+            Data = {}
+            Data['templateNames'] = templateNames
+            Data['hostNames'] = hostNames
+            Data['listNames'] = listNames
+
+            proc = httpProc(self.request, 'emailMarketing/sendEmails.html',
+                            Data)
+            return proc.render()
+
+        except KeyError as msg:
+            return redirect(loadLoginPage)
+
+    def templatePreview(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+            template = EmailTemplate.objects.get(name=self.domain)
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                pass
+            elif template.owner != admin:
+                return ACLManager.loadError()
+
+            return HttpResponse(template.emailMessage)
+        except KeyError as msg:
+            return redirect(loadLoginPage)
+
+    def fetchJobs(self):
+        try:
+
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+            selectedTemplate = data['selectedTemplate']
+
+            template = EmailTemplate.objects.get(name=selectedTemplate)
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                pass
+            elif template.owner != admin:
+                return ACLManager.loadErrorJson()
+
+            allJobs = EmailJobs.objects.filter(owner=template)
+
+            json_data = "["
+            checker = 0
+            counter = 1
+
+            for items in allJobs:
+
+                dic = {'id': items.id,
+                       'date': items.date,
+                       'host': items.host,
+                       'totalEmails': items.totalEmails,
+                       'sent': items.sent,
+                       'failed': items.failed}
+
+                if checker == 0:
+                    json_data = json_data + json.dumps(dic)
+                    checker = 1
+                else:
+                    json_data = json_data + ',' + json.dumps(dic)
+
+                counter = counter + 1
+
+            json_data = json_data + ']'
+            data_ret = {"status": 1, 'data': json_data}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def startEmailJob(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+            data = json.loads(self.request.body)
+
+            extraArgs = {}
+            extraArgs['selectedTemplate'] = data['selectedTemplate']
+            extraArgs['listName'] = data['listName']
+            extraArgs['host'] = data['host']
+            try:
+                extraArgs['verificationCheck'] = data['verificationCheck']
+            except:
+                extraArgs['verificationCheck'] = False
+            try:
+                extraArgs['unsubscribeCheck'] = data['unsubscribeCheck']
+            except:
+                extraArgs['unsubscribeCheck'] = False
+
+            extraArgs['tempStatusPath'] = "/home/cyberpanel/" + data['selectedTemplate'] + '_pendingJob'
+
+            currentACL = ACLManager.loadedACL(userID)
+            template = EmailTemplate.objects.get(name=extraArgs['selectedTemplate'])
+
+            if currentACL['admin'] == 1:
+                pass
+            elif template.owner != admin:
+                return ACLManager.loadErrorJson()
+
+            em = EM('startEmailJob', extraArgs)
+            em.start()
+
+            time.sleep(5)
+
+            data_ret = {"status": 1, 'tempStatusPath': extraArgs['tempStatusPath']}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def deleteTemplate(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+            data = json.loads(self.request.body)
+
+            selectedTemplate = data['selectedTemplate']
+
+            delTemplate = EmailTemplate.objects.get(name=selectedTemplate)
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                pass
+            elif delTemplate.owner != admin:
+                return ACLManager.loadErrorJson()
+            delTemplate.delete()
+
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def deleteJob(self):
+        try:
+            userID = self.request.session['userID']
+            admin = Administrator.objects.get(pk=userID)
+
+            if emACL.checkIfEMEnabled(admin.userName) == 0:
+                return ACLManager.loadErrorJson()
+
+            data = json.loads(self.request.body)
+            id = data['id']
+            delJob = EmailJobs(id=id)
+            delJob.delete()
+            data_ret = {"status": 1}
+            json_data = json.dumps(data_ret)
+            return HttpResponse(json_data)
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def remove(self, listName, emailAddress):
+        try:
+            eList = EmailLists.objects.get(listName=listName)
+            removeEmail = EmailsInList.objects.get(owner=eList, email=emailAddress)
+            removeEmail.verificationStatus = 'REMOVED'
+            removeEmail.save()
+        except:
+            pass
+
+        return HttpResponse('Email Address Successfully removed from the list.')

--- a/emailMarketing/meta.xml
+++ b/emailMarketing/meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cyberpanelPluginConfig>
+  <name>Email Marketing</name>
+  <type>plugin</type>
+  <description>Email Marketing plugin for CyberPanel.</description>
+  <version>1.0</version>
+</cyberpanelPluginConfig>

--- a/emailMarketing/models.py
+++ b/emailMarketing/models.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+
+from django.db import models
+from websiteFunctions.models import Websites
+from loginSystem.models import Administrator
+
+# Create your models here.
+
+class EmailMarketing(models.Model):
+    userName = models.CharField(max_length=50, unique=True)
+
+class EmailLists(models.Model):
+    owner = models.ForeignKey(Websites, on_delete=models.PROTECT)
+    listName = models.CharField(max_length=50, unique=True)
+    dateCreated = models.CharField(max_length=200)
+    verified = models.IntegerField(default=0)
+    notVerified = models.IntegerField(default=0)
+
+class EmailsInList(models.Model):
+    owner = models.ForeignKey(EmailLists, on_delete=models.CASCADE)
+    email = models.CharField(max_length=50)
+    firstName = models.CharField(max_length=20, default='')
+    lastName = models.CharField(max_length=20, default='')
+    verificationStatus = models.CharField(max_length=100)
+    dateCreated = models.CharField(max_length=200)
+
+class SMTPHosts(models.Model):
+    owner = models.ForeignKey(Administrator, on_delete=models.CASCADE)
+    host = models.CharField(max_length=150, unique= True)
+    port = models.CharField(max_length=10)
+    userName = models.CharField(max_length=200)
+    password = models.CharField(max_length=200)
+
+class EmailTemplate(models.Model):
+    owner = models.ForeignKey(Administrator, on_delete=models.CASCADE)
+    name = models.CharField(unique=True, max_length=100)
+    subject = models.CharField(max_length=1000)
+    fromName = models.CharField(max_length=100)
+    fromEmail = models.CharField(max_length=150)
+    replyTo = models.CharField(max_length=150)
+    emailMessage = models.TextField(max_length=65532)
+
+class EmailJobs(models.Model):
+    owner = models.ForeignKey(EmailTemplate, on_delete=models.CASCADE)
+    date = models.CharField(max_length=200)
+    host = models.CharField(max_length=1000)
+    totalEmails = models.IntegerField()
+    sent = models.IntegerField()
+    failed = models.IntegerField()
+
+class ValidationLog(models.Model):
+    owner = models.ForeignKey(EmailLists, on_delete=models.CASCADE)
+    status = models.IntegerField()
+    message = models.TextField()
+

--- a/emailMarketing/static/emailMarketing/emailMarketing.js
+++ b/emailMarketing/static/emailMarketing/emailMarketing.js
@@ -1,0 +1,1468 @@
+/**
+ * Created by usman on 8/1/17.
+ */
+
+var emailListURL = "/emailMarketing/" + $("#domainNamePage").text() + "/emailLists";
+$("#emailLists").attr("href", emailListURL);
+$("#emailListsChild").attr("href", emailListURL);
+
+var manageListsURL = "/emailMarketing/" + $("#domainNamePage").text() + "/manageLists";
+$("#manageLists").attr("href", manageListsURL);
+$("#manageListsChild").attr("href", manageListsURL);
+
+var sendEmailsURL = "/emailMarketing/sendEmails";
+$("#sendEmailsPage").attr("href", sendEmailsURL);
+$("#sendEmailsPageChild").attr("href", sendEmailsURL);
+
+var composeEmailURL = "/emailMarketing/composeEmailMessage";
+$("#composeEmails").attr("href", composeEmailURL);
+$("#composeEmailsChild").attr("href", composeEmailURL);
+
+var smtpHostsURL = "/emailMarketing/" + $("#domainNamePage").text() + "/manageSMTP";
+$("#manageSMTPHosts").attr("href", smtpHostsURL);
+$("#manageSMTPHostsChild").attr("href", smtpHostsURL);
+
+
+app.controller('emailMarketing', function ($scope, $http) {
+
+    $scope.cyberPanelLoading = true;
+    $scope.fetchUsers = function () {
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/fetchUsers";
+
+        var data = {};
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                $scope.users = JSON.parse(response.data.data);
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+    $scope.fetchUsers();
+    $scope.enableDisableMarketing = function (status, userName) {
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/enableDisableMarketing";
+
+        var data = {userName: userName};
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            $scope.fetchUsers();
+
+            if (response.data.status === 1) {
+                new PNotify({
+                    title: 'Success!',
+                    text: 'Changes successfully saved.',
+                    type: 'success'
+                });
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+});
+
+app.controller('createEmailList', function ($scope, $http, $timeout) {
+
+    $scope.installationDetailsForm = false;
+    $scope.installationProgress = true;
+    $scope.cyberPanelLoading = true;
+    $scope.goBackDisable = true;
+
+    var statusFile;
+    var path;
+
+
+    $scope.goBack = function () {
+        $scope.installationDetailsForm = false;
+        $scope.installationProgress = true;
+        $scope.cyberPanelLoading = true;
+        $scope.goBackDisable = true;
+        $("#installProgress").css("width", "0%");
+    };
+
+    $scope.createEmailList = function () {
+
+        $scope.installationDetailsForm = true;
+        $scope.installationProgress = false;
+        $scope.cyberPanelLoading = false;
+        $scope.goBackDisable = true;
+        $scope.currentStatus = "Starting to load email addresses..";
+
+
+        url = "/emailMarketing/submitEmailList";
+
+        var data = {
+            domain: $("#domainNamePage").text(),
+            path: $scope.path,
+            listName: $scope.listName
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+
+            if (response.data.status === 1) {
+                statusFile = response.data.tempStatusPath;
+                getInstallStatus();
+            } else {
+
+                $scope.installationDetailsForm = true;
+                $scope.cyberPanelLoading = true;
+                $scope.goBackDisable = false;
+
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+
+    function getInstallStatus() {
+
+        url = "/websites/installWordpressStatus";
+
+        var data = {
+            statusFile: statusFile,
+            domainName: $("#domainNamePage").text()
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+
+
+            if (response.data.abort === 1) {
+
+                if (response.data.installStatus === 1) {
+
+                    $scope.installationDetailsForm = true;
+                    $scope.installationProgress = false;
+                    $scope.cyberPanelLoading = true;
+                    $scope.goBackDisable = false;
+                    $scope.currentStatus = 'Emails successfully loaded.';
+                    $timeout.cancel();
+
+                } else {
+
+                    $scope.installationDetailsForm = true;
+                    $scope.installationProgress = false;
+                    $scope.cyberPanelLoading = true;
+                    $scope.goBackDisable = false;
+                    $scope.currentStatus = response.data.error_message;
+
+
+                }
+
+            } else {
+                $scope.installPercentage = response.data.installationProgress;
+                $scope.currentStatus = response.data.currentStatus;
+
+                $timeout(getInstallStatus, 1000);
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+
+        }
+
+
+    }
+
+    $scope.fetchEmails = function () {
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/fetchEmails";
+
+        var data = {'listName': $scope.listName};
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                $scope.records = JSON.parse(response.data.data);
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+
+
+});
+
+app.controller('manageEmailLists', function ($scope, $http, $timeout) {
+
+    $scope.installationDetailsForm = true;
+    $scope.installationProgress = true;
+    $scope.cyberPanelLoading = true;
+    $scope.goBackDisable = true;
+    $scope.verificationStatus = true;
+
+    var statusFile;
+    var path;
+
+
+    $scope.goBack = function () {
+        $scope.installationDetailsForm = false;
+        $scope.installationProgress = true;
+        $scope.cyberPanelLoading = true;
+        $scope.goBackDisable = true;
+        $("#installProgress").css("width", "0%");
+    };
+
+    $scope.createEmailList = function () {
+
+        $scope.installationDetailsForm = true;
+        $scope.installationProgress = false;
+        $scope.cyberPanelLoading = false;
+        $scope.goBackDisable = true;
+        $scope.currentStatus = "Starting to load email addresses..";
+
+
+        url = "/emailMarketing/submitEmailList";
+
+        var data = {
+            domain: $("#domainNamePage").text(),
+            path: $scope.path,
+            listName: $scope.listName
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+
+            if (response.data.status === 1) {
+                statusFile = response.data.tempStatusPath;
+                getInstallStatus();
+            } else {
+
+                $scope.installationDetailsForm = true;
+                $scope.cyberPanelLoading = true;
+                $scope.goBackDisable = false;
+
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+
+    function getInstallStatus() {
+
+        url = "/websites/installWordpressStatus";
+
+        var data = {
+            statusFile: statusFile,
+            domainName: $("#domainNamePage").text()
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+
+
+            if (response.data.abort === 1) {
+
+                if (response.data.installStatus === 1) {
+
+                    $scope.installationDetailsForm = true;
+                    $scope.installationProgress = false;
+                    $scope.cyberPanelLoading = true;
+                    $scope.goBackDisable = false;
+                    $scope.currentStatus = 'Emails successfully loaded.';
+                    $timeout.cancel();
+
+                } else {
+
+                    $scope.installationDetailsForm = true;
+                    $scope.installationProgress = false;
+                    $scope.cyberPanelLoading = true;
+                    $scope.goBackDisable = false;
+                    $scope.currentStatus = response.data.error_message;
+
+
+                }
+
+            } else {
+                $scope.installPercentage = response.data.installationProgress;
+                $scope.currentStatus = response.data.currentStatus;
+
+                $timeout(getInstallStatus, 1000);
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+
+        }
+
+
+    }
+
+
+    ///
+
+    $scope.currentRecords = true;
+
+    $scope.recordstoShow = 50;
+    var globalPage;
+
+    $scope.fetchRecords = function () {
+        $scope.fetchEmails(globalPage);
+    };
+
+    $scope.fetchEmails = function (page) {
+        globalPage = page;
+        listVerificationStatus();
+
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/fetchEmails";
+
+        var data = {
+            'listName': $scope.listName,
+            'recordstoShow': $scope.recordstoShow,
+            'page': page
+
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                $scope.currentRecords = false;
+                $scope.records = JSON.parse(response.data.data);
+                $scope.pagination = response.data.pagination;
+                $scope.verificationButton = false;
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+
+    $scope.deleteList = function () {
+
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/deleteList";
+
+        var data = {
+            listName: $scope.listName
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            if (response.data.status === 1) {
+                new PNotify({
+                    title: 'Success!',
+                    text: 'Emails Successfully Deleted.',
+                    type: 'success'
+                });
+            } else {
+
+                $scope.cyberPanelLoading = false;
+
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+
+    $scope.showAddEmails = function () {
+        $scope.installationDetailsForm = false;
+        $scope.verificationStatus = true;
+    };
+
+    // List Verification
+
+    $scope.startVerification = function () {
+
+        $scope.currentStatusVerification = 'Email verification job started..';
+        $scope.installationDetailsForm = true;
+        $scope.verificationStatus = false;
+        $scope.verificationButton = true;
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/emailVerificationJob";
+
+        var data = {
+            listName: $scope.listName
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+
+            if (response.data.status === 1) {
+                listVerificationStatus();
+                $scope.verificationButton = true;
+            } else {
+
+                $scope.cyberPanelLoading = true;
+                $scope.verificationButton = false;
+
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            $scope.verificationButton = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+
+    };
+
+    var globalCounter = 0;
+
+    function listVerificationStatus() {
+
+        $scope.verificationButton = true;
+        $scope.cyberPanelLoading = false;
+
+        url = "/websites/installWordpressStatus";
+
+        var data = {
+            domain: $("#domainNamePage").text(),
+            statusFile: "/home/cyberpanel/" + $("#domainNamePage").text() + "/" + $scope.listName
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+
+
+            if (response.data.abort === 1) {
+
+                if (response.data.installStatus === 1) {
+                    $scope.cyberPanelLoading = true;
+                    $scope.verificationButton = false;
+                    $scope.currentStatusVerification = 'Emails successfully verified.';
+                    $timeout.cancel();
+
+                } else {
+
+                    if (response.data.error_message.search('No such file') > -1) {
+                        $scope.verificationButton = false;
+                        return;
+                    }
+                    $scope.verificationButton = true;
+                    $scope.cyberPanelLoading = false;
+                    $scope.verificationStatus = false;
+                    $scope.currentStatusVerification = response.data.error_message;
+
+                }
+
+            } else {
+
+                if (response.data.currentStatus.search('No such file') > -1) {
+                    $scope.cyberPanelLoading = true;
+                    $scope.deleteTemplateBTN = false;
+                    $scope.sendEmailBTN = false;
+                    $scope.sendEmailsView = true;
+                    $scope.jobStatus = true;
+                    $scope.goBackDisable = false;
+                    $timeout.cancel();
+                    return;
+                }
+
+                $scope.currentStatusVerification = response.data.currentStatus;
+                $timeout(listVerificationStatus, 1000);
+                $scope.verificationStatus = false;
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+
+        }
+
+
+    }
+
+    // Delete Email from list
+
+    $scope.deleteEmail = function (id) {
+
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/deleteEmail";
+
+        var data = {
+            id: id
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            $scope.fetchEmails(globalPage);
+
+            if (response.data.status === 1) {
+                $scope.fetchEmails(globalPage);
+                new PNotify({
+                    title: 'Success.',
+                    text: 'Email Successfully deleted.',
+                    type: 'success'
+                });
+
+            } else {
+
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+
+
+    $scope.currentPageLogs = 1;
+    $scope.recordsToShowLogs = 10;
+
+    $scope.fetchLogs = function () {
+
+        $scope.cyberPanelLoading = false;
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        var data = {
+            listName: $scope.listName,
+            page: $scope.currentPageLogs,
+            recordsToShow: $scope.recordsToShowLogs
+        };
+
+        url = "/emailMarketing/fetchVerifyLogs";
+
+        $http.post(url, data, config).then(ListInitialData, cantLoadInitialData);
+
+        function ListInitialData(response) {
+            $scope.cyberPanelLoading = true;
+            if (response.data.status === 1) {
+                $scope.recordsLogs = JSON.parse(response.data.logs);
+                $scope.paginationLogs = response.data.pagination;
+                $scope.totalEmails = response.data.totalEmails;
+                $scope.verified = response.data.verified;
+                $scope.notVerified = response.data.notVerified;
+            } else {
+                new PNotify({
+                    title: 'Error!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+        function cantLoadInitialData(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+        }
+
+
+    };
+
+
+});
+
+app.controller('manageSMTPHostsCTRL', function ($scope, $http) {
+
+    $scope.cyberPanelLoading = true;
+    $scope.fetchSMTPHosts = function () {
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/fetchSMTPHosts";
+
+        var data = {};
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                $scope.records = JSON.parse(response.data.data);
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+    $scope.fetchSMTPHosts();
+    $scope.saveSMTPHost = function (status, userName) {
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/saveSMTPHost";
+
+        var data = {
+            smtpHost: $scope.smtpHost,
+            smtpPort: $scope.smtpPort,
+            smtpUserName: $scope.smtpUserName,
+            smtpPassword: $scope.smtpPassword
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                $scope.fetchSMTPHosts();
+                new PNotify({
+                    title: 'Success!',
+                    text: 'Successfully saved new SMTP host.',
+                    type: 'success'
+                });
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+    $scope.smtpHostOperations = function (operation, id) {
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/smtpHostOperations";
+
+        var data = {
+            id: id,
+            operation: operation
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            $scope.fetchSMTPHosts();
+
+            if (response.data.status === 1) {
+                new PNotify({
+                    title: 'Success!',
+                    text: response.data.message,
+                    type: 'success'
+                });
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+});
+
+app.controller('composeMessageCTRL', function ($scope, $http) {
+
+    $scope.cyberPanelLoading = true;
+    $scope.saveTemplate = function (status, userName) {
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/saveEmailTemplate";
+
+        var data = {
+            name: $scope.name,
+            subject: $scope.subject,
+            fromName: $scope.fromName,
+            fromEmail: $scope.fromEmail,
+            replyTo: $scope.replyTo,
+            emailMessage: $scope.emailMessage
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                new PNotify({
+                    title: 'Success!',
+                    text: 'Template successfully saved.',
+                    type: 'success'
+                });
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+});
+
+app.controller('sendEmailsCTRL', function ($scope, $http, $timeout) {
+
+    $scope.cyberPanelLoading = true;
+    $scope.availableFunctions = true;
+    $scope.sendEmailsView = true;
+    $scope.jobStatus = true;
+
+    // Button
+
+    $scope.deleteTemplateBTN = false;
+    $scope.sendEmailBTN = false;
+
+    $scope.templateSelected = function () {
+        $scope.availableFunctions = false;
+        $scope.sendEmailsView = true;
+        $scope.previewLink = '/emailMarketing/preview/' + $scope.selectedTemplate;
+        $scope.jobStatus = true;
+        emailJobStatus();
+
+    };
+
+    $scope.sendEmails = function () {
+        $scope.sendEmailsView = false;
+        $scope.fetchJobs();
+    };
+
+    $scope.fetchJobs = function () {
+
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/fetchJobs";
+
+        var data = {
+            'selectedTemplate': $scope.selectedTemplate
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                $scope.currentRecords = false;
+                $scope.records = JSON.parse(response.data.data);
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+
+    $scope.startEmailJob = function () {
+        $scope.cyberPanelLoading = false;
+        $scope.deleteTemplateBTN = true;
+        $scope.sendEmailBTN = true;
+        $scope.sendEmailsView = true;
+        $scope.goBackDisable = true;
+
+        url = "/emailMarketing/startEmailJob";
+
+
+        var data = {
+            'selectedTemplate': $scope.selectedTemplate,
+            'listName': $scope.listName,
+            'host': $scope.host,
+            'verificationCheck': $scope.verificationCheck,
+            'unsubscribeCheck': $scope.unsubscribeCheck
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                emailJobStatus();
+            } else {
+                $scope.cyberPanelLoading = true;
+                $scope.deleteTemplateBTN = false;
+                $scope.sendEmailBTN = false;
+                $scope.sendEmailsView = false;
+                $scope.jobStatus = true;
+                $scope.goBackDisable = false;
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+
+    };
+
+    function emailJobStatus() {
+
+        $scope.cyberPanelLoading = false;
+        $scope.deleteTemplateBTN = true;
+        $scope.sendEmailBTN = true;
+        $scope.sendEmailsView = true;
+        $scope.jobStatus = false;
+        $scope.goBackDisable = true;
+
+        url = "/websites/installWordpressStatus";
+
+        var data = {
+            domain: 'example.com',
+            statusFile: "/home/cyberpanel/" + $scope.selectedTemplate + "_pendingJob"
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+
+
+            if (response.data.abort === 1) {
+
+                if (response.data.installStatus === 1) {
+                    $scope.cyberPanelLoading = true;
+                    $scope.deleteTemplateBTN = false;
+                    $scope.sendEmailBTN = false;
+                    $scope.sendEmailsView = true;
+                    $scope.jobStatus = false;
+                    $scope.goBackDisable = false;
+                    $scope.currentStatus = 'Emails successfully sent.';
+                    $scope.fetchJobs();
+                    $timeout.cancel();
+
+                } else {
+
+                    if (response.data.error_message.search('No such file') > -1) {
+                        $scope.cyberPanelLoading = true;
+                        $scope.deleteTemplateBTN = false;
+                        $scope.sendEmailBTN = false;
+                        $scope.sendEmailsView = true;
+                        $scope.jobStatus = true;
+                        $scope.goBackDisable = false;
+                        return;
+                    }
+                    $scope.cyberPanelLoading = true;
+                    $scope.deleteTemplateBTN = false;
+                    $scope.sendEmailBTN = false;
+                    $scope.sendEmailsView = true;
+                    $scope.jobStatus = false;
+                    $scope.goBackDisable = false;
+                    $scope.currentStatus = response.data.error_message;
+
+                }
+
+            } else {
+
+                if (response.data.currentStatus.search('No such file') > -1) {
+                    $scope.cyberPanelLoading = true;
+                    $scope.deleteTemplateBTN = false;
+                    $scope.sendEmailBTN = false;
+                    $scope.sendEmailsView = true;
+                    $scope.jobStatus = true;
+                    $scope.goBackDisable = false;
+                    $timeout.cancel();
+                    return;
+                }
+
+                $scope.currentStatus = response.data.currentStatus;
+                $timeout(emailJobStatus, 1000);
+                $scope.cyberPanelLoading = false;
+                $scope.deleteTemplateBTN = true;
+                $scope.sendEmailBTN = true;
+                $scope.sendEmailsView = true;
+                $scope.jobStatus = false;
+                $scope.goBackDisable = true;
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page.',
+                type: 'error'
+            });
+
+
+        }
+
+
+    }
+
+    $scope.goBack = function () {
+        $scope.cyberPanelLoading = true;
+        $scope.deleteTemplateBTN = false;
+        $scope.sendEmailBTN = false;
+        $scope.sendEmailsView = false;
+        $scope.jobStatus = true;
+
+    };
+
+    $scope.deleteTemplate = function () {
+
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/deleteTemplate";
+
+        var data = {
+            selectedTemplate: $scope.selectedTemplate
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+                new PNotify({
+                    title: 'Success.',
+                    text: 'Template Successfully deleted.',
+                    type: 'success'
+                });
+
+            } else {
+
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+    $scope.deleteJob = function (id) {
+
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/deleteJob";
+
+        var data = {
+            id: id
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            $scope.fetchJobs();
+
+            if (response.data.status === 1) {
+                new PNotify({
+                    title: 'Success.',
+                    text: 'Template Successfully deleted.',
+                    type: 'success'
+                });
+
+            } else {
+
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+
+            }
+
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+});
+
+app.controller('configureVerify', function ($scope, $http) {
+
+    $scope.cyberPanelLoading = true;
+    $scope.ipv4Hidden = true;
+    $scope.ipv6Hidden = true;
+    $scope.delayHidden = true;
+
+    $scope.delayInitial = function () {
+        if ($scope.delay === 'Disable') {
+            $scope.delayHidden = true;
+        } else {
+            $scope.delayHidden = false;
+        }
+    };
+    $scope.rotateInitial = function () {
+        if ($scope.rotation === 'Disable') {
+            $scope.rotationHidden = true;
+        } else if ($scope.rotation === 'IPv4') {
+            $scope.ipv4Hidden = false;
+            $scope.ipv6Hidden = true;
+        } else {
+            $scope.ipv4Hidden = true;
+            $scope.ipv6Hidden = false;
+        }
+    };
+
+    $scope.saveChanges = function () {
+
+        $scope.cyberPanelLoading = false;
+
+        url = "/emailMarketing/saveConfigureVerify";
+
+        var data = {
+            domain: $("#domainName").text(),
+            rotation: $scope.rotation,
+            delay: $scope.delay,
+            delayAfter: $scope.delayAfter,
+            delayTime: $scope.delayTime,
+            ipv4: $scope.ipv4,
+            ipv6: $scope.ipv6
+        };
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+        function ListInitialDatas(response) {
+            $scope.cyberPanelLoading = true;
+
+            if (response.data.status === 1) {
+
+                new PNotify({
+                    title: 'Success!',
+                    text: 'Successfully saved verification settings.',
+                    type: 'success'
+                });
+            } else {
+                new PNotify({
+                    title: 'Operation Failed!',
+                    text: response.data.error_message,
+                    type: 'error'
+                });
+            }
+        }
+
+        function cantLoadInitialDatas(response) {
+            $scope.cyberPanelLoading = false;
+            new PNotify({
+                title: 'Operation Failed!',
+                text: 'Could not connect to server, please refresh this page',
+                type: 'error'
+            });
+
+        }
+
+    };
+});
+
+

--- a/emailMarketing/templates/emailMarketing/composeMessages.html
+++ b/emailMarketing/templates/emailMarketing/composeMessages.html
@@ -1,0 +1,90 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{% trans "Compose Email Message - CyberPanel" %}{% endblock %}
+{% block content %}
+
+{% load static %}
+{% get_current_language as LANGUAGE_CODE %}
+<!-- Current language: {{ LANGUAGE_CODE }} -->
+
+
+<div class="container">
+<div id="page-title">
+   <h2>{% trans "Compose Email Message" %}</h2>
+   <p>{% trans "On this page you can compose email message to be sent out later." %}</p>
+</div>
+<div ng-controller="composeMessageCTRL" class="panel" style="background: var(--bg-primary, white); border-color: var(--border-color, #ddd);">
+    <div class="panel-body" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+        <h3 class="title-hero">
+            {% trans "Compose Email Message" %} <img ng-hide="cyberPanelLoading" src="{% static 'images/loading.gif' %}">
+        </h3>
+        <div  class="example-box-wrapper">
+
+
+            <form action="/" class="form-horizontal bordered-row">
+
+            <!---- Create Email Template --->
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Template Name" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="text" class="form-control" ng-model="name" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Email Subject" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="text" class="form-control" ng-model="subject" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "From Name" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="text" class="form-control" ng-model="fromName" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "From Email" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="text" class="form-control" ng-model="fromEmail" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Reply Email" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="text" class="form-control" ng-model="replyTo" required>
+                    </div>
+                </div>
+
+
+                <div ng-hide="request" class="form-group">
+                    <div class="col-sm-12">
+                        <textarea placeholder="Paste your email message, any format is accepted. (HTML or Plain)" ng-model="emailMessage" rows="15" class="form-control"></textarea>
+                    </div>
+                </div>
+
+                <div ng-hide="installationProgress" class="form-group">
+                    <label class="col-sm-3 control-label"></label>
+                    <div class="col-sm-4">
+                        <button type="button"  ng-click="saveTemplate()" class="btn btn-primary btn-lg btn-block">{% trans "Save Template" %}</button>
+                    </div>
+                </div>
+
+            <!---- Create Email Template --->
+
+            </form>
+
+
+
+
+        </div>
+    </div>
+</div>
+</div>
+
+
+{% endblock %}

--- a/emailMarketing/templates/emailMarketing/configureVerify.html
+++ b/emailMarketing/templates/emailMarketing/configureVerify.html
@@ -1,0 +1,99 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{% trans "Configure Email Verification - CyberPanel" %}{% endblock %}
+{% block content %}
+
+    {% load static %}
+    {% get_current_language as LANGUAGE_CODE %}
+    <!-- Current language: {{ LANGUAGE_CODE }} -->
+
+
+    <div class="container">
+        <div id="page-title">
+            <h2>{% trans "Configure Email Verification" %}</h2>
+            <p>{% trans "On this page you can configure parameters regarding how email verification is performed for " %}<span id="domainName">{{ domain }}</span></p>
+        </div>
+        <div ng-controller="configureVerify" class="panel" style="background: var(--bg-primary, white); border-color: var(--border-color, #ddd);">
+            <div class="panel-body" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                <h3 class="title-hero">
+                    {% trans "Compose Email Message" %} <img ng-hide="cyberPanelLoading"
+                                                             src="{% static 'images/loading.gif' %}">
+                </h3>
+                <div class="example-box-wrapper">
+
+
+                    <form action="/" class="form-horizontal bordered-row">
+
+                        <!---- Create Email Template --->
+
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">{% trans "Configure Delay" %} </label>
+                            <div class="col-sm-6">
+                                <select ng-change="delayInitial()" ng-model="delay" class="form-control">
+                                    <option>Disable</option>
+                                    <option>Enable</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div ng-hide="delayHidden" class="form-group">
+                            <label class="col-sm-3 control-label">{% trans "Delay After" %}</label>
+                            <div class="col-sm-6">
+                                <input placeholder="{% trans 'Start delay after this many verifications are done.' %}" type="number" class="form-control" ng-model="delayAfter" required>
+                            </div>
+                        </div>
+
+                        <div ng-hide="delayHidden" class="form-group">
+                            <label class="col-sm-3 control-label">{% trans "Delay Time" %}</label>
+                            <div class="col-sm-6">
+                                <input placeholder="{% trans 'Set the number of seconds to wait.' %}" type="number" class="form-control" ng-model="delayTime" required>
+                            </div>
+                        </div>
+
+                         <div class="form-group">
+                            <label class="col-sm-3 control-label">{% trans "IP Rotation" %} </label>
+                            <div class="col-sm-6">
+                                <select ng-change="rotateInitial()" ng-model="rotation" class="form-control">
+                                    <option>Disable</option>
+                                    <option>IPv4</option>
+                                    <option>IPv6</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div ng-hide="ipv4Hidden" class="form-group">
+                            <label class="col-sm-3 control-label">{% trans "IPv4" %}</label>
+                            <div class="col-sm-6">
+                                <input placeholder="{% trans 'Enter IPv4(s) to be used separate with commas.' %}" type="text" class="form-control" ng-model="ipv4" required>
+                            </div>
+                        </div>
+
+                        <div ng-hide="ipv6Hidden" class="form-group">
+                            <label class="col-sm-3 control-label">{% trans "IPv6" %}</label>
+                            <div class="col-sm-6">
+                                <input placeholder="{% trans 'Enter IPv6(s) to be used separate with commas.' %}" type="text" class="form-control" ng-model="ipv6" required>
+                            </div>
+                        </div>
+
+
+
+                        <div ng-hide="installationProgress" class="form-group">
+                            <label class="col-sm-3 control-label"></label>
+                            <div class="col-sm-4">
+                                <button type="button" ng-click="saveChanges()"
+                                        class="btn btn-primary btn-lg btn-block">{% trans "Save" %}</button>
+                            </div>
+                        </div>
+
+                        <!---- Create Email Template --->
+
+                    </form>
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+{% endblock %}

--- a/emailMarketing/templates/emailMarketing/createEmailList.html
+++ b/emailMarketing/templates/emailMarketing/createEmailList.html
@@ -1,0 +1,75 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{% trans "Create Email List - CyberPanel" %}{% endblock %}
+{% block content %}
+
+{% load static %}
+{% get_current_language as LANGUAGE_CODE %}
+<!-- Current language: {{ LANGUAGE_CODE }} -->
+
+
+<div ng-controller="createEmailList" class="container">
+<div id="page-title">
+   <h2>{% trans "Create Email List" %} - <span id="domainNamePage">{{ domain }}</span> </h2>
+   <p>{% trans "Create email list, to send out news letters and marketing emails." %}</p>
+</div>
+<div class="panel" style="background: var(--bg-primary, white); border-color: var(--border-color, #ddd);">
+    <div class="panel-body" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+        <h3 class="title-hero">
+            {% trans "Create Email List" %} <img ng-hide="cyberPanelLoading" src="{% static 'images/loading.gif' %}">
+        </h3>
+        <div class="example-box-wrapper">
+
+
+            <form   action="/" id="createPackages" class="form-horizontal bordered-row">
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "List Name" %}</label>
+                    <div class="col-sm-6">
+                        <input name="pname"  type="text" class="form-control" ng-model="listName" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Path" %}</label>
+                    <div class="col-sm-6">
+                        <input placeholder="Path to emails file (.txt and .csv accepted)"  type="text" class="form-control" ng-model="path" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label"></label>
+                    <div class="col-sm-4">
+                         <button type="button" ng-click="createEmailList()" class="btn btn-primary btn-lg btn-block">{% trans "Create List" %}</button>
+
+                    </div>
+                </div>
+
+                <div ng-hide="installationProgress" class="form-group">
+                    <label class="col-sm-2 control-label"></label>
+                    <div class="col-sm-7">
+                            <div class="alert alert-success text-center" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <h2>{$ currentStatus $}</h2>
+                            </div>
+                    </div>
+                </div>
+
+                <div ng-hide="installationProgress" class="form-group">
+                    <label class="col-sm-3 control-label"></label>
+                    <div class="col-sm-4">
+                        <button type="button" ng-disabled="goBackDisable"  ng-click="goBack()" class="btn btn-primary btn-lg btn-block">{% trans "Go Back" %}</button>
+                    </div>
+                </div>
+
+            </form>
+
+
+
+
+        </div>
+    </div>
+</div>
+
+
+</div>
+{% endblock %}
+

--- a/emailMarketing/templates/emailMarketing/emailMarketing.html
+++ b/emailMarketing/templates/emailMarketing/emailMarketing.html
@@ -1,12 +1,17 @@
 {% extends "baseTemplate/index.html" %}
 {% load i18n %}
+{% load static %}
 {% block title %}{% trans "Email Marketing - CyberPanel" %}{% endblock %}
+{% block module_scripts %}
+{{ block.super }}
+<script defer src="{% static 'emailMarketing/emailMarketing.js' %}?v={{ CP_VERSION }}"></script>
+{% endblock %}
 {% block content %}
 
-{% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 <!-- Current language: {{ LANGUAGE_CODE }} -->
 
+{% if not cosmetic.HidePromotions %}
 <div id="cybermailBanner" style="display:none; margin-bottom:20px;">
   <div style="background:linear-gradient(135deg,#4f46e5 0%,#7c3aed 50%,#9333ea 100%);border-radius:10px;padding:20px 24px;display:flex;align-items:center;gap:18px;box-shadow:0 4px 15px rgba(79,70,229,0.3);">
     <div style="flex-shrink:0;font-size:32px;">&#9993;</div>
@@ -22,6 +27,7 @@
 (function(){if(!document.cookie.includes('cybermail_dismiss=1')){document.getElementById('cybermailBanner').style.display='';}})();
 function dismissCyberMailBanner(){document.getElementById('cybermailBanner').style.display='none';document.cookie='cybermail_dismiss=1; path=/; max-age='+7*86400;}
 </script>
+{% endif %}
 
 <div class="container">
 

--- a/emailMarketing/templates/emailMarketing/manageLists.html
+++ b/emailMarketing/templates/emailMarketing/manageLists.html
@@ -1,0 +1,315 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{% trans "Manage Email Lists - CyberPanel" %}{% endblock %}
+{% block content %}
+
+    {% load static %}
+    {% get_current_language as LANGUAGE_CODE %}
+    <!-- Current language: {{ LANGUAGE_CODE }} -->
+
+
+    <div class="container">
+        <div id="page-title">
+            <h2>{% trans "Manage Email Lists" %} - <span id="domainNamePage">{{ domain }}</span></h2>
+            <p>{% trans "On this page you can manage your email lists (Delete, Verify, Add More Emails)." %}</p>
+        </div>
+        <div ng-controller="manageEmailLists" class="panel" style="background: var(--bg-primary, white); border-color: var(--border-color, #ddd);">
+            <div class="panel-body" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                <h3 class="title-hero">
+                    {% trans "Manage Email Lists" %} <img ng-hide="cyberPanelLoading"
+                                                          src="{% static 'images/loading.gif' %}">
+                </h3>
+                <div class="example-box-wrapper">
+
+
+                    <form action="/" class="form-horizontal bordered-row">
+
+
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">{% trans "Select List" %} </label>
+                            <div class="col-sm-6">
+                                <select ng-change="fetchEmails(1)" ng-model="listName" class="form-control">
+                                    {% for items in listNames %}
+                                        <option>{{ items }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+
+                        <div ng-hide="currentRecords" class="form-group">
+                            <div class="row">
+                                <div class="col-sm-1">
+                                    <button data-toggle="modal" data-target="#deleteList"
+                                            class="btn ra-100 btn-danger">{% trans 'Delete' %}</button>
+                                    <!--- Delete Pool --->
+                                    <div class="modal fade" id="deleteList" tabindex="-1" role="dialog"
+                                         aria-labelledby="myModalLabel" aria-hidden="true">
+                                        <div class="modal-dialog">
+                                            <div class="modal-content" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <div class="modal-header">
+                                                    <button type="button" class="close" data-dismiss="modal"
+                                                            aria-hidden="true">&times;
+                                                    </button>
+                                                    <h4 class="modal-title">{% trans "You are doing to delete this list.." %}
+                                                        <img ng-hide="cyberPanelLoading"
+                                                             src="{% static 'images/loading.gif' %}"></h4>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <p>{% trans 'Are you sure?' %}</p>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-default"
+                                                            data-dismiss="modal">{% trans 'Close' %}</button>
+                                                    <button data-dismiss="modal" ng-click="deleteList()" type="button"
+                                                            class="btn btn-primary">{% trans 'Confirm' %}</button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <!--- Delete Pool --->
+                                </div>
+                                <div class="col-sm-1">
+                                    <button ng-disabled="verificationButton" ng-click="startVerification()"
+                                            class="btn ra-100 btn-blue-alt">{% trans 'Verify' %}</button>
+                                </div>
+                                <div class="col-sm-3">
+                                    <button onclick="location.href='/emailMarketing/{{ domain }}/configureVerify'"
+                                            class="btn ra-100 btn-blue-alt">{% trans 'Configure Verification' %}</button>
+                                </div>
+                                <div class="col-sm-3">
+                                    <button ng-click="fetchLogs()" data-toggle="modal" data-target="#verificationLogs"
+                                            class="btn ra-100 btn-blue-alt">{% trans 'Verfications Logs' %}</button>
+                                    <!--- Delete Pool --->
+                                    <div class="modal fade" id="verificationLogs" tabindex="-1" role="dialog"
+                                         aria-labelledby="myModalLabel" aria-hidden="true">
+                                        <div class="modal-dialog modal-lg">
+                                            <div class="modal-content" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <div class="modal-header">
+                                                    <button type="button" class="close" data-dismiss="modal"
+                                                            aria-hidden="true">&times;
+                                                    </button>
+                                                    <h4 class="modal-title">{% trans "Verification Logs" %}
+                                                        <img ng-hide="cyberPanelLoading"
+                                                             src="{% static 'images/loading.gif' %}"></h4>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <!------ List of records --------------->
+
+                                                    <div ng-hide="currentRecords" class="form-group">
+
+                                                        <table style="margin: 0px; padding-bottom: 2%; background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);" class="table">
+                                                            <thead>
+                                                            <tr>
+                                                                <th>{% trans "Total Emails" %}</th>
+                                                                <th>{% trans "Verified" %}</th>
+                                                                <th>{% trans "Not-Verified" %}</th>
+                                                            </tr>
+                                                            </thead>
+                                                            <tbody>
+                                                            <tr>
+                                                                <td>{$ totalEmails $}</td>
+                                                                <td>{$ verified $}</td>
+                                                                <td>{$ notVerified $}</td>
+                                                            </tr>
+                                                            </tbody>
+                                                        </table>
+
+                                                        <div class="col-sm-10">
+                                                            <input placeholder="Search Logs..." name="dom" type="text"
+                                                                   class="form-control" ng-model="searchLogs"
+                                                                   required>
+                                                        </div>
+
+                                                        <div style="margin-bottom: 1%;" class="col-sm-2">
+                                                            <select ng-change="fetchLogs()" ng-model="recordsToShowLogs"
+                                                                    class="form-control">
+                                                                <option>10</option>
+                                                                <option>50</option>
+                                                                <option>100</option>
+                                                                <option>500</option>
+                                                            </select>
+                                                        </div>
+
+                                                        <div class="col-sm-12">
+
+                                                            <table style="margin: 0px; background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);" class="table">
+                                                                <thead>
+                                                                <tr>
+                                                                    <th>{% trans "Status" %}</th>
+                                                                    <th>{% trans "Message" %}</th>
+                                                                </tr>
+                                                                </thead>
+                                                                <tbody>
+                                                                <tr ng-repeat="record in recordsLogs | filter:searchLogs">
+                                                                    <td ng-bind="record.status"></td>
+                                                                    <td ng-bind="record.message"></td>
+                                                                </tr>
+                                                                </tbody>
+                                                            </table>
+
+                                                            <div style="margin-top: 2%" class="row">
+                                                                <div class="col-md-12">
+                                                                    <div class="row">
+                                                                        <div class="col-md-8">
+                                                                        </div>
+                                                                        <div class="col-md-3">
+                                                                            <div class="form-group">
+                                                                                <select ng-model="currentPageLogs"
+                                                                                        class="form-control"
+                                                                                        ng-change="fetchLogs()">
+                                                                                    <option ng-repeat="page in paginationLogs">
+                                                                                        {$ $index + 1
+                                                                                        $}
+                                                                                    </option>
+                                                                                </select>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div> <!-- end row -->
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
+                                                    <!------ List of records --------------->
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-default"
+                                                            data-dismiss="modal">{% trans 'Close' %}</button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <!--- Delete Pool --->
+                                </div>
+                                <div class="col-sm-2">
+                                    <button ng-click="showAddEmails()"
+                                            class="btn ra-100 btn-blue-alt">{% trans 'Add More Emails' %}</button>
+                                </div>
+                            </div>
+                        </div>
+
+
+                        <!---- Create Email List --->
+
+                        <div ng-hide="installationDetailsForm" class="form-group">
+                            <label class="col-sm-3 control-label">{% trans "Path" %}</label>
+                            <div class="col-sm-6">
+                                <input placeholder="Path to emails file (.txt and .csv accepted)" type="text"
+                                       class="form-control" ng-model="path" required>
+                            </div>
+                        </div>
+
+                        <div ng-hide="installationDetailsForm" class="form-group">
+                            <label class="col-sm-3 control-label"></label>
+                            <div class="col-sm-4">
+                                <button type="button" ng-click="createEmailList()"
+                                        class="btn btn-primary btn-lg btn-block">{% trans "Load Emails" %}</button>
+
+                            </div>
+                        </div>
+
+                        <div ng-hide="installationProgress" class="form-group">
+                            <label class="col-sm-2 control-label"></label>
+                            <div class="col-sm-7">
+                                <div class="alert alert-success text-center" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                    <h2>{$ currentStatus $}</h2>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div ng-hide="installationProgress" class="form-group">
+                            <label class="col-sm-3 control-label"></label>
+                            <div class="col-sm-4">
+                                <button type="button" ng-disabled="goBackDisable" ng-click="goBack()"
+                                        class="btn btn-primary btn-lg btn-block">{% trans "Go Back" %}</button>
+                            </div>
+                        </div>
+
+                        <!---- Create Email List --->
+
+                        <!---- Email List Verification --->
+
+                        <div ng-hide="verificationStatus" class="form-group">
+                            <label class="col-sm-2 control-label"></label>
+                            <div class="col-sm-7">
+                                <div class="alert alert-success text-center" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                    <h2>{$ currentStatusVerification $}</h2>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!---- Create Email List --->
+
+
+                        <!------ List of records --------------->
+
+                        <div ng-hide="currentRecords" class="form-group">
+
+                            <div class="col-sm-10">
+                                <input placeholder="Search Emails..." ng-model="searchEmails" name="dom" type="text"
+                                       class="form-control" ng-model="domainNameCreate" required>
+                            </div>
+
+                            <div style="margin-bottom: 1%;" class="col-sm-2">
+                                <select ng-change="fetchRecords()" ng-model="recordstoShow" class="form-control">
+                                    <option>10</option>
+                                    <option>50</option>
+                                    <option>100</option>
+                                </select>
+                            </div>
+
+                            <div class="col-sm-12">
+
+                                <table class="table" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                    <thead>
+                                    <tr>
+                                        <th>{% trans "ID" %}</th>
+                                        <th>{% trans "email" %}</th>
+                                        <th>{% trans "Verification Status" %}</th>
+                                        <th>{% trans "Date Created" %}</th>
+                                        <th>{% trans "Actions" %}</th>
+                                        <th></th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr ng-repeat="record in records | filter:searchEmails">
+                                        <td ng-bind="record.id"></td>
+                                        <td ng-bind="record.email"></td>
+                                        <td ng-bind="record.verificationStatus"></td>
+                                        <td ng-bind="record.dateCreated"></td>
+                                        <td>
+                                            <button type="button" ng-click="deleteEmail(record.id)"
+                                                    class="btn ra-100 btn-purple">{% trans "Delete" %}</button>
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <div class="row">
+                                    <div class="col-sm-4 col-sm-offset-8">
+
+                                        <nav aria-label="Page navigation">
+                                            <ul class="pagination">
+                                                <li ng-click="fetchEmails(page)" ng-repeat="page in pagination"><a
+                                                        href="">{$ page $}</a></li>
+                                            </ul>
+                                        </nav>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!------ List of records --------------->
+
+                    </form>
+
+
+                </div>
+            </div>
+        </div>
+
+
+    </div>
+
+
+{% endblock %}

--- a/emailMarketing/templates/emailMarketing/manageSMTPHosts.html
+++ b/emailMarketing/templates/emailMarketing/manageSMTPHosts.html
@@ -1,0 +1,126 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{% trans "Manage SMTP Hosts - CyberPanel" %}{% endblock %}
+{% block content %}
+
+{% load static %}
+{% get_current_language as LANGUAGE_CODE %}
+<!-- Current language: {{ LANGUAGE_CODE }} -->
+
+
+<div class="container">
+<div id="page-title">
+   <h2>{% trans "Manage SMTP Hosts" %}</h2>
+   <p>{% trans "On this page you can manage STMP Host. (SMTP hosts are used to send emails)" %}</p>
+</div>
+<div ng-controller="manageSMTPHostsCTRL" class="panel" style="background: var(--bg-primary, white); border-color: var(--border-color, #ddd);">
+    <div class="panel-body" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+        <h3 class="title-hero">
+            {% trans "Manage SMTP Hosts" %} <img ng-hide="cyberPanelLoading" src="{% static 'images/loading.gif' %}">
+        </h3>
+        <div  class="example-box-wrapper">
+
+
+            <form action="/" class="form-horizontal bordered-row">
+
+            <!---- Create SMTP Host --->
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "SMTP Host" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="text" class="form-control" ng-model="smtpHost" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Port" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="text" class="form-control" ng-model="smtpPort" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Username" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="text" class="form-control" ng-model="smtpUserName" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationDetailsForm" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Password" %}</label>
+                    <div class="col-sm-6">
+                        <input  type="password" class="form-control" ng-model="smtpPassword" required>
+                    </div>
+                </div>
+
+                <div ng-hide="installationProgress" class="form-group">
+                    <label class="col-sm-3 control-label"></label>
+                    <div class="col-sm-4">
+                        <button type="button"  ng-click="saveSMTPHost()" class="btn btn-primary btn-lg btn-block">{% trans "Save Host" %}</button>
+                    </div>
+                </div>
+
+            <!---- Create SMTP Host --->
+
+            <!------ List of records --------------->
+
+                <div ng-hide="currentRecords" class="form-group">
+
+                    <div  class="col-sm-12">
+
+                        <table class="table" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                            <thead>
+                            <tr>
+                                <th>{% trans "ID" %}</th>
+                                <th>{% trans "Owner" %}</th>
+                                <th>{% trans "Host" %}</th>
+                                <th>{% trans "Port" %}</th>
+                                <th>{% trans "Username" %}</th>
+                                <th>{% trans "Actions" %}</th>
+                                <th></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr ng-repeat="record in records | filter:searchEmails">
+                                <td ng-bind="record.id"></td>
+                                <td ng-bind="record.owner"></td>
+                                <td ng-bind="record.host"></td>
+                                <td ng-bind="record.port"></td>
+                                <td ng-bind="record.userName"></td>
+                                <td >
+                                    <button type="button" ng-click="smtpHostOperations('verify', record.id)" class="btn ra-100 btn-purple">{% trans "Verify Host" %}</button>
+                                    <button type="button" ng-click="smtpHostOperations('delete', record.id)" class="btn ra-100 btn-purple">{% trans "Delete" %}</button>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+
+                        <div class="row">
+                            <div class="col-sm-4 col-sm-offset-8">
+
+                                <nav aria-label="Page navigation">
+                                    <ul class="pagination">
+                                        <li ng-click="fetchEmails(page)" ng-repeat="page in pagination"><a href="">{$ page $}</a></li>
+                                    </ul>
+                                </nav>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            <!------ List of records --------------->
+
+            </form>
+
+
+
+
+        </div>
+    </div>
+</div>
+
+
+</div>
+
+
+{% endblock %}

--- a/emailMarketing/templates/emailMarketing/sendEmails.html
+++ b/emailMarketing/templates/emailMarketing/sendEmails.html
@@ -1,0 +1,204 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{% trans "Send Emails - CyberPanel" %}{% endblock %}
+{% block content %}
+
+{% load static %}
+{% get_current_language as LANGUAGE_CODE %}
+<!-- Current language: {{ LANGUAGE_CODE }} -->
+
+
+<div class="container">
+<div id="page-title">
+   <h2>{% trans "Send Emails" %}</h2>
+   <p>{% trans "On this page you can send emails to the lists you created using SMTP Hosts." %}</p>
+</div>
+<div ng-controller="sendEmailsCTRL" class="panel" style="background: var(--bg-primary, white); border-color: var(--border-color, #ddd);">
+    <div class="panel-body" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+        <h3 class="title-hero">
+            {% trans "Send Emails" %} <img ng-hide="cyberPanelLoading" src="{% static 'images/loading.gif' %}">
+        </h3>
+        <div  class="example-box-wrapper">
+
+
+            <form action="/" class="form-horizontal bordered-row">
+
+
+                <div class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Select Template" %} </label>
+                    <div class="col-sm-6">
+                        <select ng-change="templateSelected()" ng-model="selectedTemplate" class="form-control">
+                            {% for items in templateNames %}
+                                <option>{{ items }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+
+                <div ng-hide="availableFunctions" class="form-group">
+                    <label class="col-sm-2 control-label"></label>
+                    <div class="col-sm-3">
+                         <button type="button" ng-disabled="deleteTemplateBTN" data-toggle="modal" data-target="#deleteTemplate" class="btn ra-100 btn-danger">{% trans 'Delete This Template' %}</button>
+                         <!--- Delete Template --->
+                            <div class="modal fade" id="deleteTemplate" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <div class="modal-header">
+                                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                                            <h4 class="modal-title">{% trans "You are doing to delete this template.." %} <img ng-hide="cyberPanelLoading" src="{% static 'images/loading.gif' %}"></h4>
+                                        </div>
+                                        <div class="modal-body">
+                                            <p>{% trans 'Are you sure?' %}</p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Close' %}</button>
+                                            <button data-dismiss="modal" ng-click="deleteTemplate()" type="button" class="btn btn-primary">{% trans 'Confirm' %}</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        <!--- Delete Template --->
+                    </div>
+                    <div class="col-sm-3">
+                         <a target="_blank" href="{$ previewLink $}"><button type="button" class="btn ra-100 btn-blue-alt">{% trans 'Preview Template' %}</button></a>
+                    </div>
+                    <div class="col-sm-3">
+                         <button ng-disabled="sendEmailBTN" type="button" ng-click="sendEmails()" class="btn ra-100 btn-blue-alt">{% trans 'Send Emails' %}</button>
+                    </div>
+                </div>
+
+                <div ng-hide="sendEmailsView" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Select List" %} </label>
+                    <div class="col-sm-6">
+                        <select ng-model="listName" class="form-control">
+                            {% for items in listNames %}
+                                <option>{{ items }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+
+                <div ng-hide="sendEmailsView" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "Select STMP Host" %} </label>
+                    <div class="col-sm-6">
+                        <select ng-model="host" class="form-control">
+                            {% for items in hostNames %}
+                                <option>{{ items }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+
+                <div ng-hide="sendEmailsView" class="form-group">
+                    <label class="col-sm-3 control-label">{% trans "" %}</label>
+                    <div class="col-sm-9">
+                        <div class="checkbox">
+                            <label>
+                                <input ng-model="verificationCheck" type="checkbox" value="">
+                                {% trans 'Send to un-verified email addresses.' %}
+                            </label>
+                        </div>
+                    </div>
+                    <label class="col-sm-3 control-label"></label>
+                    <div class="col-sm-9">
+                        <div class="checkbox">
+                            <label>
+                                <input ng-model="unsubscribeCheck" type="checkbox" value="">
+                                {% trans 'Include unsubscribe link.' %}
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div ng-hide="sendEmailsView" class="form-group">
+                    <label class="col-sm-3 control-label"></label>
+                    <div class="col-sm-4">
+                         <button type="button" ng-click="startEmailJob()" class="btn btn-primary btn-lg btn-block">{% trans "Start Job" %}</button>
+
+                    </div>
+                </div>
+
+            <!---- Email Job Status --->
+
+                <div ng-hide="jobStatus" class="form-group">
+                    <label class="col-sm-2 control-label"></label>
+                    <div class="col-sm-7">
+                            <div class="alert alert-success text-center" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <h2>{$ currentStatus $}</h2>
+                            </div>
+                    </div>
+                </div>
+
+                <div ng-hide="jobStatus" class="form-group">
+                    <label class="col-sm-3 control-label"></label>
+                    <div class="col-sm-4">
+                        <button type="button" ng-disabled="goBackDisable"  ng-click="goBack()" class="btn btn-primary btn-lg btn-block">{% trans "Go Back" %}</button>
+                    </div>
+                </div>
+
+            <!---- Email Job Status --->
+
+
+            <!------ List of records --------------->
+
+                <div ng-hide="sendEmailsView" class="form-group">
+
+                    <div  class="col-sm-12">
+
+                        <table class="table" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                            <thead>
+                            <tr>
+                                <th>{% trans "Job ID" %}</th>
+                                <th>{% trans "Date" %}</th>
+                                <th>{% trans "SMTP Host" %}</th>
+                                <th>{% trans "Total Emails" %}</th>
+                                <th>{% trans "Sent" %}</th>
+                                <th>{% trans "Failed" %}</th>
+                                <th>{% trans "Actions" %}</th>
+                                <th></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr ng-repeat="record in records | filter:searchEmails">
+                                <td ng-bind="record.id"></td>
+                                <td ng-bind="record.date"></td>
+                                <td ng-bind="record.host"></td>
+                                <td ng-bind="record.totalEmails"></td>
+                                <td ng-bind="record.sent"></td>
+                                <td ng-bind="record.failed"></td>
+                                <td >
+                                    <button type="button" ng-click="deleteJob(record.id)" class="btn ra-100 btn-purple">{% trans "Delete" %}</button>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+
+                        <div class="row">
+                            <div class="col-sm-4 col-sm-offset-8">
+
+                                <nav aria-label="Page navigation">
+                                    <ul class="pagination">
+                                        <li ng-click="fetchEmails(page)" ng-repeat="page in pagination"><a href="">{$ page $}</a></li>
+                                    </ul>
+                                </nav>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            <!------ List of records --------------->
+
+            </form>
+
+
+
+
+        </div>
+    </div>
+</div>
+
+
+</div>
+
+
+{% endblock %}

--- a/emailMarketing/templates/emailMarketing/website.html
+++ b/emailMarketing/templates/emailMarketing/website.html
@@ -1,0 +1,1134 @@
+{% extends "baseTemplate/index.html" %}
+{% load i18n %}
+{% block title %}{{ domain }} - CyberPanel{% endblock %}
+{% block content %}
+
+    {% load static %}
+    {% get_current_language as LANGUAGE_CODE %}
+    <!-- Current language: {{ LANGUAGE_CODE }} -->
+
+    <div ng-controller="websitePages" class="container">
+
+        <div id="page-title">
+            <h2><span id="domainNamePage">{{ domain }}</span> - <a target="_blank" href="{$ previewUrl $}"
+                                                                   style="height: 23px;line-height: 21px;"
+                                                                   class="btn btn-border btn-alt border-red btn-link font-red"
+                                                                   title=""><span>{% trans "Preview" %}</span></a></h2>
+            <p>{% trans "All functions related to a particular site." %}</p>
+        </div>
+
+        {% if not error %}
+
+
+            <div class="example-box-wrapper">
+
+                <div style="border-radius: 25px;border-color:#3498db; background: var(--bg-primary, white); color: var(--text-primary, #333);" class="content-box">
+
+                    <h3 class="content-box-header bg-blue">
+                        {% trans "Resource Usage" %} <img ng-hide="domainLoading" src="/static/images/loading.gif">
+                    </h3>
+
+
+                    <div class="content-box-wrapper" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                        <div class="row">
+
+                            <div class="col-md-6">
+                                <table class="table table-bordered" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                    <thead>
+                                    <tr>
+                                        <th>{% trans "Resource" %}</th>
+                                        <th>{% trans "Usage" %}</th>
+                                        <th>{% trans "Allowed" %}</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td><code>{% trans "FTP" %}</code></td>
+                                        <td><span class="bs-badge badge-success">{{ ftpUsed }}</span></td>
+                                        <td><span class="bs-badge badge-success">{{ ftpTotal }}</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>{% trans "Databases" %}</code></td>
+                                        <td><span class="bs-badge badge-success">{{ databasesUsed }}</span></td>
+                                        <td><span class="bs-badge badge-success">{{ databasesTotal }}</span></td>
+                                    </tr>
+
+
+                                    <tr>
+                                        <td><code>{% trans "Disk Usage" %}</code></td>
+                                        <td><span class="bs-badge badge-success">{{ diskInMB }} (MB)</span></td>
+                                        <td><span class="bs-badge badge-success">{{ diskInMBTotal }} (MB)</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>{% trans "Bandwidth Usage" %}</code></td>
+                                        <td><span class="bs-badge badge-success">{{ bwInMB }} (MB)</span></td>
+                                        <td><span class="bs-badge badge-success">{{ bwInMBTotal }} (MB)</span></td>
+                                    </tr>
+
+
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <div class="col-md-6">
+                                <div class="panel" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                    <div class="panel-body" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                                        <div class="example-box-wrapper">
+                                            <h3 class="title-hero">
+                                                {% trans "Disk Usage" %}
+                                            </h3>
+                                            <div class="progressbar" style="background: var(--bg-secondary, #f8f9ff); border-color: var(--border-color, #ddd);" data-value="{{ diskUsage }}">
+                                                <div class="progressbar-value bg-primary">
+                                                    <div class="progress-overlay"></div>
+                                                    <div class="progress-label">{{ diskUsage }}%</div>
+                                                </div>
+                                            </div>
+
+
+                                            <h3 class="title-hero">
+                                                {% trans "Bandwidth Usage" %}
+                                            </h3>
+                                            <div class="progressbar" style="background: var(--bg-secondary, #f8f9ff); border-color: var(--border-color, #ddd);" data-value="{{ bwUsage }}">
+                                                <div class="progressbar-value bg-primary">
+                                                    <div class="progress-overlay"></div>
+                                                    <div class="progress-label">{{ bwUsage }}%</div>
+                                                </div>
+                                            </div>
+
+
+                                        </div>
+
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                    </div>
+
+
+                </div>
+            </div>
+
+
+            <div class="example-box-wrapper">
+
+                <div style="border-radius: 25px;border-color:#3498db; background: var(--bg-primary, white); color: var(--text-primary, #333);" class="content-box">
+                    <h3 class="content-box-header bg-blue">
+                        {% trans "Logs" %} <img ng-hide="logFileLoading" src="/static/images/loading.gif">
+                    </h3>
+
+                    <div class="content-box-wrapper" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                        <div class="row">
+
+                            <div class="col-md-6" style="margin-bottom: 2%;">
+                                <a ng-click="fetchLogs(1)" href="" title="{% trans 'Load Access Logs' %}">
+                                    <img src="{% static 'images/icons/log-file-format.png' %}">
+                                </a>
+                                <a ng-click="fetchLogs(1)" href="" title="{% trans 'Load Access Logs' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Access Logs" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-6" style="margin-bottom: 2%;">
+                                <a ng-click="fetchErrorLogs(1)" href="" title="{% trans 'Load Error Logs' %}">
+                                    <img src="{% static 'images/icons/warning.png' %}">
+                                </a>
+                                <a ng-click="fetchErrorLogs(1)" href="" title="{% trans 'Load Error Logs' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Error Logs" %}</span>
+                                </a>
+                                </a>
+                            </div>
+
+
+                            <div class="col-md-12">
+
+                                <form ng-hide="hideLogs" class="form-horizontal bordered-row" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+                                    <div ng-hide="logsFeteched" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Logs Fetched" %}</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotFetchLogs" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not fetch logs, see the logs file through command line. Error message:" %}
+                                            {$ errorMessage $}</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotConnect" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                    </div>
+
+
+                                    <div ng-hide="fetchedData" class="form-group">
+
+                                        <div class="col-sm-3">
+                                            <input placeholder="Search..." ng-model="logSearch" name="dom" type="text"
+                                                   class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);" ng-model="domainNameCreate" required>
+                                        </div>
+
+                                        <div class="col-sm-2">
+                                            <input placeholder="Page Number" type="number" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);"
+                                                   ng-model="pageNumber" required>
+                                        </div>
+
+                                        <div class="col-sm-6">
+                                            <button ng-click="fetchLogs(3)" type="button"
+                                                    class="btn ra-100 btn-purple">{% trans "Next" %}</button>
+                                            <button ng-click="fetchLogs(4)" type="button"
+                                                    class="btn ra-100 btn-purple">{% trans "Previous" %}</button>
+                                        </div>
+
+                                        <div style="margin-bottom: 1%;" class=" col-sm-1">
+                                            <a ng-click="hidelogsbtn()" href=""><img src="/static/images/close-32.png"></a>
+                                        </div>
+                                        <div class="col-sm-12">
+                                            <table class="table" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <thead>
+                                                <tr>
+                                                    <th>Domain</th>
+                                                    <th>IP Address</th>
+                                                    <th>Time</th>
+                                                    <th>Resource</th>
+                                                    <th>Size</th>
+                                                </tr>
+                                                </thead>
+                                                <tbody>
+                                                <tr ng-repeat="record in records | filter:logSearch">
+                                                    <td ng-bind="record.domain"></td>
+                                                    <td ng-bind="record.ipAddress"></td>
+                                                    <td ng-bind="record.time"></td>
+                                                    <td ng-bind="record.resource"></td>
+                                                    <td ng-bind="record.size"></td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+
+
+                                    <div ng-hide="hideErrorLogs" class="form-group">
+
+                                        <div class="col-sm-2">
+                                            <input placeholder="Page Number" type="number" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);"
+                                                   ng-model="errorPageNumber" required>
+                                        </div>
+
+                                        <div class="col-sm-9">
+                                            <button ng-click="fetchErrorLogs(3)" type="button"
+                                                    class="btn ra-100 btn-purple">{% trans "Next" %}</button>
+                                            <button ng-click="fetchErrorLogs(4)" type="button"
+                                                    class="btn ra-100 btn-purple">{% trans "Previous" %}</button>
+                                        </div>
+
+                                        <div style="margin-bottom: 1%;" class=" col-sm-1">
+                                            <a ng-click="hideErrorLogsbtn()" href=""><img
+                                                    src="/static/images/close-32.png"></a>
+                                        </div>
+
+                                        <div class="col-sm-12">
+                                            <textarea ng-model="errorLogsData" rows="25"
+                                                      class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);"></textarea>
+                                        </div>
+                                    </div>
+
+
+                                </form>
+
+
+                            </div>
+
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
+            <div class="example-box-wrapper">
+                <div style="border-radius: 25px;border-color:#3498db; background: var(--bg-primary, white); color: var(--text-primary, #333);" class="content-box">
+
+                    <h3 class="content-box-header bg-blue">
+                        {% trans "Domains" %} <img ng-hide="domainLoading" src="/static/images/loading.gif">
+                    </h3>
+
+                    <div class="content-box-wrapper" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+                        <div class="row">
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+                                <a href="" ng-click="showCreateDomainForm()" title="{% trans 'Add Domains' %}" href="">
+                                    <img src="{% static 'images/icons/domains.png' %}">
+                                </a>
+                                <a ng-click="showCreateDomainForm()" title="{% trans 'Add Domains' %}" href=""
+                                   title="{% trans 'Add Domains' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Add Domains" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+                                <a href="" ng-click="showListDomains()" title="{% trans 'List Domains' %}" href=""
+                                   title="{% trans 'List Domains' %}">
+                                    <img src="{% static 'images/icons/sort.png' %}">
+                                </a>
+                                <a ng-click="showListDomains()" title="{% trans 'List Domains' %}" href=""
+                                   title="{% trans 'List Domains' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "List Domains" %}</span>
+                                </a>
+
+                            </div>
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+                                <a href="{$ domainAliasURL $}" target="_blank" title="{% trans 'Domain Alias' %}"
+                                   href="" title="{% trans 'Domain Alias' %}">
+                                    <img src="{% static 'images/icons/web-domain.png' %}">
+                                </a>
+                                <a href="{$ domainAliasURL $}" target="_blank" title="{% trans 'Domain Alias' %}"
+                                   href="" title="{% trans 'Domain Alias' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Domain Alias" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+                                <a href="{% url 'listCron' %}" target="_blank" title="{% trans 'Add new Cron Job' %}"
+                                   href="" title="{% trans 'List Domains' %}">
+                                    <img src="{% static 'images/icons/repeat.png' %}">
+                                </a>
+                                <a href="{% url 'listCron' %}" target="_blank" title="{% trans 'List Domains' %}"
+                                   title="{% trans 'Add new Cron Job' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Cron Jobs" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <!---------- HTML For creating domains --------------->
+                            <div class="col-md-12">
+                                <form id="domainCreationForm" name="websiteCreationForm" action="/"
+                                      class="form-horizontal bordered-row" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+
+                                    <div ng-hide="installationDetailsForm" class="form-group">
+                                        <label class="col-sm-3 control-label">{% trans "Domain Name" %}</label>
+                                        <div class="col-sm-6">
+                                            <input name="dom" type="text" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);"
+                                                   ng-model="domainNameCreate" required>
+                                        </div>
+                                        <div style="margin-bottom: 1%;" class=" col-sm-1">
+                                            <a title="{% trans 'Cancel' %}" ng-click="hideDomainCreationForm()" href=""><img
+                                                    src="/static/images/close-32.png"></a>
+                                        </div>
+                                    </div>
+
+                                    <div ng-hide="installationDetailsForm" class="form-group">
+                                        <label class="col-sm-3 control-label">{% trans "Path" %}</label>
+                                        <div class="col-sm-6">
+                                            <input placeholder="{% trans 'This path is relative to: ' %}{$ masterDomain $}. {% trans 'Leave empty to set default.' %}"
+                                                   type="text" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);" ng-model="docRootPath" required>
+                                        </div>
+                                        <div ng-show="websiteCreationForm.dom.$error.pattern"
+                                             class="current-pack">{% trans "Invalid Domain (Note: You don't need to add 'http' or 'https')" %}</div>
+                                    </div>
+
+
+                                    <div ng-hide="installationDetailsForm" class="form-group">
+                                        <label class="col-sm-3 control-label">{% trans "Select PHP" %}</label>
+                                        <div class="col-sm-6">
+                                            <select ng-model="phpSelection" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                {% for php in phps %}
+                                                    <option>{{ php }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    </div>
+
+
+                                    <div ng-hide="installationDetailsForm" ng-hide="installationDetailsForm"
+                                         class="form-group">
+                                        <label class="col-sm-3 control-label">{% trans "Additional Features" %}</label>
+                                        <div class="col-sm-9">
+                                            <div class="checkbox" style="color: var(--text-primary, #333);">
+                                                <label>
+                                                    <input ng-model="sslCheck" type="checkbox" value="">
+                                                    SSL
+                                                </label>
+                                            </div>
+                                        </div>
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-9">
+                                            <div class="checkbox" style="color: var(--text-primary, #333);">
+                                                <label>
+                                                    <input ng-model="dkimCheck" type="checkbox" value="">
+                                                    DKIM Support
+                                                </label>
+                                            </div>
+                                        </div>
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-9">
+                                            <div class="checkbox" style="color: var(--text-primary, #333);">
+                                                <label>
+                                                    <input ng-model="openBasedir" type="checkbox" value="">
+                                                    open_basedir Protection
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                    <div ng-hide="installationDetailsForm" class="form-group">
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <button type="button" ng-click="createDomain()"
+                                                    class="btn btn-primary btn-lg btn-block">{% trans "Create Domain" %}</button>
+
+                                        </div>
+                                    </div>
+
+
+                                    <div ng-hide="installationProgress" class="form-group">
+                                        <label class="col-sm-2 control-label"></label>
+                                        <div class="col-sm-7">
+
+                                            <div class="alert alert-success text-center" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <h2>{$ currentStatus $}</h2>
+                                            </div>
+
+                                            <div class="progress" style="background: var(--bg-secondary, #f8f9ff); border-color: var(--border-color, #ddd);">
+                                                <div id="installProgress" class="progress-bar" style="background: var(--bg-primary, white); color: var(--text-primary, #333);" role="progressbar"
+                                                     aria-valuenow="70" aria-valuemin="0" aria-valuemax="100"
+                                                     style="width:0%">
+                                                    <span class="sr-only">70% Complete</span>
+                                                </div>
+                                            </div>
+
+                                            <div ng-hide="errorMessageBox" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "Error message:" %} {$ errorMessage $}</p>
+                                            </div>
+
+                                            <div ng-hide="success" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "Website succesfully created." %}</p>
+                                            </div>
+
+
+                                            <div ng-hide="couldNotConnect" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                            </div>
+
+
+                                        </div>
+                                    </div>
+
+                                    <div ng-hide="installationProgress" class="form-group">
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <button type="button" ng-disabled="goBackDisable" ng-click="goBack()"
+                                                    class="btn btn-primary btn-lg btn-block">{% trans "Go Back" %}</button>
+                                        </div>
+                                    </div>
+
+
+                                </form>
+                            </div>
+
+                            <!---------- HTML For creating domains --------------->
+
+                            <!---------- HTML For Listing domains --------------->
+
+                            <div id="listDomains" class="col-md-12">
+
+                                <form ng-hide="" class="form-horizontal bordered-row" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+
+                                    <div ng-hide="phpChanged" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "PHP Version Changed to:" %} {$ changedPHPVersion $} </p>
+                                    </div>
+
+                                    <div ng-hide="domainDeleted" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Deleted:" %} {$ deletedDomain $} </p>
+                                    </div>
+
+                                    <div ng-hide="sslIssued" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "SSL Issued:" %} {$ sslDomainIssued $} </p>
+                                    </div>
+
+                                    <div ng-hide="childBaseDirChanged" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Changes applied successfully." %} </p>
+                                    </div>
+
+
+                                    <div ng-hide="domainError" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{$ errorMessage $}</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotConnect" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                    </div>
+
+
+                                    <div ng-hide="" class="form-group">
+
+                                        <div class="col-sm-11">
+                                            <input placeholder="Search Domain..." ng-model="logSearch" name="dom"
+                                                   type="text" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);" ng-model="domainNameCreate"
+                                                   required>
+                                        </div>
+
+                                        <div style="margin-bottom: 1%;" class=" col-sm-1">
+                                            <a title="{% trans 'Close' %}" ng-click="hideListDomains()" href=""><img
+                                                    src="/static/images/close-32.png"></a>
+                                        </div>
+
+
+                                        <div class="col-sm-12">
+                                            <table class="table" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <thead>
+                                                <tr>
+                                                    <th>Domain</th>
+                                                    <th>Launch</th>
+                                                    <th>Path</th>
+                                                    <th>open_basedir</th>
+                                                    <th>PHP</th>
+                                                    <th>SSL</th>
+                                                    <th>Delete</th>
+                                                </tr>
+                                                </thead>
+                                                <tbody>
+                                                <tr ng-repeat="record in childDomains | filter:logSearch">
+                                                    <td ng-bind="record.childDomain"></td>
+                                                    <td><a href="{$ record.childLunch $}"><img width="30px" height="30"
+                                                                                               class="center-block"
+                                                                                               src="{% static 'baseTemplate/assets/image-resources/webPanel.png' %}"></a>
+                                                    </td>
+                                                    <td ng-bind="record.path"></td>
+                                                    <td>
+                                                        <select ng-change="changeChildBaseDir(record.childDomain,childBaseDir)"
+                                                                ng-model="childBaseDir" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                            <option>Enable</option>
+                                                            <option>Disable</option>
+                                                        </select>
+                                                    </td>
+                                                    <td>
+                                                        <select ng-change="changePHP(record.childDomain,phpSelection)"
+                                                                ng-model="phpSelection" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                            {% for php in phps %}
+                                                                <option>{{ php }}</option>
+                                                            {% endfor %}
+                                                        </select>
+                                                    </td>
+                                                    <td>
+                                                        <button type="button"
+                                                                ng-click="issueSSL(record.childDomain,record.path)"
+                                                                class="btn ra-100 btn-purple">{% trans "Issue" %}</button>
+                                                    </td>
+                                                    <td>
+                                                        <button type="button"
+                                                                ng-click="deleteChildDomain(record.childDomain)"
+                                                                class="btn ra-100 btn-purple">{% trans "Delete" %}</button>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+
+
+                                </form>
+
+                            </div>
+
+                            <!---------- HTML For Listing domains --------------->
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
+
+            <div class="example-box-wrapper">
+
+                <div style="border-radius: 25px;border-color:#3498db; background: var(--bg-primary, white); color: var(--text-primary, #333); margin-bottom: 2%;" class="content-box">
+                    <h3 class="content-box-header bg-blue">
+                        {% trans "Configurations" %} <img ng-hide="configFileLoading" src="/static/images/loading.gif">
+                    </h3>
+
+
+                    <div class="content-box-wrapper" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                        <div class="row">
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                <a ng-click="fetchConfigurations()" href=""
+                                   title="{% trans 'Edit vHost Main Configurations' %}">
+                                    <img src="{% static 'images/icons/file.png' %}">
+                                </a>
+                                <a ng-click="fetchConfigurations()" href=""
+                                   title="{% trans 'Edit vHost Main Configurations' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "vHost Conf" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                <a ng-click="fetchRewriteFules()" href=""
+                                   title="{% trans 'Add Rewrite Rules (.htaccess)' %}">
+                                    <img src="{% static 'images/icons/pencilcase.png' %}">
+                                </a>
+                                <a ng-click="fetchRewriteFules()" href=""
+                                   title="{% trans 'Rewrite Rules (.htaccess)' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Rewrite Rules" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                <a ng-click="addSSL()" href="" title="{% trans 'Add Your Own SSL' %}">
+                                    <img src="{% static 'images/icons/locked.png' %}">
+                                </a>
+                                <a ng-click="addSSL()" href="" title="{% trans 'Add Your Own SSL' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Add SSL" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                <a ng-click="changePHPMaster()" href="" title="{% trans 'Change PHP Version' %}">
+                                    <img src="{% static 'images/icons/laptop.png' %}">
+                                </a>
+                                <a ng-click="changePHPMaster()" href="" title="{% trans 'Change PHP Version' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Change PHP" %}</span>
+                                </a>
+
+                            </div>
+
+                            <!---- HTML for main ssl file ---->
+
+                            <div class="col-md-12">
+
+                                <form ng-hide="hidsslconfigs" class="form-horizontal bordered-row" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+                                    <div ng-hide="sslSaved" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "SSL Saved" %}</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotSaveSSL" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not save SSL. Error message:" %} {$ errorMessage $}</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotConnect" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                    </div>
+
+
+                                    <div ng-hide="" class="form-group">
+                                        <div style="margin-bottom: 1%;" class="col-sm-offset-11 col-sm-1">
+                                            <a ng-click="hidesslbtn()" href=""><img
+                                                    src="/static/images/close-32.png"></a>
+                                        </div>
+                                        <div class="col-sm-6">
+                                            <textarea placeholder="Paste Your Cert" ng-model="cert" rows="10"
+                                                      class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);"></textarea>
+                                        </div>
+                                        <div class="col-sm-6">
+                                            <textarea placeholder="Paste Your Key" ng-model="key" rows="10"
+                                                      class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);"></textarea>
+                                        </div>
+                                    </div>
+
+                                    <div ng-hide="" class="form-group">
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <button type="button" ng-click="saveSSL()"
+                                                    class="btn btn-primary btn-lg btn-block">{% trans "Save" %}</button>
+
+                                        </div>
+                                    </div>
+
+
+                                </form>
+
+
+                            </div>
+
+
+                            <!----- HTML For SSL ---->
+
+
+                            <!---- HTML for main conf file ---->
+
+                            <div class="col-md-12">
+
+                                <form ng-hide="configurationsBox" class="form-horizontal bordered-row" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+                                    <div ng-hide="configsFetched" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Current configuration in the file fetched." %}</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotFetchConfigs" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not fetch current configuration. Error message:" %} {$
+                                            errorMessage $}</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotConnect" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                    </div>
+
+                                    <div ng-hide="configSaved" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Configurations saved." %}</p>
+                                    </div>
+
+                                    <div ng-hide="couldNotSaveConfigurations" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not fetch current configuration. Error message:" %} {$
+                                            errorMessage $}</p>
+                                    </div>
+
+
+                                    <div ng-hide="fetchedConfigsData" class="form-group">
+                                        <div style="margin-bottom: 1%;" class="col-sm-offset-11 col-sm-1">
+                                            <a ng-click="hideconfigbtn()" href=""><img
+                                                    src="/static/images/close-32.png"></a>
+                                        </div>
+                                        <div class="col-sm-12">
+                                            <textarea ng-model="configData" rows="20" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);"></textarea>
+                                        </div>
+                                    </div>
+
+                                    <div ng-hide="saveConfigBtn" class="form-group">
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <button type="button" ng-click="saveCongiruations()"
+                                                    class="btn btn-primary btn-lg btn-block">{% trans "Save" %}</button>
+
+                                        </div>
+                                    </div>
+
+
+                                </form>
+
+                            </div>
+
+                            <!-- HTML For rewrite rules-->
+
+                            <div class="col-md-12">
+
+                                <form ng-hide="configurationsBoxRewrite" class="form-horizontal bordered-row" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+
+                                    <div ng-hide="rewriteRulesFetched" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Current rewrite rules in the file fetched." %} <a target="_blank"
+                                                                                                       href="https://cyberpanel.net/KnowledgeBase/home/rewrite-rules/">Click</a>
+                                            to read more about whats changed in <a target="_blank"
+                                                                                   href="https://cyberpanel.net/KnowledgeBase/home/rewrite-rules/">rewrite
+                                                rules</a> from v1.7 onwards.</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotFetchRewriteRules" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not fetch current rewrite rules. Error message:" %} {$
+                                            errorMessage $}</p>
+                                    </div>
+
+
+                                    <div ng-hide="couldNotConnect" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                    </div>
+
+                                    <div ng-hide="rewriteRulesSaved" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Configurations saved." %}</p>
+                                    </div>
+
+                                    <div ng-hide="couldNotSaveRewriteRules" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                        <p>{% trans "Could not save rewrite rules. Error message:" %} {$ errorMessage
+                                            $}</p>
+                                    </div>
+
+
+                                    <div ng-hide="fetchedRewriteRules" class="form-group">
+                                        <div style="margin-bottom: 1%;" class="col-sm-offset-11 col-sm-1">
+                                            <a ng-click="hideRewriteRulesbtn()" href=""><img
+                                                    src="/static/images/close-32.png"></a>
+                                        </div>
+                                        <div class="col-sm-12">
+                                            <textarea ng-model="rewriteRules" rows="10" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);"></textarea>
+                                        </div>
+                                    </div>
+
+                                    <div ng-hide="saveRewriteRulesBTN" class="form-group">
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <button type="button" ng-click="saveRewriteRules()"
+                                                    class="btn btn-primary btn-lg btn-block">{% trans "Save Rewrite Rules" %}</button>
+
+                                        </div>
+                                    </div>
+
+
+                                </form>
+
+                            </div>
+
+                            <!--- HTML To change PHP --->
+
+                            <div class="col-md-12">
+
+                                <form ng-hide="changePHPView" name="" action="/" class="form-horizontal bordered-row" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+
+                                    <div class="form-group">
+                                        <label class="col-sm-3 control-label">{% trans "Select PHP" %}</label>
+                                        <div class="col-sm-6">
+                                            <select ng-model="phpSelectionMaster" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                {% for php in phps %}
+                                                    <option>{{ php }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+
+                                        <div style="margin-bottom: 1%;" class=" col-sm-1">
+                                            <a title="{% trans 'Cancel' %}" ng-click="hideChangePHPMaster()"
+                                               href=""><img src="/static/images/close-32.png"></a>
+                                        </div>
+
+                                    </div>
+
+
+                                    <div class="form-group">
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <button type="button" ng-click="changePHPVersionMaster()"
+                                                    class="btn btn-primary btn-lg btn-block">{% trans "Change PHP" %}</button>
+                                        </div>
+                                    </div>
+
+
+                                    <div class="form-group">
+
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <div ng-hide="failedToChangePHPMaster" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "Failed to change PHP version. Error message:" %} {$
+                                                    errorMessage $}</p>
+                                            </div>
+
+                                            <div ng-hide="phpChangedMaster" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "PHP successfully changed for: " %} <strong>{$ websiteDomain
+                                                    $}</strong></p>
+                                            </div>
+
+                                            <div ng-hide="couldNotConnect" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                            </div>
+                                        </div>
+
+
+                                    </div>
+
+
+                                </form>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
+            <div class="example-box-wrapper">
+                <div style="border-radius: 25px;border-color:#3498db; background: var(--bg-primary, white); color: var(--text-primary, #333);" class="content-box">
+                    <h3 class="content-box-header bg-blue">
+                        {% trans "Files" %}
+                    </h3>
+
+                    <div class="content-box-wrapper" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                        <div class="row">
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                <a href="{$ fileManagerURL $}" target="_blank" title="{% trans 'File Manager' %}">
+                                    <img src="{% static 'images/icons/office-material.png' %}">
+                                </a>
+                                <a href="{$ fileManagerURL $}" target="_blank" title="{% trans 'File Manager' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "File Manager" %}</span>
+                                </a>
+
+                            </div>
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                <a ng-click="openBaseDirView()" href="" title="{% trans 'open_basedir Protection' %}">
+                                    <img src="{% static 'images/icons/open_basedir.png' %}">
+                                </a>
+                                <a ng-click="openBaseDirView()" href="" title="{% trans 'open_basedir Protection' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "open_basedir" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                <a href="{% url 'createFTPAccount' %}" title="{% trans 'Create FTP Account' %}">
+                                    <img src="{% static 'images/icons/ftp-upload.png' %}">
+                                </a>
+                                <a href="{% url 'createFTPAccount' %}" title="{% trans 'Create FTP Account' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Create FTP Acct" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                <a href="{% url 'deleteFTPAccount' %}" title="{% trans 'Delete FTP Account' %}">
+                                    <img src="{% static 'images/icons/delete-ftp.png' %}">
+                                </a>
+                                <a href="{% url 'deleteFTPAccount' %}" title="{% trans 'Delete FTP Account' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Delete FTP Acct" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <!--- HTML To change open_basedir --->
+
+                            <div ng-hide="openBaseDirBox" class="col-md-12">
+
+                                <form action="/" class="form-horizontal bordered-row" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+
+                                    <div class="form-group">
+                                        <label class="col-sm-3 control-label">{% trans "open_basedir Protection" %}</label>
+                                        <div class="col-sm-6">
+                                            <select ng-model="openBasedirValue" class="form-control" style="background: var(--bg-primary, white); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <option>Enable</option>
+                                                <option>Disable</option>
+                                            </select>
+                                        </div>
+
+                                        <div ng-hide="baseDirLoading" style="margin-bottom: 1%;" class=" col-sm-1">
+                                            <img src="{% static 'images/loading.gif' %}">
+                                        </div>
+
+                                        <div style="margin-bottom: 2%;" class=" col-sm-1">
+                                            <a title="{% trans 'Cancel' %}" ng-click="hideOpenBasedir()" href=""><img
+                                                    src="/static/images/close-32.png"></a>
+                                        </div>
+
+                                    </div>
+
+
+                                    <div class="form-group">
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <button type="button" ng-click="applyOpenBasedirChanges()"
+                                                    class="btn btn-primary btn-lg btn-block">{% trans "Apply Changes" %}</button>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+
+                                        <label class="col-sm-3 control-label"></label>
+                                        <div class="col-sm-4">
+                                            <div ng-hide="operationFailed" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "Error message:" %} {$ errorMessage $} </p>
+                                            </div>
+
+                                            <div ng-hide="operationSuccessfull" class="alert alert-success" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "Changes successfully saved." %}</p>
+                                            </div>
+
+                                            <div ng-hide="couldNotConnect" class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                                                <p>{% trans "Could not connect to server. Please refresh this page." %}</p>
+                                            </div>
+                                        </div>
+
+                                    </div>
+
+
+                                </form>
+                            </div>
+
+                            <!--- HTML To change open_basedir --->
+
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {% if marketingStatus %}
+
+                <div class="example-box-wrapper">
+                    <div style="border-radius: 25px;border-color:#3498db; background: var(--bg-primary, white); color: var(--text-primary, #333);" class="content-box">
+                        <h3 class="content-box-header bg-blue">
+                            {% trans "Email Marketing" %}
+                        </h3>
+
+                        <div class="content-box-wrapper" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                            <div class="row">
+
+                                <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                    <a id="emailLists" target="_blank" title="{% trans 'Create Lists' %}">
+                                        <img src="{% static 'emailMarketing/mailing.png' %}">
+                                    </a>
+                                    <a id="emailListsChild" target="_blank" title="{% trans 'Create Lists' %}">
+                                        <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Create Lists" %}</span>
+                                    </a>
+
+                                </div>
+
+                                <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                    <a id="manageLists" target="_blank" title="{% trans 'Manage Lists' %}">
+                                        <img src="{% static 'emailMarketing/checklist.png' %}">
+                                    </a>
+                                    <a id="manageListsChild" target="_blank" title="{% trans 'Manage Lists' %}">
+                                        <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Manage Lists" %}</span>
+                                    </a>
+
+                                </div>
+
+                                <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                    <a id="manageSMTPHosts" target="_blank" title="{% trans 'SMTP Hosts' %}">
+                                        <img src="{% static 'emailMarketing/post-office.png' %}">
+                                    </a>
+                                    <a id="manageSMTPHostsChild" target="_blank" title="{% trans 'SMTP Hosts' %}">
+                                        <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "SMTP Hosts" %}</span>
+                                    </a>
+
+                                </div>
+
+                                <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                    <a id="composeEmails" target="_blank" title="{% trans 'Compose Message' %}">
+                                        <img src="{% static 'emailMarketing/compose.png' %}">
+                                    </a>
+                                    <a id="composeEmailsChild" target="_blank" title="{% trans 'Compose Message' %}">
+                                        <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Compose" %}</span>
+                                    </a>
+
+                                </div>
+
+                                <div class="col-md-3" style="margin-bottom: 2%;">
+
+                                    <a id="sendEmailsPage" target="_blank" title="{% trans 'Send Emails' %}">
+                                        <img src="{% static 'emailMarketing/paper-plane.png' %}">
+                                    </a>
+                                    <a id="sendEmailsPageChild" target="_blank" title="{% trans 'Send Emails' %}">
+                                        <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Send Emails" %}</span>
+                                    </a>
+
+                                </div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            {% endif %}
+
+            <div class="example-box-wrapper">
+
+                <div style="border-radius: 25px;border-color:#3498db; background: var(--bg-primary, white); color: var(--text-primary, #333);" class="content-box">
+                    <h3 class="content-box-header bg-blue">
+                        {% trans "Application Installer" %} <img ng-hide="applicationInstallerLoading"
+                                                                 src="/static/images/loading.gif">
+                    </h3>
+
+                    <div class="content-box-wrapper" style="background: var(--bg-primary, white); color: var(--text-primary, #333);">
+                        <div class="row">
+
+
+                            <div class="col-md-4" style="margin-bottom: 2%;">
+
+                                <a href="{$ wordPressInstallURL $}" target="_blank"
+                                   title="{% trans 'Install wordpress with LSCache' %}">
+                                    <img src="{% static 'images/icons/wordpress.png' %}">
+                                </a>
+                                <a href="{$ wordPressInstallURL $}" target="_blank"
+                                   title="{% trans 'Install wordpress with LSCache' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Wordpress with LSCache" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-4" style="margin-bottom: 2%;">
+
+                                <a href="{$ joomlaInstallURL $}" target="_blank"
+                                   title="{% trans 'Install Joomla with LSCache' %}">
+                                    <img src="{% static 'images/icons/joomla-logo.png' %}">
+                                </a>
+                                <a href="{$ joomlaInstallURL $}" target="_blank"
+                                   title="{% trans 'Install Joomla with LSCache' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Joomla" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-4" style="margin-bottom: 2%;">
+
+                                <a href="{$ setupGit $}" target="_blank"
+                                   title="{% trans 'Attach Git with this website!' %}">
+                                    <img src="{% static 'images/icons/git-logo.png' %}">
+                                </a>
+                                <a href="{$ setupGit $}" target="_blank"
+                                   title="{% trans 'Attach Git with this website!' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Git" %}</span>
+                                </a>
+
+                            </div>
+
+
+                            <div class="col-md-4" style="margin-bottom: 2%;">
+
+                                <a href="{$ installPrestaURL $}" target="_blank"
+                                   title="{% trans 'Install Prestashop' %}">
+                                    <img src="{% static 'images/icons/prestashop.png' %}">
+                                </a>
+                                <a href="{$ installPrestaURL $}" target="_blank"
+                                   title="{% trans 'Install Prestashop' %}">
+                                    <span style='font-size: 21px;font-family: "Times New Roman", Times, serif; padding-left: 2%'>{% trans "Prestashop" %}</span>
+                                </a>
+
+                            </div>
+
+
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+
+        {% else %}
+
+            <div class="alert alert-danger" style="background: var(--bg-secondary, #f8f9ff); color: var(--text-primary, #333); border-color: var(--border-color, #ddd);">
+                <p>{{ domain }}</p>
+            </div>
+
+
+        {% endif %}
+
+
+    </div>
+
+
+
+{% endblock %}

--- a/emailMarketing/tests.py
+++ b/emailMarketing/tests.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+
+from django.test import TestCase
+
+# Create your tests here.

--- a/emailMarketing/urls.py
+++ b/emailMarketing/urls.py
@@ -1,0 +1,31 @@
+from django.urls import path, re_path
+from . import views
+
+urlpatterns = [
+    path('', views.emailMarketing, name='emailMarketing'),
+    path('fetchUsers', views.fetchUsers, name='fetchUsers'),
+    path('enableDisableMarketing', views.enableDisableMarketing, name='enableDisableMarketing'),
+    path('saveConfigureVerify', views.saveConfigureVerify, name='saveConfigureVerify'),
+    path('fetchVerifyLogs', views.fetchVerifyLogs, name='fetchVerifyLogs'),
+    re_path(r'^(?P<domain>.+)/emailLists$', views.createEmailList, name='createEmailList'),
+    path('submitEmailList', views.submitEmailList, name='submitEmailList'),
+    re_path(r'^(?P<domain>.+)/manageLists$', views.manageLists, name='manageLists'),
+    re_path(r'^(?P<domain>.+)/manageSMTP$', views.manageSMTP, name='manageSMTP'),
+    re_path(r'^(?P<domain>.+)/configureVerify$', views.configureVerify, name='configureVerify'),
+    path('fetchEmails', views.fetchEmails, name='fetchEmails'),
+    path('deleteList', views.deleteList, name='deleteList'),
+    path('emailVerificationJob', views.emailVerificationJob, name='emailVerificationJob'),
+    path('deleteEmail', views.deleteEmail, name='deleteEmail'),
+    path('saveSMTPHost', views.saveSMTPHost, name='saveSMTPHost'),
+    path('fetchSMTPHosts', views.fetchSMTPHosts, name='fetchSMTPHosts'),
+    path('smtpHostOperations', views.smtpHostOperations, name='smtpHostOperations'),
+    path('composeEmailMessage', views.composeEmailMessage, name='composeEmailMessage'),
+    path('saveEmailTemplate', views.saveEmailTemplate, name='saveEmailTemplate'),
+    path('sendEmails', views.sendEmails, name='sendEmails'),
+    re_path(r'^preview/(?P<templateName>[-\w]+)/$', views.templatePreview, name='templatePreview'),
+    path('fetchJobs', views.fetchJobs, name='fetchJobs'),
+    path('startEmailJob', views.startEmailJob, name='startEmailJob'),
+    path('deleteTemplate', views.deleteTemplate, name='deleteTemplate'),
+    path('deleteJob', views.deleteJob, name='deleteJob'),
+    re_path(r'^remove/(?P<listName>[-\w]+)/(?P<emailAddress>\w+@.+)$', views.remove, name='remove'),
+]

--- a/emailMarketing/views.py
+++ b/emailMarketing/views.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+
+from django.shortcuts import redirect
+from loginSystem.views import loadLoginPage
+from .emailMarketingManager import EmailMarketingManager
+# Create your views here.
+
+
+def emailMarketing(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.emailMarketing()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def fetchUsers(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.fetchUsers()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def enableDisableMarketing(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.enableDisableMarketing()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def createEmailList(request, domain):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request, domain)
+        return emm.createEmailList()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def submitEmailList(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.submitEmailList()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def manageLists(request, domain):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request, domain)
+        return emm.manageLists()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def configureVerify(request, domain):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request, domain)
+        return emm.configureVerify()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def saveConfigureVerify(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.saveConfigureVerify()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def fetchVerifyLogs(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.fetchVerifyLogs()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def fetchEmails(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.fetchEmails()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def deleteList(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.deleteList()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def emailVerificationJob(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.emailVerificationJob()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def deleteEmail(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.deleteEmail()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def manageSMTP(request, domain):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request, domain)
+        return emm.manageSMTP()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def saveSMTPHost(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.saveSMTPHost()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def fetchSMTPHosts(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.fetchSMTPHosts()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def smtpHostOperations(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.smtpHostOperations()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def composeEmailMessage(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.composeEmailMessage()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def saveEmailTemplate(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.saveEmailTemplate()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def sendEmails(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.sendEmails()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def templatePreview(request, templateName):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request, templateName)
+        return emm.templatePreview()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def fetchJobs(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.fetchJobs()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def startEmailJob(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.startEmailJob()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def deleteTemplate(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.deleteTemplate()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+def deleteJob(request):
+    try:
+        userID = request.session['userID']
+        emm = EmailMarketingManager(request)
+        return emm.deleteJob()
+    except KeyError:
+        return redirect(loadLoginPage)
+
+
+def remove(request, listName, emailAddress):
+    try:
+        emm = EmailMarketingManager(request)
+        return emm.remove(listName, emailAddress)
+    except KeyError:
+        return redirect(loadLoginPage)

--- a/emailPremium/templates/emailPremium/EmailDebugger.html
+++ b/emailPremium/templates/emailPremium/EmailDebugger.html
@@ -212,22 +212,22 @@
     
     .status-badge.success {
         background: var(--success-color, #10b981);
-        color: var(--bg-secondary, white);
+        color: #fff;
     }
     
     .status-badge.error {
         background: var(--danger-color, #ef4444);
-        color: var(--bg-secondary, white);
+        color: #fff;
     }
     
     .status-badge.warning {
         background: var(--warning-color, #f59e0b);
-        color: var(--bg-secondary, white);
+        color: #fff;
     }
     
     .status-badge.info {
         background: var(--info-color, #3b82f6);
-        color: var(--bg-secondary, white);
+        color: #fff;
     }
     
     /* Action Link */

--- a/emailPremium/templates/emailPremium/Rspamd.html
+++ b/emailPremium/templates/emailPremium/Rspamd.html
@@ -11,8 +11,9 @@
     }
     
     .rspamd-container {
-        max-width: 1200px;
+        max-width: 920px;
         margin: 0 auto;
+        width: 100%;
     }
     
     /* Page Header */
@@ -218,6 +219,11 @@
         background: var(--bg-primary, white);
         transition: all 0.3s ease;
         cursor: pointer;
+    }
+
+    .form-select option {
+        color: var(--text-primary, #2f3640);
+        background: var(--bg-primary, white);
     }
     
     .form-select:focus {
@@ -545,7 +551,14 @@
     .help-text {
         font-size: 13px;
         color: var(--text-muted, #94a3b8);
-        margin-top: 5px;
+        margin: 0 0 8px 0;
+        display: block;
+        font-weight: 400;
+        text-transform: none;
+    }
+
+    .form-label + .help-text {
+        margin-top: -4px;
     }
     
     /* Responsive */
@@ -697,20 +710,16 @@
 
             <form>
                 <div class="form-group">
-                    <label class="form-label">
-                        {% trans "Antivirus Status" %}
-                        <span class="help-text">{% trans "Enable or disable antivirus scanning" %}</span>
-                    </label>
+                    <label class="form-label">{% trans "Antivirus Status" %}</label>
+                    <div class="help-text">{% trans "Enable or disable antivirus scanning" %}</div>
                     <div class="toggle-container">
                         <input type="checkbox" id="antivirus_status" data-toggle="toggle">
                     </div>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="action_rspamd">
-                        {% trans "Action" %}
-                        <span class="help-text">{% trans "Action to take when virus is detected" %}</span>
-                    </label>
+                    <label class="form-label" for="action_rspamd">{% trans "Action" %}</label>
+                    <div class="help-text">{% trans "Action to take when virus is detected" %}</div>
                     <select class="form-select" id="action_rspamd" ng-model="action_rspamd">
                         <option selected="selected">Reject</option>
                         <option>Unset</option>
@@ -718,46 +727,36 @@
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label">
-                        {% trans "Scan MIME Parts" %}
-                        <span class="help-text">{% trans "Enable scanning of MIME parts" %}</span>
-                    </label>
+                    <label class="form-label">{% trans "Scan MIME Parts" %}</label>
+                    <div class="help-text">{% trans "Enable scanning of MIME parts" %}</div>
                     <div class="toggle-container">
                         <input type="checkbox" id="scan_mime_parts" data-toggle="toggle">
                     </div>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label">
-                        {% trans "Log Clean" %}
-                        <span class="help-text">{% trans "Log clean messages" %}</span>
-                    </label>
+                    <label class="form-label">{% trans "Log Clean" %}</label>
+                    <div class="help-text">{% trans "Log clean messages" %}</div>
                     <div class="toggle-container">
                         <input type="checkbox" id="log_clean" data-toggle="toggle">
                     </div>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="max_size">
-                        {% trans "Max Size" %}
-                        <span class="help-text">{% trans "Maximum file size to scan (in bytes)" %}</span>
-                    </label>
+                    <label class="form-label" for="max_size">{% trans "Max Size" %}</label>
+                    <div class="help-text">{% trans "Maximum file size to scan (in bytes)" %}</div>
                     <input type="text" class="form-control" id="max_size" ng-model="max_size" placeholder="26214400" required>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="CLAMAV_VIRUS">
-                        {% trans "ClamAV Virus Symbol" %}
-                        <span class="help-text">{% trans "Symbol name for virus detection" %}</span>
-                    </label>
+                    <label class="form-label" for="CLAMAV_VIRUS">{% trans "ClamAV Virus Symbol" %}</label>
+                    <div class="help-text">{% trans "Symbol name for virus detection" %}</div>
                     <input type="text" class="form-control" id="CLAMAV_VIRUS" ng-model="CLAMAV_VIRUS" placeholder="CLAMAV_VIRUS" required>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="server">
-                        {% trans "Servers" %}
-                        <span class="help-text">{% trans "ClamAV server address" %}</span>
-                    </label>
+                    <label class="form-label" for="server">{% trans "Servers" %}</label>
+                    <div class="help-text">{% trans "ClamAV server address" %}</div>
                     <input type="text" class="form-control" id="server" ng-model="server" placeholder="127.0.0.1:3310" required>
                 </div>
 
@@ -804,36 +803,28 @@
 
             <form>
                 <div class="form-group">
-                    <label class="form-label" for="TCPSocket">
-                        {% trans "TCP Socket" %}
-                        <span class="help-text">{% trans "ClamAV TCP socket port" %}</span>
-                    </label>
+                    <label class="form-label" for="TCPSocket">{% trans "TCP Socket" %}</label>
+                    <div class="help-text">{% trans "ClamAV TCP socket port" %}</div>
                     <input type="text" class="form-control" id="TCPSocket" ng-model="TCPSocket" placeholder="3310" required>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="TCPAddr">
-                        {% trans "TCP Address" %}
-                        <span class="help-text">{% trans "ClamAV TCP address" %}</span>
-                    </label>
+                    <label class="form-label" for="TCPAddr">{% trans "TCP Address" %}</label>
+                    <div class="help-text">{% trans "ClamAV TCP address" %}</div>
                     <input type="text" class="form-control" id="TCPAddr" ng-model="TCPAddr" placeholder="127.0.0.1" required>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label">
-                        {% trans "Debug" %}
-                        <span class="help-text">{% trans "Enable debug logging" %}</span>
-                    </label>
+                    <label class="form-label">{% trans "Debug" %}</label>
+                    <div class="help-text">{% trans "Enable debug logging" %}</div>
                     <div class="toggle-container">
                         <input type="checkbox" id="clamav_Debug" data-toggle="toggle">
                     </div>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="LogFile">
-                        {% trans "Log Path" %}
-                        <span class="help-text">{% trans "Path to ClamAV log file" %}</span>
-                    </label>
+                    <label class="form-label" for="LogFile">{% trans "Log Path" %}</label>
+                    <div class="help-text">{% trans "Path to ClamAV log file" %}</div>
                     <input type="text" class="form-control" id="LogFile" ng-model="LogFile" placeholder="/var/log/clamav/clamav.log" required>
                 </div>
 
@@ -880,18 +871,14 @@
 
             <form>
                 <div class="form-group">
-                    <label class="form-label" for="smtpd_milters">
-                        {% trans "SMTPD Milters" %}
-                        <span class="help-text">{% trans "Mail filter configuration for SMTP daemon" %}</span>
-                    </label>
+                    <label class="form-label" for="smtpd_milters">{% trans "SMTPD Milters" %}</label>
+                    <div class="help-text">{% trans "Mail filter configuration for SMTP daemon" %}</div>
                     <input type="text" class="form-control" id="smtpd_milters" ng-model="smtpd_milters" placeholder="inet:127.0.0.1:11332" required>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="non_smtpd_milters">
-                        {% trans "Non-SMTPD Milters" %}
-                        <span class="help-text">{% trans "Mail filter configuration for non-SMTP mail" %}</span>
-                    </label>
+                    <label class="form-label" for="non_smtpd_milters">{% trans "Non-SMTPD Milters" %}</label>
+                    <div class="help-text">{% trans "Mail filter configuration for non-SMTP mail" %}</div>
                     <input type="text" class="form-control" id="non_smtpd_milters" ng-model="non_smtpd_milters" placeholder="inet:127.0.0.1:11332" required>
                 </div>
 
@@ -938,18 +925,14 @@
 
             <form>
                 <div class="form-group">
-                    <label class="form-label" for="write_servers">
-                        {% trans "Write Servers" %}
-                        <span class="help-text">{% trans "Redis write servers configuration" %}</span>
-                    </label>
+                    <label class="form-label" for="write_servers">{% trans "Write Servers" %}</label>
+                    <div class="help-text">{% trans "Redis write servers configuration" %}</div>
                     <input type="text" class="form-control" id="write_servers" ng-model="write_servers" placeholder="127.0.0.1:6379" required>
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label" for="read_servers">
-                        {% trans "Read Servers" %}
-                        <span class="help-text">{% trans "Redis read servers configuration" %}</span>
-                    </label>
+                    <label class="form-label" for="read_servers">{% trans "Read Servers" %}</label>
+                    <div class="help-text">{% trans "Redis read servers configuration" %}</div>
                     <input type="text" class="form-control" id="read_servers" ng-model="read_servers" placeholder="127.0.0.1:6379" required>
                 </div>
 

--- a/emailPremium/templates/emailPremium/emailPage.html
+++ b/emailPremium/templates/emailPremium/emailPage.html
@@ -9,6 +9,7 @@
 {% get_current_language as LANGUAGE_CODE %}
 <!-- Current language: {{ LANGUAGE_CODE }} -->
 
+{% if not cosmetic.HidePromotions %}
 <div id="cybermailBanner" style="display:none; margin-bottom:20px;">
   <div style="background:linear-gradient(135deg,#4f46e5 0%,#7c3aed 50%,#9333ea 100%);border-radius:10px;padding:20px 24px;display:flex;align-items:center;gap:18px;box-shadow:0 4px 15px rgba(79,70,229,0.3);">
     <div style="flex-shrink:0;font-size:32px;">&#9993;</div>
@@ -24,6 +25,7 @@
 (function(){if(!document.cookie.includes('cybermail_dismiss=1')){document.getElementById('cybermailBanner').style.display='';}})();
 function dismissCyberMailBanner(){document.getElementById('cybermailBanner').style.display='none';document.cookie='cybermail_dismiss=1; path=/; max-age='+7*86400;}
 </script>
+{% endif %}
 
 <div ng-controller="emailPage" class="container">
 

--- a/firewall/firewallManager.py
+++ b/firewall/firewallManager.py
@@ -25,6 +25,7 @@ from random import randint
 import time
 from plogical.firewallUtilities import FirewallUtilities
 from firewall.models import FirewallRules
+from firewall import ruleOrder as FirewallRuleOrder
 from plogical.modSec import modSec
 from plogical.csf import CSF
 from plogical.processUtilities import ProcessUtilities
@@ -266,7 +267,7 @@ class FirewallManager:
             else:
                 return ACLManager.loadErrorJson('fetchStatus', 0)
 
-            rules_qs = FirewallRules.objects.all().order_by('id')
+            rules_qs = FirewallRuleOrder.ordered_queryset()
 
             # Ensure CyberPanel port 7080 rule exists in database for visibility
             cyberpanel_rule_exists = rules_qs.filter(port='7080').exists()
@@ -276,12 +277,13 @@ class FirewallManager:
                         name="CyberPanel Admin",
                         proto="tcp",
                         port="7080",
-                        ipAddress="0.0.0.0/0"
+                        ipAddress="0.0.0.0/0",
+                        sortOrder=FirewallRuleOrder.next_sort_order()
                     ).save()
                     logging.CyberCPLogFileWriter.writeToFile("Added CyberPanel port 7080 to firewall database for UI visibility")
                 except Exception as e:
                     logging.CyberCPLogFileWriter.writeToFile(f"Failed to add CyberPanel port 7080 to database: {str(e)}")
-                rules_qs = FirewallRules.objects.all().order_by('id')
+                rules_qs = FirewallRuleOrder.ordered_queryset()
 
             total_count = rules_qs.count()
             page = 1
@@ -302,8 +304,12 @@ class FirewallManager:
 
             json_data = "["
             for i, items in enumerate(rules):
+                # displayId is 1-based position in the full ordered list (top row = 1)
+                display_id = start + i + 1
                 dic = {
                     'id': items.id,
+                    'displayId': display_id,
+                    'sortOrder': items.sortOrder or display_id,
                     'name': items.name,
                     'proto': items.proto,
                     'port': items.port,
@@ -346,7 +352,13 @@ class FirewallManager:
 
             FirewallUtilities.addRule(ruleProtocol, rulePort, ruleIP)
 
-            newFWRule = FirewallRules(name=ruleName, proto=ruleProtocol, port=rulePort, ipAddress=ruleIP)
+            newFWRule = FirewallRules(
+                name=ruleName,
+                proto=ruleProtocol,
+                port=rulePort,
+                ipAddress=ruleIP,
+                sortOrder=FirewallRuleOrder.next_sort_order()
+            )
             newFWRule.save()
 
             final_dic = {'status': 1, 'add_status': 1, 'error_message': "None"}
@@ -357,6 +369,75 @@ class FirewallManager:
             final_dic = {'status': 0, 'add_status': 0, 'error_message': str(msg)}
             final_json = json.dumps(final_dic)
             return HttpResponse(final_json)
+
+    def reorderRules(self, userID=None, data=None):
+        """
+        Persist Firewall Rules table order in MariaDB (sortOrder).
+        Payload options:
+          - direction + id: move one step up/down
+          - page_ordered_ids + page + page_size: reorder within a page
+          - ordered_ids: full global order
+        Works whether firewalld is running or stopped (DB-only).
+        """
+        try:
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] != 1:
+                return ACLManager.loadErrorJson('reorder_status', 0)
+
+            data = data or {}
+            direction = (data.get('direction') or '').strip().lower()
+            rule_id = data.get('id')
+            page_ordered_ids = data.get('page_ordered_ids')
+            ordered_ids = data.get('ordered_ids')
+
+            if direction in ('up', 'down') and rule_id is not None:
+                new_order = FirewallRuleOrder.move_rule(rule_id, direction)
+            elif page_ordered_ids is not None:
+                page = data.get('page', 1)
+                page_size = data.get('page_size', 10)
+                new_order = FirewallRuleOrder.apply_page_order(
+                    page_ordered_ids, page, page_size
+                )
+            elif ordered_ids is not None:
+                new_order = FirewallRuleOrder.apply_ordered_ids(ordered_ids)
+            else:
+                final_dic = {
+                    'status': 0,
+                    'reorder_status': 0,
+                    'error_message': 'Provide direction+id, page_ordered_ids, or ordered_ids'
+                }
+                return HttpResponse(
+                    json.dumps(final_dic), content_type='application/json'
+                )
+
+            final_dic = {
+                'status': 1,
+                'reorder_status': 1,
+                'error_message': 'None',
+                'ordered_ids': new_order,
+            }
+            return HttpResponse(
+                json.dumps(final_dic), content_type='application/json'
+            )
+
+        except ValueError as msg:
+            final_dic = {
+                'status': 0,
+                'reorder_status': 0,
+                'error_message': str(msg)
+            }
+            return HttpResponse(
+                json.dumps(final_dic), content_type='application/json'
+            )
+        except BaseException as msg:
+            final_dic = {
+                'status': 0,
+                'reorder_status': 0,
+                'error_message': str(msg)
+            }
+            return HttpResponse(
+                json.dumps(final_dic), content_type='application/json'
+            )
 
     def deleteRule(self, userID = None, data = None):
         try:
@@ -377,6 +458,7 @@ class FirewallManager:
 
             delRule = FirewallRules.objects.get(id=ruleID)
             delRule.delete()
+            FirewallRuleOrder.renumber_all()
 
             final_dic = {'status': 1, 'delete_status': 1, 'error_message': "None"}
             final_json = json.dumps(final_dic)
@@ -482,6 +564,14 @@ class FirewallManager:
             res = ProcessUtilities.executioner(command)
 
             if res == 1:
+                # UI order lives in MariaDB sortOrder; getCurrentRules / start both read that order.
+                # firewalld rich-rules are a set of accepts (port opens); order is persisted for the panel.
+                try:
+                    FirewallRuleOrder.ensure_sort_orders()
+                except BaseException as order_msg:
+                    logging.CyberCPLogFileWriter.writeToFile(
+                        "Firewall start: ensure sortOrder warning: %s" % str(order_msg)
+                    )
                 final_dic = {'start_status': 1, 'error_message': "None"}
                 final_json = json.dumps(final_dic)
                 return HttpResponse(final_json)
@@ -2816,8 +2906,8 @@ class FirewallManager:
                 except Exception:
                     pass
 
-            # Get all firewall rules
-            rules = FirewallRules.objects.all()
+            # Get all firewall rules (stable UI order)
+            rules = FirewallRuleOrder.ordered_queryset()
             default_rules = ['CyberPanel Admin', 'SSHCustom']
             custom_rules = []
             for rule in rules:
@@ -2826,7 +2916,8 @@ class FirewallManager:
                         'name': rule.name,
                         'proto': rule.proto,
                         'port': rule.port,
-                        'ipAddress': rule.ipAddress
+                        'ipAddress': rule.ipAddress,
+                        'sortOrder': rule.sortOrder
                     })
 
             logging.CyberCPLogFileWriter.writeToFile(f"Firewall rules exported successfully. Total rules: {len(custom_rules)}")
@@ -2950,7 +3041,8 @@ class FirewallManager:
                         name=rule_data['name'],
                         proto=rule_data['proto'],
                         port=rule_data['port'],
-                        ipAddress=rule_data['ipAddress']
+                        ipAddress=rule_data['ipAddress'],
+                        sortOrder=FirewallRuleOrder.next_sort_order()
                     )
                     new_rule.save()
                     

--- a/firewall/migrations/0003_firewallrules_sortorder.py
+++ b/firewall/migrations/0003_firewallrules_sortorder.py
@@ -1,0 +1,80 @@
+# Add sortOrder on legacy firewall_firewallrules (table predates Django migrations).
+
+from django.db import migrations, connection
+
+
+def add_sort_order_column(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'firewall_firewallrules'
+              AND COLUMN_NAME = 'sortOrder'
+            """
+        )
+        exists = cursor.fetchone()[0] > 0
+        if not exists:
+            cursor.execute(
+                "ALTER TABLE `firewall_firewallrules` "
+                "ADD COLUMN `sortOrder` int(11) NOT NULL DEFAULT 0"
+            )
+        cursor.execute(
+            "UPDATE `firewall_firewallrules` SET `sortOrder` = `id` "
+            "WHERE `sortOrder` IS NULL OR `sortOrder` <= 0"
+        )
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM information_schema.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'firewall_firewallrules'
+              AND INDEX_NAME = 'firewall_fw_rules_sortorder_idx'
+            """
+        )
+        idx_exists = cursor.fetchone()[0] > 0
+        if not idx_exists:
+            cursor.execute(
+                "CREATE INDEX `firewall_fw_rules_sortorder_idx` "
+                "ON `firewall_firewallrules` (`sortOrder`)"
+            )
+
+
+def drop_sort_order_column(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'firewall_firewallrules'
+              AND COLUMN_NAME = 'sortOrder'
+            """
+        )
+        exists = cursor.fetchone()[0] > 0
+        if exists:
+            cursor.execute(
+                """
+                SELECT COUNT(*) FROM information_schema.STATISTICS
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_NAME = 'firewall_firewallrules'
+                  AND INDEX_NAME = 'firewall_fw_rules_sortorder_idx'
+                """
+            )
+            if cursor.fetchone()[0] > 0:
+                cursor.execute(
+                    "DROP INDEX `firewall_fw_rules_sortorder_idx` "
+                    "ON `firewall_firewallrules`"
+                )
+            cursor.execute(
+                "ALTER TABLE `firewall_firewallrules` DROP COLUMN `sortOrder`"
+            )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('firewall', '0002_create_bannedips_table'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_sort_order_column, drop_sort_order_column),
+    ]

--- a/firewall/models.py
+++ b/firewall/models.py
@@ -11,6 +11,8 @@ class FirewallRules(models.Model):
     proto = models.CharField(max_length=10)
     port = models.CharField(max_length=25)
     ipAddress = models.CharField(max_length=30,default="0.0.0.0/0")
+    # Display / apply order for Firewall Rules table (1 = top). Independent of auto-increment PK.
+    sortOrder = models.IntegerField(default=0, db_index=True)
 
 
 class BannedIP(models.Model):

--- a/firewall/ruleOrder.py
+++ b/firewall/ruleOrder.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""Firewall rule display order helpers (MariaDB sortOrder)."""
+from __future__ import unicode_literals
+
+from django.db import transaction
+from django.db.models import Max
+
+from firewall.models import FirewallRules
+
+
+def ensure_sort_orders():
+    """Backfill sortOrder for rows that still use the default 0."""
+    rules = list(FirewallRules.objects.all().order_by('id'))
+    needs = [r for r in rules if not r.sortOrder or r.sortOrder <= 0]
+    if not needs and rules:
+        # Also normalize gaps if every row already has a positive order
+        return
+    if not rules:
+        return
+    with transaction.atomic():
+        for idx, rule in enumerate(rules, start=1):
+            if rule.sortOrder != idx:
+                rule.sortOrder = idx
+                rule.save(update_fields=['sortOrder'])
+
+
+def next_sort_order():
+    """Return the next sortOrder value for a newly added rule."""
+    ensure_sort_orders()
+    current = FirewallRules.objects.aggregate(m=Max('sortOrder')).get('m') or 0
+    return int(current) + 1
+
+
+def ordered_queryset():
+    """Rules queryset ordered for UI and apply paths."""
+    ensure_sort_orders()
+    return FirewallRules.objects.all().order_by('sortOrder', 'id')
+
+
+def renumber_all():
+    """Force contiguous sortOrder values 1..n in current order."""
+    rules = list(FirewallRules.objects.all().order_by('sortOrder', 'id'))
+    with transaction.atomic():
+        for idx, rule in enumerate(rules, start=1):
+            if rule.sortOrder != idx:
+                rule.sortOrder = idx
+                rule.save(update_fields=['sortOrder'])
+    return [r.id for r in rules]
+
+
+def apply_ordered_ids(ordered_ids):
+    """
+    Persist a full global order from a list of primary keys.
+    Returns the new ordered id list (1..n).
+    """
+    if not isinstance(ordered_ids, (list, tuple)) or not ordered_ids:
+        raise ValueError('ordered_ids must be a non-empty list of rule IDs')
+
+    try:
+        ordered_ids = [int(x) for x in ordered_ids]
+    except (TypeError, ValueError):
+        raise ValueError('ordered_ids must contain integers')
+
+    existing = list(FirewallRules.objects.values_list('id', flat=True))
+    if sorted(ordered_ids) != sorted(existing):
+        raise ValueError('ordered_ids must include every firewall rule exactly once')
+
+    with transaction.atomic():
+        for idx, rule_id in enumerate(ordered_ids, start=1):
+            FirewallRules.objects.filter(id=rule_id).update(sortOrder=idx)
+    return ordered_ids
+
+
+def apply_page_order(page_ordered_ids, page, page_size):
+    """
+    Replace the slice for the given page with page_ordered_ids and renumber.
+    """
+    if not isinstance(page_ordered_ids, (list, tuple)) or not page_ordered_ids:
+        raise ValueError('page_ordered_ids must be a non-empty list')
+
+    try:
+        page = max(1, int(page))
+        page_size = max(1, min(100, int(page_size)))
+        page_ordered_ids = [int(x) for x in page_ordered_ids]
+    except (TypeError, ValueError):
+        raise ValueError('Invalid page reorder payload')
+
+    all_ids = list(ordered_queryset().values_list('id', flat=True))
+    start = (page - 1) * page_size
+    end = start + page_size
+    current_slice = all_ids[start:end]
+
+    if sorted(page_ordered_ids) != sorted(current_slice):
+        raise ValueError('page_ordered_ids must be a permutation of the current page')
+
+    all_ids[start:start + len(page_ordered_ids)] = page_ordered_ids
+    return apply_ordered_ids(all_ids)
+
+
+def move_rule(rule_id, direction):
+    """
+    Move a rule one step up or down in the global order.
+    direction: 'up' | 'down'
+    """
+    direction = (direction or '').strip().lower()
+    if direction not in ('up', 'down'):
+        raise ValueError("direction must be 'up' or 'down'")
+
+    try:
+        rule_id = int(rule_id)
+    except (TypeError, ValueError):
+        raise ValueError('Invalid rule id')
+
+    ids = list(ordered_queryset().values_list('id', flat=True))
+    if rule_id not in ids:
+        raise ValueError('Rule not found')
+
+    idx = ids.index(rule_id)
+    if direction == 'up':
+        if idx == 0:
+            return ids
+        ids[idx - 1], ids[idx] = ids[idx], ids[idx - 1]
+    else:
+        if idx >= len(ids) - 1:
+            return ids
+        ids[idx + 1], ids[idx] = ids[idx], ids[idx + 1]
+
+    return apply_ordered_ids(ids)

--- a/firewall/static/firewall/firewall.js
+++ b/firewall/static/firewall/firewall.js
@@ -171,9 +171,14 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
 
     firewallStatus();
 
-    // Load both tabs on init; also load on tab change (watch) so content always shows
-    populateCurrentRecords();
-    populateBannedIPs();
+    // Load active tab data on init (avoid flipping UX by always prefetching banned).
+    if ($scope.activeTab === 'banned') {
+        populateBannedIPs();
+    } else if ($scope.activeTab === 'trusted') {
+        populateTrustedSSHWhitelist();
+    } else {
+        populateCurrentRecords();
+    }
 
     $scope.$watch('activeTab', function(newVal, oldVal) {
         if (newVal === oldVal || !newVal) return;
@@ -497,19 +502,24 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         };
     }
     
-    // Load banned IPs on page load - use $timeout for Angular compatibility
-    // Wrap in try-catch to ensure it executes even if there are other errors
+    // Prefetch banned IPs shortly after load only when that tab is active (avoids tab race noise).
     try {
         $timeout(function() {
             try {
-                console.log('=== Calling populateBannedIPs from $timeout on page load ===');
-                populateBannedIPs();
+                if ($scope.activeTab === 'banned') {
+                    console.log('=== Calling populateBannedIPs from $timeout on page load ===');
+                    populateBannedIPs();
+                } else if ($scope.activeTab === 'rules') {
+                    populateCurrentRecords();
+                } else if ($scope.activeTab === 'trusted') {
+                    populateTrustedSSHWhitelist();
+                }
             } catch(e) {
-                console.error('Error in populateBannedIPs from timeout:', e);
+                console.error('Error in firewall tab prefetch from timeout:', e);
             }
         }, 500);
     } catch(e) {
-        console.error('Error setting up timeout for populateBannedIPs:', e);
+        console.error('Error setting up timeout for firewall tab prefetch:', e);
     }
     
     $scope.addRule = function () {
@@ -1030,7 +1040,8 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.ruleAdded = true;
                 $scope.couldNotConnect = true;
 
-                $scope.rulesDetails = true;
+                /* Keep rules UI visible while firewall is stopped so operators can still edit stored rules. */
+                $scope.rulesDetails = false;
 
                 firewallStatus();
 
@@ -1093,19 +1104,17 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
             if (response.data.status == 1) {
 
                 if (response.data.firewallStatus == 1) {
-                    $scope.rulesDetails = false;
                     $scope.status = "ON";
                 }
                 else {
-                    $scope.rulesDetails = true;
                     $scope.status = "OFF";
                 }
             }
             else {
-
-                $scope.rulesDetails = true;
                 $scope.status = "OFF";
             }
+            /* Never hide the rules table/form when firewall is OFF (was rulesDetails=true). */
+            $scope.rulesDetails = false;
 
 
         }

--- a/firewall/static/firewall/firewall.js
+++ b/firewall/static/firewall/firewall.js
@@ -711,6 +711,197 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         populateCurrentRecords();
     };
 
+    function renumberDisplayedRuleIds() {
+        var start = $scope.rulesRangeStart() || 1;
+        ($scope.rules || []).forEach(function(rule, idx) {
+            rule.displayId = start + idx;
+            rule.sortOrder = rule.displayId;
+        });
+    }
+
+    function persistPageRuleOrder() {
+        var pageIds = ($scope.rules || []).map(function(r) { return r.id; });
+        if (!pageIds.length) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = {
+            page_ordered_ids: pageIds,
+            page: Math.max(1, parseInt($scope.rulesPage, 10) || 1),
+            page_size: Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10))
+        };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                renumberDisplayedRuleIds();
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                $scope.rulesLoading = false;
+            } else {
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not save rule order';
+                populateCurrentRecords();
+            }
+        }, function() {
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+            populateCurrentRecords();
+        });
+    }
+
+    $scope.canMoveRuleUp = function(index) {
+        var page = Math.max(1, parseInt($scope.rulesPage, 10) || 1);
+        return !(page === 1 && index === 0);
+    };
+
+    $scope.canMoveRuleDown = function(index) {
+        var page = Math.max(1, parseInt($scope.rulesPage, 10) || 1);
+        var size = Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10));
+        var total = $scope.rulesTotalCount || ($scope.rules ? $scope.rules.length : 0) || 0;
+        var globalIndex = (page - 1) * size + index;
+        return globalIndex < (total - 1);
+    };
+
+    $scope.moveRuleUp = function(rule) {
+        if (!rule || !rule.id) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = { id: rule.id, direction: 'up' };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not move rule';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    $scope.moveRuleDown = function(rule) {
+        if (!rule || !rule.id) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = { id: rule.id, direction: 'down' };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not move rule';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    var rulesDragFromIndex = null;
+
+    function bindRulesDragDrop() {
+        var tbody = document.getElementById('firewall-rules-tbody');
+        if (!tbody || tbody.getAttribute('data-dnd-bound') === '1') {
+            return;
+        }
+        tbody.setAttribute('data-dnd-bound', '1');
+
+        tbody.addEventListener('dragstart', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            // Allow drag from row/handle; block from action buttons/inputs
+            if (ev.target.closest && ev.target.closest('button, a, input, select, textarea')) {
+                ev.preventDefault();
+                return;
+            }
+            rulesDragFromIndex = parseInt(row.getAttribute('data-rule-index'), 10);
+            if (isNaN(rulesDragFromIndex)) {
+                rulesDragFromIndex = null;
+                return;
+            }
+            row.classList.add('rule-row-dragging');
+            try {
+                ev.dataTransfer.effectAllowed = 'move';
+                ev.dataTransfer.setData('text/plain', String(rulesDragFromIndex));
+            } catch (ignoreSet) {}
+        });
+
+        tbody.addEventListener('dragover', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            ev.preventDefault();
+            try {
+                ev.dataTransfer.dropEffect = 'move';
+            } catch (ignoreDrop) {}
+        });
+
+        tbody.addEventListener('drop', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            ev.preventDefault();
+            var toIndex = parseInt(row.getAttribute('data-rule-index'), 10);
+            var fromIndex = rulesDragFromIndex;
+            if (fromIndex === null || isNaN(toIndex) || fromIndex === toIndex) {
+                return;
+            }
+            $scope.$applyAsync(function() {
+                var list = $scope.rules || [];
+                if (fromIndex < 0 || fromIndex >= list.length || toIndex < 0 || toIndex >= list.length) {
+                    return;
+                }
+                var moved = list.splice(fromIndex, 1)[0];
+                list.splice(toIndex, 0, moved);
+                $scope.rules = list;
+                renumberDisplayedRuleIds();
+                persistPageRuleOrder();
+            });
+        });
+
+        tbody.addEventListener('dragend', function(ev) {
+            rulesDragFromIndex = null;
+            var dragging = tbody.querySelectorAll('.rule-row-dragging');
+            for (var i = 0; i < dragging.length; i++) {
+                dragging[i].classList.remove('rule-row-dragging');
+            }
+        });
+    }
+
+    // Bind after Angular paints the rules table (tbody is destroyed when rules empty)
+    $scope.$watchCollection('rules', function() {
+        $timeout(bindRulesDragDrop, 0);
+    });
+
     $scope.openModifyRuleModal = function(rule) {
         if (!rule) return;
         $scope.modifyRuleData = {

--- a/firewall/static/firewall/firewall.js
+++ b/firewall/static/firewall/firewall.js
@@ -18,6 +18,44 @@ function getCookie(name) {
     return cookieValue;
 }
 
+/**
+ * Confirm destructive firewall actions.
+ * Prefers PNotify confirm (Docker Manager pattern); falls back to window.confirm.
+ */
+function firewallConfirmDelete(title, text, onConfirm) {
+    var msg = text || 'Are you sure?';
+    if (typeof PNotify !== 'undefined') {
+        try {
+            (new PNotify({
+                title: title || 'Confirmation Needed',
+                text: msg,
+                icon: 'fa fa-question-circle',
+                hide: false,
+                confirm: {
+                    confirm: true
+                },
+                buttons: {
+                    closer: false,
+                    sticker: false
+                },
+                history: {
+                    history: false
+                }
+            })).get().on('pnotify.confirm', function () {
+                if (typeof onConfirm === 'function') {
+                    onConfirm();
+                }
+            });
+            return;
+        } catch (e) {
+            /* fall through to window.confirm */
+        }
+    }
+    if (window.confirm(msg) && typeof onConfirm === 'function') {
+        onConfirm();
+    }
+}
+
 /* Java script code to ADD Firewall Rules */
 
 app.controller('firewallController', function ($scope, $http, $timeout) {
@@ -376,30 +414,36 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
 
     $scope.removeTrustedSSHWhitelist = function(ip) {
         if (!ip) return;
-        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
-        $http.post('/base/sshSecurityWhitelistRemove', { ip: ip }, config).then(
-            function(response) {
-                var res = response.data;
-                if (typeof res === 'string') {
-                    try { res = JSON.parse(res); } catch (e) { res = {}; }
-                }
-                if (res && res.status === 1) {
-                    populateTrustedSSHWhitelist();
-                    if (typeof PNotify !== 'undefined') {
-                        new PNotify({ title: 'Trusted IPs', text: 'IP removed', type: 'success', delay: 4000 });
+        firewallConfirmDelete(
+            'Remove Trusted IP',
+            'Are you sure you want to remove trusted SSH IP "' + ip + '" from the whitelist?',
+            function () {
+                var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
+                $http.post('/base/sshSecurityWhitelistRemove', { ip: ip }, config).then(
+                    function(response) {
+                        var res = response.data;
+                        if (typeof res === 'string') {
+                            try { res = JSON.parse(res); } catch (e) { res = {}; }
+                        }
+                        if (res && res.status === 1) {
+                            populateTrustedSSHWhitelist();
+                            if (typeof PNotify !== 'undefined') {
+                                new PNotify({ title: 'Trusted IPs', text: 'IP removed', type: 'success', delay: 4000 });
+                            }
+                        } else {
+                            var errRm = (res && res.error) ? res.error : 'Failed to remove';
+                            if (typeof PNotify !== 'undefined') {
+                                new PNotify({ title: 'Trusted IPs', text: errRm, type: 'error', delay: 6000 });
+                            }
+                        }
+                    },
+                    function(err) {
+                        var em2 = (err.data && err.data.error) ? err.data.error : 'Request failed';
+                        if (typeof PNotify !== 'undefined') {
+                            new PNotify({ title: 'Trusted IPs', text: em2, type: 'error', delay: 6000 });
+                        }
                     }
-                } else {
-                    var errRm = (res && res.error) ? res.error : 'Failed to remove';
-                    if (typeof PNotify !== 'undefined') {
-                        new PNotify({ title: 'Trusted IPs', text: errRm, type: 'error', delay: 6000 });
-                    }
-                }
-            },
-            function(err) {
-                var em2 = (err.data && err.data.error) ? err.data.error : 'Request failed';
-                if (typeof PNotify !== 'undefined') {
-                    new PNotify({ title: 'Trusted IPs', text: em2, type: 'error', delay: 6000 });
-                }
+                );
             }
         );
     };
@@ -963,74 +1007,81 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         });
     };
 
-    $scope.deleteRule = function (id, proto, port, ruleIP) {
+    $scope.deleteRule = function (id, proto, port, ruleIP, ruleName) {
+        var nameLabel = (ruleName && String(ruleName).trim()) ? String(ruleName).trim() : ('#' + id);
+        var detail = nameLabel + ' (' + (proto || '') + '/' + (port || '') + ', ' + (ruleIP || '') + ')';
+        firewallConfirmDelete(
+            'Delete Firewall Rule',
+            'Are you sure you want to delete firewall rule "' + detail + '"? This cannot be undone.',
+            function () {
+                $scope.rulesLoading = true;
 
-        $scope.rulesLoading = true;
+                url = "/firewall/deleteRule";
 
-        url = "/firewall/deleteRule";
+                var data = {
+                    id: id,
+                    proto: proto,
+                    port: port,
+                    ruleIP: ruleIP
+                };
 
-        var data = {
-            id: id,
-            proto: proto,
-            port: port,
-            ruleIP: ruleIP
-        };
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+
+                $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+                function ListInitialDatas(response) {
+
+
+                    if (response.data.delete_status === 1) {
+
+
+                        populateCurrentRecords();
+                        $scope.actionFailed = true;
+                        $scope.actionSuccess = true;
+
+                        $scope.canNotAddRule = true;
+                        $scope.ruleAdded = true;
+                        $scope.couldNotConnect = true;
+
+
+                    }
+                    else {
+
+                        $scope.rulesLoading = false;
+                        $scope.actionFailed = true;
+                        $scope.actionSuccess = true;
+
+                        $scope.canNotAddRule = false;
+                        $scope.ruleAdded = true;
+                        $scope.couldNotConnect = true;
+
+                        $scope.errorMessage = response.data.error_message;
+
+
+                    }
+
+                }
+
+                function cantLoadInitialDatas(response) {
+
+                    $scope.rulesLoading = false;
+                    $scope.actionFailed = true;
+                    $scope.actionSuccess = true;
+
+                    $scope.canNotAddRule = true;
+                    $scope.ruleAdded = true;
+                    $scope.couldNotConnect = false;
+
+
+                }
             }
-        };
-
-
-        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
-
-
-        function ListInitialDatas(response) {
-
-
-            if (response.data.delete_status === 1) {
-
-
-                populateCurrentRecords();
-                $scope.actionFailed = true;
-                $scope.actionSuccess = true;
-
-                $scope.canNotAddRule = true;
-                $scope.ruleAdded = true;
-                $scope.couldNotConnect = true;
-
-
-            }
-            else {
-
-                $scope.rulesLoading = false;
-                $scope.actionFailed = true;
-                $scope.actionSuccess = true;
-
-                $scope.canNotAddRule = false;
-                $scope.ruleAdded = true;
-                $scope.couldNotConnect = true;
-
-                $scope.errorMessage = response.data.error_message;
-
-
-            }
-
-        }
-
-        function cantLoadInitialDatas(response) {
-
-            $scope.rulesLoading = false;
-            $scope.actionFailed = true;
-            $scope.actionSuccess = true;
-
-            $scope.canNotAddRule = true;
-            $scope.ruleAdded = true;
-            $scope.couldNotConnect = false;
-
-
-        }
+        );
 
 
     };
@@ -1380,71 +1431,77 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
     };
 
     $scope.removeBannedIP = function(id, ip) {
-        if (!confirm('Are you sure you want to unban IP address ' + ip + '?')) {
-            return;
-        }
+        var ipLabel = ip || ('#' + id);
+        firewallConfirmDelete(
+            'Unban IP Address',
+            'Are you sure you want to unban IP address "' + ipLabel + '"?',
+            function () {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
 
-        $scope.bannedIPsLoading = true;
-        $scope.bannedIPActionFailed = true;
-        $scope.bannedIPActionSuccess = true;
-        $scope.bannedIPCouldNotConnect = true;
+                var data = { id: id };
 
-        var data = { id: id };
+                var url = "/firewall/removeBannedIP";
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var url = "/firewall/removeBannedIP";
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                $http.post(url, data, config).then(function(response) {
+                    $scope.bannedIPsLoading = false;
+                    if (response.data.status === 1) {
+                        $scope.bannedIPActionSuccess = false;
+                        populateBannedIPs(); // Refresh the list
+                    } else {
+                        $scope.bannedIPActionFailed = false;
+                        $scope.bannedIPErrorMessage = response.data.error_message;
+                    }
+                }, function(error) {
+                    $scope.bannedIPsLoading = false;
+                    $scope.bannedIPCouldNotConnect = false;
+                });
             }
-        };
-
-        $http.post(url, data, config).then(function(response) {
-            $scope.bannedIPsLoading = false;
-            if (response.data.status === 1) {
-                $scope.bannedIPActionSuccess = false;
-                populateBannedIPs(); // Refresh the list
-            } else {
-                $scope.bannedIPActionFailed = false;
-                $scope.bannedIPErrorMessage = response.data.error_message;
-            }
-        }, function(error) {
-            $scope.bannedIPsLoading = false;
-            $scope.bannedIPCouldNotConnect = false;
-        });
+        );
     };
 
     $scope.deleteBannedIP = function(id, ip) {
-        if (!confirm('Are you sure you want to permanently delete the record for IP address ' + ip + '? This action cannot be undone.')) {
-            return;
-        }
+        var ipLabel = ip || ('#' + id);
+        firewallConfirmDelete(
+            'Delete Banned IP Record',
+            'Are you sure you want to permanently delete the record for IP address "' + ipLabel + '"? This action cannot be undone.',
+            function () {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
 
-        $scope.bannedIPsLoading = true;
-        $scope.bannedIPActionFailed = true;
-        $scope.bannedIPActionSuccess = true;
-        $scope.bannedIPCouldNotConnect = true;
+                var data = { id: id };
 
-        var data = { id: id };
+                var url = "/firewall/deleteBannedIP";
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var url = "/firewall/deleteBannedIP";
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                $http.post(url, data, config).then(function(response) {
+                    $scope.bannedIPsLoading = false;
+                    if (response.data.status === 1) {
+                        $scope.bannedIPActionSuccess = false;
+                        populateBannedIPs(); // Refresh the list
+                    } else {
+                        $scope.bannedIPActionFailed = false;
+                        $scope.bannedIPErrorMessage = response.data.error_message;
+                    }
+                }, function(error) {
+                    $scope.bannedIPsLoading = false;
+                    $scope.bannedIPCouldNotConnect = false;
+                });
             }
-        };
-
-        $http.post(url, data, config).then(function(response) {
-            $scope.bannedIPsLoading = false;
-            if (response.data.status === 1) {
-                $scope.bannedIPActionSuccess = false;
-                populateBannedIPs(); // Refresh the list
-            } else {
-                $scope.bannedIPActionFailed = false;
-                $scope.bannedIPErrorMessage = response.data.error_message;
-            }
-        }, function(error) {
-            $scope.bannedIPsLoading = false;
-            $scope.bannedIPCouldNotConnect = false;
-        });
+        );
     };
 
     $scope.openModifyModal = function(bannedIP) {

--- a/firewall/static/firewall/firewall.js
+++ b/firewall/static/firewall/firewall.js
@@ -885,6 +885,9 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.ruleAdded = true;
                 $scope.couldNotConnect = true;
 
+                $scope.rulesDetails = false;
+                populateCurrentRecords();
+
 
             }
             else {
@@ -963,6 +966,8 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.rulesDetails = false;
 
                 firewallStatus();
+                /* Reload rules after Start so the table stays visible and populated. */
+                populateCurrentRecords();
 
 
             }
@@ -1044,6 +1049,7 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.rulesDetails = false;
 
                 firewallStatus();
+                populateCurrentRecords();
 
 
             }

--- a/firewall/templates/firewall/firewall.html
+++ b/firewall/templates/firewall/firewall.html
@@ -1536,7 +1536,7 @@
                                 {% trans "Modify" %}
                             </button>
                             <button type="button"
-                                    ng-click="deleteRule(rule.id, rule.proto, rule.port, rule.ipAddress)"
+                                    ng-click="$parent.deleteRule(rule.id, rule.proto, rule.port, rule.ipAddress, rule.name); $event.stopPropagation()"
                                     class="btn-delete"
                                     title="{% trans 'Delete Rule' %}">
                                 <i class="fas fa-times"></i>

--- a/firewall/templates/firewall/firewall.html
+++ b/firewall/templates/firewall/firewall.html
@@ -1274,6 +1274,10 @@
 
     <!-- Rules Panel (ng-show so panel is always in DOM; visibility toggled by tab) -->
     <div class="rules-panel" ng-show="activeTab === 'rules'">
+        <div ng-show="status === 'OFF'" class="alert alert-warning" style="margin: 1rem 1.5rem 0;">
+            <i class="fas fa-exclamation-triangle alert-icon"></i>
+            <span>{% trans "Firewall is stopped. Rules below are still stored and will apply when you start the firewall." %}</span>
+        </div>
         <div class="panel-header">
             <div class="panel-title">
                 <div class="panel-icon">
@@ -1346,8 +1350,8 @@
             </div>
         </div>
         
-        <!-- Add Rule Section -->
-        <div ng-hide="rulesDetails" class="add-rule-section">
+        <!-- Add Rule Section (always visible on Rules tab; do not gate on firewall ON/OFF) -->
+        <div class="add-rule-section">
             <form class="rule-form">
                 <div class="form-group">
                     <label class="form-label">{% trans "Rule Name" %}</label>
@@ -1393,8 +1397,8 @@
             </form>
         </div>
         
-        <!-- Rules Table -->
-        <div ng-hide="rulesDetails" class="rules-table-section">
+        <!-- Rules Table (always visible on Rules tab; do not gate on firewall ON/OFF) -->
+        <div class="rules-table-section">
             <div class="table-responsive">
                 <table class="rules-table" ng-if="rules && rules.length > 0">
                 <thead>

--- a/firewall/templates/firewall/firewall.html
+++ b/firewall/templates/firewall/firewall.html
@@ -148,7 +148,6 @@
         color: var(--badge-error-text, #991b1b);
     }
 
-
     /* Firewall service status (JS sets status to ON/OFF). Distinct from banned-IP .status-active (red). */
     .status-badge.fw-status-on {
         background: var(--badge-success-bg, #d1fae5);
@@ -159,7 +158,6 @@
         background: var(--badge-error-bg, #fee2e2);
         color: var(--badge-error-text, #991b1b);
     }
-
 
     .status-content {
         padding: 2rem;
@@ -438,6 +436,72 @@
     .rule-id {
         font-weight: 600;
         color: var(--text-muted, #64748b);
+    }
+
+    .rules-table tbody tr.rule-row-draggable {
+        cursor: grab;
+    }
+
+    .rules-table tbody tr.rule-row-dragging {
+        opacity: 0.55;
+        background: var(--bg-hover, #f8f9ff);
+    }
+
+    .rule-drag-handle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        margin-right: 0.35rem;
+        color: var(--text-muted, #64748b);
+        border-radius: 4px;
+        cursor: grab;
+        user-select: none;
+    }
+
+    .rule-drag-handle:active {
+        cursor: grabbing;
+    }
+
+    .rule-order-controls {
+        display: inline-flex;
+        flex-direction: column;
+        gap: 2px;
+        margin-left: 0.25rem;
+        vertical-align: middle;
+    }
+
+    .btn-rule-order {
+        background: var(--bg-code, #f3f4f6);
+        color: var(--text-primary, #334155);
+        border: 1px solid var(--border-light, #e2e8f0);
+        width: 26px;
+        height: 22px;
+        border-radius: 4px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        padding: 0;
+        font-size: 0.65rem;
+        transition: all 0.15s ease;
+    }
+
+    .btn-rule-order:hover:not(:disabled) {
+        background: var(--accent-color, #5b5fcf);
+        color: var(--bg-secondary, #fff);
+        border-color: var(--accent-color, #5b5fcf);
+    }
+
+    .btn-rule-order:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+    }
+
+    .rule-id-cell {
+        white-space: nowrap;
+        min-width: 5.5rem;
     }
 
     .rule-name {
@@ -1424,9 +1488,32 @@
                         <th>{% trans "Action" %}</th>
                     </tr>
                 </thead>
-                <tbody>
-                    <tr ng-repeat="rule in rules track by $index">
-                        <td class="rule-id">#{$ rule.id $}</td>
+                <tbody id="firewall-rules-tbody">
+                    <tr ng-repeat="rule in rules track by rule.id"
+                        class="rule-row-draggable"
+                        draggable="true"
+                        data-rule-id="{$ rule.id $}"
+                        data-rule-index="{$ $index $}">
+                        <td class="rule-id rule-id-cell">
+                            <span class="rule-drag-handle" title="{% trans 'Drag to reorder' %}">
+                                <i class="fas fa-grip-vertical"></i>
+                            </span>
+                            <span>#{$ rule.displayId || (rulesRangeStart() + $index) $}</span>
+                            <span class="rule-order-controls">
+                                <button type="button" class="btn-rule-order"
+                                        ng-click="$parent.moveRuleUp(rule); $event.stopPropagation()"
+                                        ng-disabled="!$parent.canMoveRuleUp($index)"
+                                        title="{% trans 'Move up' %}">
+                                    <i class="fas fa-chevron-up"></i>
+                                </button>
+                                <button type="button" class="btn-rule-order"
+                                        ng-click="$parent.moveRuleDown(rule); $event.stopPropagation()"
+                                        ng-disabled="!$parent.canMoveRuleDown($index)"
+                                        title="{% trans 'Move down' %}">
+                                    <i class="fas fa-chevron-down"></i>
+                                </button>
+                            </span>
+                        </td>
                         <td class="rule-name">{$ rule.name $}</td>
                         <td>
                             <span class="protocol-badge" 

--- a/firewall/templates/firewall/firewall.html
+++ b/firewall/templates/firewall/firewall.html
@@ -5,9 +5,11 @@
 {% block header_scripts %}
 <style>
     .modern-container {
-        max-width: 1400px;
+        max-width: var(--cp-content-max, min(1680px, 100%));
         margin: 0 auto;
-        padding: 2rem;
+        padding: var(--cp-pad-main-y, 1.5rem) var(--cp-pad-main-x, 1.25rem);
+        width: 100%;
+        box-sizing: border-box;
     }
 
     [ng-cloak], .ng-cloak {
@@ -16,8 +18,8 @@
     
     .page-header {
         text-align: center;
-        margin-bottom: 3rem;
-        padding: 3rem 0;
+        margin-bottom: clamp(1.25rem, 2.5vw, 2rem);
+        padding: clamp(1.25rem, 3vw, 2.25rem) 1rem;
         background: linear-gradient(135deg, var(--firewall-gradient-start, #ef4444) 0%, var(--firewall-gradient-end, #dc2626) 100%);
         border-radius: 20px;
         animation: fadeInDown 0.5s ease-out;
@@ -70,9 +72,9 @@
     }
 
     .page-title {
-        font-size: 2.5rem;
+        font-size: clamp(1.65rem, 1.2vw + 1.25rem, 2.35rem);
         font-weight: 700;
-        margin-bottom: 1rem;
+        margin-bottom: 0.65rem;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -160,7 +162,7 @@
     }
 
     .status-content {
-        padding: 2rem;
+        padding: clamp(1rem, 2vw, 1.5rem);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -169,17 +171,17 @@
     }
 
     .control-btn {
-        padding: 0.75rem 1.5rem;
+        padding: 0.8rem 1.55rem;
         border-radius: 10px;
         font-weight: 500;
-        font-size: 0.875rem;
+        font-size: var(--cp-font-sm, 0.9375rem);
         cursor: pointer;
         transition: all 0.3s ease;
         border: none;
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        min-width: 120px;
+        min-width: 7.5rem;
         justify-content: center;
     }
 
@@ -306,16 +308,17 @@
     .form-label {
         font-weight: 500;
         color: var(--text-secondary, #475569);
-        font-size: 0.75rem;
+        font-size: var(--cp-font-sm, 0.875rem);
         text-transform: uppercase;
         letter-spacing: 0.05em;
     }
 
     .form-control {
-        padding: 0.75rem 1rem;
+        padding: 0.8rem 1rem;
         border: 1px solid var(--border-color, #e8e9ff);
         border-radius: 8px;
-        font-size: 0.875rem;
+        font-size: var(--cp-font-md, 1rem);
+        min-height: 2.65rem;
         transition: all 0.3s ease;
         background: var(--bg-primary, #fff);
         color: var(--text-primary, #1e293b);
@@ -348,10 +351,10 @@
     .btn-add {
         background: var(--firewall-accent, #ef4444);
         color: var(--text-light, white);
-        padding: 0.75rem 1.5rem;
+        padding: 0.8rem 1.5rem;
         border-radius: 8px;
         font-weight: 500;
-        font-size: 0.875rem;
+        font-size: var(--cp-font-sm, 0.9375rem);
         cursor: pointer;
         transition: all 0.3s ease;
         border: none;
@@ -359,6 +362,7 @@
         align-items: center;
         gap: 0.5rem;
         align-self: flex-end;
+        min-height: 2.65rem;
     }
 
     .btn-add:hover {
@@ -369,7 +373,9 @@
 
     /* Rules Table */
     .rules-table-section {
-        padding: 2rem;
+        padding: clamp(1rem, 2vw, 1.75rem);
+        display: block;
+        visibility: visible;
     }
 
     .rules-table {
@@ -395,7 +401,7 @@
         text-align: left;
         font-weight: 600;
         color: var(--text-secondary, #475569);
-        font-size: 0.75rem;
+        font-size: var(--cp-font-xs, 0.8125rem);
         text-transform: uppercase;
         letter-spacing: 0.05em;
         border-bottom: 1px solid var(--border-color, #e8e9ff);
@@ -415,7 +421,7 @@
         padding: 1rem;
         border-bottom: 1px solid var(--border-light, #f1f5f9);
         color: var(--text-primary, #334155);
-        font-size: 0.875rem;
+        font-size: var(--cp-font-sm, 0.9375rem);
     }
 
     .rules-table tbody tr {
@@ -855,7 +861,7 @@
         border-radius: 8px;
         color: var(--text-secondary, #64748b);
         font-weight: 500;
-        font-size: 0.9rem;
+        font-size: var(--cp-font-sm, 0.95rem);
         cursor: pointer;
         pointer-events: auto;
         transition: all 0.2s ease;

--- a/firewall/templates/firewall/firewall.html
+++ b/firewall/templates/firewall/firewall.html
@@ -148,6 +148,19 @@
         color: var(--badge-error-text, #991b1b);
     }
 
+
+    /* Firewall service status (JS sets status to ON/OFF). Distinct from banned-IP .status-active (red). */
+    .status-badge.fw-status-on {
+        background: var(--badge-success-bg, #d1fae5);
+        color: var(--badge-success-text, #065f46);
+    }
+
+    .status-badge.fw-status-off {
+        background: var(--badge-error-bg, #fee2e2);
+        color: var(--badge-error-text, #991b1b);
+    }
+
+
     .status-content {
         padding: 2rem;
         display: flex;
@@ -1222,7 +1235,7 @@
                 <i class="fas fa-info-circle"></i>
                 {% trans "Firewall Status" %}
             </h3>
-            <div class="status-badge" ng-class="{'status-active': status == 'Active', 'status-inactive': status != 'Active'}">
+            <div class="status-badge" ng-class="{'fw-status-on': status == 'ON', 'fw-status-off': status != 'ON'}">
                 <i class="fas fa-circle" style="font-size: 0.5rem;"></i>
                 {$ status $}
             </div>

--- a/firewall/urls.py
+++ b/firewall/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('addRule', views.addRule, name='addRule'),
     path('modifyRule', views.modifyRule, name='modifyRule'),
     path('deleteRule', views.deleteRule, name='deleteRule'),
+    path('reorderRules', views.reorderRules, name='reorderRules'),
 
     path('reloadFirewall', views.reloadFirewall, name='reloadFirewall'),
     path('stopFirewall', views.stopFirewall, name='stopFirewall'),

--- a/firewall/views.py
+++ b/firewall/views.py
@@ -113,6 +113,22 @@ def deleteRule(request):
         return redirect(loadLoginPage)
 
 
+def reorderRules(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        try:
+            body = request.body
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            data = json.loads(body) if body and body.strip() else {}
+        except (json.JSONDecodeError, Exception):
+            data = {}
+        return fm.reorderRules(userID, data)
+    except KeyError:
+        return redirect(loadLoginPage)
+
+
 def reloadFirewall(request):
     try:
         userID = request.session['userID']

--- a/mailServer/templates/mailServer/createEmailAccount.html
+++ b/mailServer/templates/mailServer/createEmailAccount.html
@@ -317,7 +317,8 @@
         }
     </style>
 
-    <div id="cybermailBanner" style="display:none; margin-bottom:20px;">
+    {% if not cosmetic.HidePromotions %}
+<div id="cybermailBanner" style="display:none; margin-bottom:20px;">
       <div style="background:linear-gradient(135deg,#4f46e5 0%,#7c3aed 50%,#9333ea 100%);border-radius:10px;padding:20px 24px;display:flex;align-items:center;gap:18px;box-shadow:0 4px 15px rgba(79,70,229,0.3);">
         <div style="flex-shrink:0;font-size:32px;">&#9993;</div>
         <div style="flex:1;min-width:0;">
@@ -332,8 +333,8 @@
     (function(){if(!document.cookie.includes('cybermail_dismiss=1')){document.getElementById('cybermailBanner').style.display='';}})();
     function dismissCyberMailBanner(){document.getElementById('cybermailBanner').style.display='none';document.cookie='cybermail_dismiss=1; path=/; max-age='+7*86400;}
     </script>
-
-    <div class="modern-container" ng-controller="createEmailAccount">
+{% endif %}
+<div class="modern-container" ng-controller="createEmailAccount">
         <div class="page-header">
             <h1 class="page-title">
                 <i class="fas fa-envelope"></i>

--- a/mailServer/templates/mailServer/dkimManager.html
+++ b/mailServer/templates/mailServer/dkimManager.html
@@ -400,7 +400,8 @@
         }
     </style>
 
-    <div id="cybermailBanner" style="display:none; margin-bottom:20px;">
+    {% if not cosmetic.HidePromotions %}
+<div id="cybermailBanner" style="display:none; margin-bottom:20px;">
       <div style="background:linear-gradient(135deg,#4f46e5 0%,#7c3aed 50%,#9333ea 100%);border-radius:10px;padding:20px 24px;display:flex;align-items:center;gap:18px;box-shadow:0 4px 15px rgba(79,70,229,0.3);">
         <div style="flex-shrink:0;font-size:32px;">&#9993;</div>
         <div style="flex:1;min-width:0;">
@@ -415,8 +416,8 @@
     (function(){if(!document.cookie.includes('cybermail_dismiss=1')){document.getElementById('cybermailBanner').style.display='';}})();
     function dismissCyberMailBanner(){document.getElementById('cybermailBanner').style.display='none';document.cookie='cybermail_dismiss=1; path=/; max-age='+7*86400;}
     </script>
-
-    <div class="modern-container" ng-controller="dkimManager">
+{% endif %}
+<div class="modern-container" ng-controller="dkimManager">
         <div class="page-header">
             <h1 class="page-title">
                 <i class="fas fa-shield-alt"></i>

--- a/mailServer/templates/mailServer/index.html
+++ b/mailServer/templates/mailServer/index.html
@@ -7,7 +7,8 @@
     {% get_current_language as LANGUAGE_CODE %}
     <!-- Current language: {{ LANGUAGE_CODE }} -->
 
-    <div id="cybermailBanner" style="display:none; margin-bottom:20px;">
+    {% if not cosmetic.HidePromotions %}
+<div id="cybermailBanner" style="display:none; margin-bottom:20px;">
       <div style="background:linear-gradient(135deg,#4f46e5 0%,#7c3aed 50%,#9333ea 100%);border-radius:10px;padding:20px 24px;display:flex;align-items:center;gap:18px;box-shadow:0 4px 15px rgba(79,70,229,0.3);">
         <div style="flex-shrink:0;font-size:32px;">&#9993;</div>
         <div style="flex:1;min-width:0;">
@@ -22,8 +23,8 @@
     (function(){if(!document.cookie.includes('cybermail_dismiss=1')){document.getElementById('cybermailBanner').style.display='';}})();
     function dismissCyberMailBanner(){document.getElementById('cybermailBanner').style.display='none';document.cookie='cybermail_dismiss=1; path=/; max-age='+7*86400;}
     </script>
-
-    <div class="container">
+{% endif %}
+<div class="container">
         <div id="page-title">
             <h2>{% trans "Mail Functions" %}</h2>
             <p>{% trans "Manage email accounts on this page." %}</p>

--- a/managePHP/phpManager.py
+++ b/managePHP/phpManager.py
@@ -13,132 +13,62 @@ class PHPManager:
     @staticmethod
     def findPHPVersions():
         """
-        Comprehensive PHP version detection that checks multiple locations and methods
+        Detect installed LiteSpeed PHP versions via filesystem only.
+        Avoids `yum/dnf list available` (multi-second) on every page render.
         """
         try:
             finalPHPVersions = []
-            
-            # Method 1: Check /usr/local/lsws directory (LiteSpeed PHP)
-            try:
-                result = ProcessUtilities.outputExecutioner('ls -la /usr/local/lsws')
-                lsphp_lines = [line for line in result.split('\n') if 'lsphp' in line]
+            lsws_root = '/usr/local/lsws'
 
-                if os.path.exists(ProcessUtilities.debugPath):
-                    from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as logging
-                    logging.writeToFile(f'Found PHP lines in findPHPVersions: {lsphp_lines}')
-
-                # Parse lsphp directories
-                for line in lsphp_lines:
-                    try:
-                        parts = line.split()
-                        if len(parts) >= 9:
-                            for part in parts:
-                                if part.startswith('lsphp') and part != 'lsphp':
-                                    version_part = part[5:]  # Remove 'lsphp' prefix
-                                    if len(version_part) >= 2:
-                                        major = version_part[0]
-                                        minor = version_part[1:]
-                                        formatted_version = f'PHP {major}.{minor}'
-                                        
-                                        # Validate the PHP installation
-                                        phpString = PHPManager.getPHPString(formatted_version)
-                                        php_path = f"/usr/local/lsws/lsphp{phpString}/bin/php"
-                                        lsphp_path = f"/usr/local/lsws/lsphp{phpString}/bin/lsphp"
-                                        
-                                        if os.path.exists(php_path) or os.path.exists(lsphp_path):
-                                            if formatted_version not in finalPHPVersions:
-                                                finalPHPVersions.append(formatted_version)
-                    except (IndexError, ValueError):
-                        continue
-            except Exception as e:
-                if os.path.exists(ProcessUtilities.debugPath):
-                    from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as logging
-                    logging.writeToFile(f'Error checking /usr/local/lsws: {str(e)}')
-
-            # Method 2: Check system-wide PHP installations
-            try:
-                # Check for system PHP versions
-                system_php_versions = ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
-                for version in system_php_versions:
-                    formatted_version = f'PHP {version}'
+            def _add_from_dirname(name):
+                if not name or not name.startswith('lsphp') or name == 'lsphp':
+                    return
+                version_part = name[5:]
+                if len(version_part) < 2 or not version_part.isdigit():
+                    return
+                major = version_part[0]
+                minor = version_part[1:]
+                formatted_version = f'PHP {major}.{minor}'
+                php_path = f"{lsws_root}/{name}/bin/php"
+                lsphp_path = f"{lsws_root}/{name}/bin/lsphp"
+                if os.path.exists(php_path) or os.path.exists(lsphp_path):
                     if formatted_version not in finalPHPVersions:
-                        # Check if this version exists in system
-                        try:
-                            phpString = PHPManager.getPHPString(formatted_version)
-                            php_path = f"/usr/local/lsws/lsphp{phpString}/bin/php"
-                            lsphp_path = f"/usr/local/lsws/lsphp{phpString}/bin/lsphp"
-                            
-                            if os.path.exists(php_path) or os.path.exists(lsphp_path):
-                                finalPHPVersions.append(formatted_version)
-                        except:
-                            continue
-            except Exception as e:
-                if os.path.exists(ProcessUtilities.debugPath):
-                    from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as logging
-                    logging.writeToFile(f'Error checking system PHP: {str(e)}')
+                        finalPHPVersions.append(formatted_version)
 
-            # Method 3: Check package manager for available PHP versions
+            # Primary: scan /usr/local/lsws/lsphp* directories (no shell).
             try:
-                # Try to detect available PHP packages
-                if ProcessUtilities.decideDistro() in [ProcessUtilities.centos, ProcessUtilities.cent8]:
-                    # For CentOS/RHEL/AlmaLinux
-                    command = "yum list available | grep lsphp | grep -E 'lsphp[0-9]+' | head -20"
-                else:
-                    # For Ubuntu/Debian
-                    command = "apt list --installed | grep lsphp | grep -E 'lsphp[0-9]+' | head -20"
-                
-                result = ProcessUtilities.outputExecutioner(command)
-                if result and result.strip():
-                    for line in result.split('\n'):
-                        if 'lsphp' in line:
-                            # Extract version from package name
-                            import re
-                            match = re.search(r'lsphp(\d+)(\d+)', line)
-                            if match:
-                                major = match.group(1)
-                                minor = match.group(2)
-                                formatted_version = f'PHP {major}.{minor}'
-                                
-                                if formatted_version not in finalPHPVersions:
-                                    # Validate installation
-                                    try:
-                                        phpString = PHPManager.getPHPString(formatted_version)
-                                        php_path = f"/usr/local/lsws/lsphp{phpString}/bin/php"
-                                        lsphp_path = f"/usr/local/lsws/lsphp{phpString}/bin/lsphp"
-                                        
-                                        if os.path.exists(php_path) or os.path.exists(lsphp_path):
-                                            finalPHPVersions.append(formatted_version)
-                                    except:
-                                        continue
+                if os.path.isdir(lsws_root):
+                    for entry in os.listdir(lsws_root):
+                        full = os.path.join(lsws_root, entry)
+                        if os.path.isdir(full):
+                            _add_from_dirname(entry)
             except Exception as e:
                 if os.path.exists(ProcessUtilities.debugPath):
                     from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as logging
-                    logging.writeToFile(f'Error checking package manager: {str(e)}')
+                    logging.writeToFile(f'Error scanning /usr/local/lsws: {str(e)}')
 
-            # Method 4: Fallback to checking common PHP versions
+            # Fallback probe for common versions if scan returned nothing.
             if not finalPHPVersions:
-                fallback_versions = ['PHP 7.4', 'PHP 8.0', 'PHP 8.1', 'PHP 8.2', 'PHP 8.3', 'PHP 8.4', 'PHP 8.5', 'PHP 8.6']
-                for version in fallback_versions:
+                for version in ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']:
+                    formatted_version = f'PHP {version}'
                     try:
-                        phpString = PHPManager.getPHPString(version)
-                        php_path = f"/usr/local/lsws/lsphp{phpString}/bin/php"
-                        lsphp_path = f"/usr/local/lsws/lsphp{phpString}/bin/lsphp"
+                        phpString = PHPManager.getPHPString(formatted_version)
+                        php_path = f"{lsws_root}/lsphp{phpString}/bin/php"
+                        lsphp_path = f"{lsws_root}/lsphp{phpString}/bin/lsphp"
                         if os.path.exists(php_path) or os.path.exists(lsphp_path):
-                            finalPHPVersions.append(version)
-                    except:
+                            finalPHPVersions.append(formatted_version)
+                    except Exception:
                         continue
 
-            # Sort versions (newest first)
             def version_sort_key(version):
                 try:
-                    # Extract version number for sorting
                     version_num = version.replace('PHP ', '').split('.')
                     major = int(version_num[0])
                     minor = int(version_num[1]) if len(version_num) > 1 else 0
                     return (major, minor)
-                except:
+                except Exception:
                     return (0, 0)
-            
+
             finalPHPVersions.sort(key=version_sort_key, reverse=True)
 
             if os.path.exists(ProcessUtilities.debugPath):

--- a/managePHP/templates/managePHP/editPHPConfig.html
+++ b/managePHP/templates/managePHP/editPHPConfig.html
@@ -1,4 +1,6 @@
 {% extends "baseTemplate/index.html" %}
+{% load static %}
+{% block module_scripts %}<script defer src="{% static 'managePHP/managePHP.js' %}?v={{ CP_VERSION }}"></script>{% endblock %}
 {% load i18n %}
 {% block title %}{% trans "Edit PHP Configurations - CyberPanel" %}{% endblock %}
 

--- a/managePHP/views.py
+++ b/managePHP/views.py
@@ -11,6 +11,7 @@ from loginSystem.views import loadLoginPage
 from .models import PHP, installedPackages, ApachePHP, installedPackagesApache
 from django.http import HttpResponse
 import json
+import time
 from plogical.phpUtilities import phpUtilities
 import os
 from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as logging
@@ -1429,72 +1430,89 @@ def getExtensionsInformation(request):
                     if os.path.exists(ProcessUtilities.debugPath):
                         logging.writeToFile(f'PHP Version apache {phpVers}')
 
-                # php = PHP.objects.get(phpVers=phpVers)
+                # Short-lived cache: package metadata listing is expensive on RHEL/Alma.
+                cache_dir = '/usr/local/CyberCP/tmp'
+                try:
+                    os.makedirs(cache_dir, mode=0o700, exist_ok=True)
+                except Exception:
+                    cache_dir = '/tmp'
+                cache_file = os.path.join(cache_dir, f'php_ext_list_{phpVers}.json')
+                cache_ttl = 300
+                try:
+                    if os.path.isfile(cache_file) and (time.time() - os.path.getmtime(cache_file)) < cache_ttl:
+                        with open(cache_file, 'r', encoding='utf-8') as cf:
+                            cached = cf.read()
+                        if cached:
+                            return HttpResponse(cached)
+                except Exception:
+                    pass
 
-                if os.path.exists('/etc/lsb-release'):
-                    command = f'apt list | grep {phpVers}'
-                else:
-                    command = 'yum list installed'
-                    resultInstalled = ProcessUtilities.outputExecutioner(command)
-
-                    command = f'yum list | grep ^{phpVers} | xargs -n3 | column -t'
-
-                result = ProcessUtilities.outputExecutioner(command).split('\n')
-
-                #records = php.installedpackages_set.all()
-
-                json_data = "["
-                checker = 0
-                counter = 1
-
-                for items in result:
-                    if os.path.exists('/etc/lsb-release'):
+                is_deb = os.path.exists('/etc/lsb-release')
+                rows = []
+                if is_deb:
+                    command = f'apt list 2>/dev/null | grep {shlex.quote(phpVers)}'
+                    result = ProcessUtilities.outputExecutioner(command).split('\n')
+                    for items in result:
                         if items.find(phpVers) > -1:
-                            if items.find('installed') == -1:
-                                status = "Not-Installed"
-                            else:
-                                status = "Installed"
+                            status = "Not-Installed" if items.find('installed') == -1 else "Installed"
+                            rows.append({
+                                'phpVers': phpVers,
+                                'extensionName': items.split('/')[0],
+                                'description': items,
+                                'status': status
+                            })
+                else:
+                    # Prefer rpm + dnf repoquery (seconds faster than `yum list` full metadata).
+                    installed_raw = ProcessUtilities.outputExecutioner(
+                        f"rpm -qa --qf '%{{NAME}}\\n' '{phpVers}*' 2>/dev/null"
+                    ) or ''
+                    installed_set = set([x.strip() for x in installed_raw.split('\n') if x.strip()])
+                    available_raw = ProcessUtilities.outputExecutioner(
+                        f"dnf -C repoquery --available --qf '%{{name}} %{{version}}-%{{release}}' '{phpVers}*' 2>/dev/null"
+                    )
+                    if not available_raw or 'No matching' in available_raw:
+                        available_raw = ProcessUtilities.outputExecutioner(
+                            f"yum -C list available '{phpVers}*' 2>/dev/null | grep '^{phpVers}'"
+                        ) or ''
+                    seen = set()
+                    for items in (available_raw or '').split('\n'):
+                        items = items.strip()
+                        if not items:
+                            continue
+                        extesnion = items.split()[0].split('.')[0] if items.split() else ''
+                        if not extesnion or phpVers not in extesnion or extesnion in seen:
+                            continue
+                        seen.add(extesnion)
+                        status = "Installed" if extesnion in installed_set else "Not-Installed"
+                        rows.append({
+                            'phpVers': phpVers,
+                            'extensionName': extesnion,
+                            'description': items,
+                            'status': status
+                        })
+                    # Include installed packages missing from available listing.
+                    for extesnion in sorted(installed_set):
+                        if extesnion in seen:
+                            continue
+                        rows.append({
+                            'phpVers': phpVers,
+                            'extensionName': extesnion,
+                            'description': extesnion,
+                            'status': 'Installed'
+                        })
 
-                            dic = {'id': counter,
-                                   'phpVers': phpVers,
-                                   'extensionName': items.split('/')[0],
-                                   'description': items,
-                                   'status': status
-                                   }
-
-                            if checker == 0:
-                                json_data = json_data + json.dumps(dic)
-                                checker = 1
-                            else:
-                                json_data = json_data + ',' + json.dumps(dic)
-                            counter += 1
-                    else:
-                        ResultExt = items.split(' ')
-                        extesnion = ResultExt[0]
-
-                        if extesnion.find(phpVers) > -1:
-                            if resultInstalled.find(extesnion) == -1:
-                                status = "Not-Installed"
-                            else:
-                                status = "Installed"
-
-                            dic = {'id': counter,
-                                   'phpVers': phpVers,
-                                   'extensionName': extesnion,
-                                   'description': items,
-                                   'status': status
-                                   }
-
-
-                            if checker == 0:
-                                json_data = json_data + json.dumps(dic)
-                                checker = 1
-                            else:
-                                json_data = json_data + ',' + json.dumps(dic)
-                            counter += 1
-
-                json_data = json_data + ']'
+                json_rows = []
+                for idx, dic in enumerate(rows, start=1):
+                    dic = dict(dic)
+                    dic['id'] = idx
+                    json_rows.append(dic)
+                json_data = json.dumps(json_rows)
                 final_json = json.dumps({'fetchStatus': 1, 'error_message': "None", "data": json_data})
+                try:
+                    with open(cache_file, 'w', encoding='utf-8') as cf:
+                        cf.write(final_json)
+                except Exception:
+                    pass
                 return HttpResponse(final_json)
 
         except BaseException as msg:
@@ -1531,6 +1549,19 @@ def submitExtensionRequest(request):
                     execPath = execPath + " unInstallPHPExtension --extension " + extensionName
 
                 ProcessUtilities.popenExecutioner(execPath)
+
+                # Bust extension list caches after install/uninstall requests.
+                try:
+                    cache_dir = '/usr/local/CyberCP/tmp'
+                    if os.path.isdir(cache_dir):
+                        for name in os.listdir(cache_dir):
+                            if name.startswith('php_ext_list_') and name.endswith('.json'):
+                                try:
+                                    os.remove(os.path.join(cache_dir, name))
+                                except Exception:
+                                    pass
+                except Exception:
+                    pass
 
                 final_json = json.dumps({'extensionRequestStatus': 1, 'error_message': "None"})
                 return HttpResponse(final_json)

--- a/manageServices/static/manageServices/manageServices.js
+++ b/manageServices/static/manageServices/manageServices.js
@@ -12,21 +12,21 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
     $scope.changesApplied = true;
     $scope.slaveIPs = true;
     $scope.masterServerHD = true;
+    $scope.pdnsEnabled = false;
+    if (!$scope.dnsMode) {
+        $scope.dnsMode = 'Default';
+    }
 
-    var pdnsStatus = false;
-
-
-    $('#pdnsStatus').change(function () {
-        pdnsStatus = $(this).prop('checked');
-    });
+    $scope.pdnsToggleChanged = function () {
+        // ng-model already synced; keep for future hooks
+    };
 
     fetchPDNSStatus('powerdns');
 
     function fetchPDNSStatus(service) {
 
         $scope.pdnsLoading = false;
-
-        $('#pdnsStatus').bootstrapToggle('off');
+        $scope.pdnsEnabled = false;
 
         url = "/manageservices/fetchStatus";
 
@@ -50,10 +50,11 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
 
             if (response.data.status === 1) {
 
-                if (response.data.installCheck === 1) {
-                    $('#pdnsStatus').bootstrapToggle('on');
+                $scope.pdnsEnabled = (response.data.installCheck === 1 || response.data.installCheck === '1' || response.data.installCheck === true);
+                if (response.data.dnsMode) {
+                    $scope.dnsMode = response.data.dnsMode;
                 }
-
+                $scope.modeChange();
                 $scope.slaveIPData = response.data.slaveIPData;
 
             } else {
@@ -88,7 +89,7 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
 
         if (service === 'powerdns') {
             var data = {
-                status: pdnsStatus,
+                status: !!$scope.pdnsEnabled,
                 service: service,
                 dnsMode: $scope.dnsMode,
                 slaveServerNS: $scope.slaveServerNS,
@@ -102,7 +103,7 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
             };
         } else {
             var data = {
-                status: pdnsStatus,
+                status: !!$scope.pdnsEnabled,
                 service: service
             };
         }

--- a/manageServices/templates/manageServices/managePowerDNS.html
+++ b/manageServices/templates/manageServices/managePowerDNS.html
@@ -146,12 +146,20 @@
         transition: all 0.3s ease;
         cursor: pointer;
     }
+
+    .form-select option {
+        color: var(--text-primary, #2f3640);
+        background: var(--bg-primary, white);
+    }
     
     .form-select:focus {
         outline: none;
         border-color: #5856d6;
         box-shadow: 0 0 0 3px rgba(88,86,214,0.1);
     }
+
+    .pdns-state-label.is-on { color: var(--success-color, #10b981); }
+    .pdns-state-label.is-off { color: var(--danger-color, #ef4444); }
     
     /* Toggle Switch */
     .toggle-switch {
@@ -422,10 +430,17 @@
                         <div class="status-label">{% trans "Service Status" %}</div>
                         <div class="status-toggle">
                             <label class="toggle-switch">
-                                <input type="checkbox" id="pdnsStatus">
+                                <input type="checkbox" id="pdnsStatus" ng-model="pdnsEnabled" ng-change="pdnsToggleChanged()">
                                 <span class="toggle-slider"></span>
                             </label>
+                            <span class="pdns-state-label" ng-class="{'is-on': pdnsEnabled, 'is-off': !pdnsEnabled}" style="font-weight: 700; min-width: 2.5rem;">
+                                <span ng-show="pdnsEnabled">{% trans "ON" %}</span>
+                                <span ng-hide="pdnsEnabled">{% trans "OFF" %}</span>
+                            </span>
                             <span style="font-weight: 600; color: var(--text-primary, #2f3640);">{% trans "Enable/Disable PowerDNS" %}</span>
+                        </div>
+                        <div class="help-text" style="margin-top: 8px;">
+                            {% trans "Current mode" %}: <strong ng-bind="dnsMode || 'Default'"></strong>
                         </div>
                     </div>
                 </div>
@@ -439,10 +454,10 @@
 
                     <div class="form-group">
                         <label class="form-label">{% trans "Select Function Mode" %}</label>
-                        <select ng-change="modeChange()" ng-model="dnsMode" class="form-select">
-                            <option>Default</option>
-                            <option>MASTER</option>
-                            <option>SLAVE</option>
+                        <select ng-change="modeChange()" ng-model="dnsMode" class="form-select" ng-init="dnsMode='{{ dnsMode|default:'Default'|escapejs }}'">
+                            <option value="Default">Default</option>
+                            <option value="MASTER">MASTER</option>
+                            <option value="SLAVE">SLAVE</option>
                         </select>
                         <div class="help-text">{% trans "Choose how PowerDNS should operate - Default, Master, or Slave mode" %}</div>
                     </div>
@@ -553,21 +568,5 @@
         {% endif %}
     </div>
 </div>
-
-<script>
-$(document).ready(function() {
-    // Initialize toggle switch
-    setTimeout(function() {
-        $('#pdnsStatus').bootstrapToggle({
-            on: 'Enabled',
-            off: 'Disabled',
-            onstyle: 'success',
-            offstyle: 'secondary',
-            size: 'normal'
-        });
-    }, 100);
-});
-</script>
-
 
 {% endblock %}

--- a/manageServices/views.py
+++ b/manageServices/views.py
@@ -47,6 +47,13 @@ def managePowerDNS(request):
         data['slaveServerNS'] = pdnsStatus.masterServer
         data['masterServerIP'] = pdnsStatus.masterIP
 
+    # UI shows Default/MASTER/SLAVE; DB may store NATIVE for default mode
+    if pdnsStatus.type in ('MASTER', 'SLAVE'):
+        data['dnsMode'] = pdnsStatus.type
+    else:
+        data['dnsMode'] = 'Default'
+    data['pdnsEnabled'] = 1 if int(pdnsStatus.serverStatus or 0) == 1 else 0
+
     proc = httpProc(request, 'manageServices/managePowerDNS.html',
                     data, 'admin')
     return proc.render()
@@ -85,10 +92,15 @@ def fetchStatus(request):
                     try:
                         pdns = PDNSStatus.objects.get(pk=1)
                         data_ret['installCheck'] = pdns.serverStatus
+                        if pdns.type in ('MASTER', 'SLAVE'):
+                            data_ret['dnsMode'] = pdns.type
+                        else:
+                            data_ret['dnsMode'] = 'Default'
                         #data_ret['slaveIPData'] = pdns.also_notify
                     except:
                         PDNSStatus(serverStatus=1).save()
                         data_ret['installCheck'] = 1
+                        data_ret['dnsMode'] = 'Default'
                         #data_ret['slaveIPData'] = ''
 
                     json_data = json.dumps(data_ret)

--- a/public/static/baseTemplate/css/cyberpanel-ui.css
+++ b/public/static/baseTemplate/css/cyberpanel-ui.css
@@ -1519,7 +1519,7 @@ textarea:focus-visible,
 }
 
 /* ============================================================
-   Sidebar quick-filter / jump-to search
+   Sidebar feature/site search (near server-info / uptime)
    ============================================================ */
 .sidebar-search {
     position: relative;
@@ -1527,21 +1527,31 @@ textarea:focus-visible,
     display: flex;
     align-items: center;
 }
+#sidebar .server-info .sidebar-search--server {
+    flex: 1 1 100%;
+    width: 100%;
+    margin: 8px 0 0;
+    order: 3;
+}
+#sidebar .server-info {
+    flex-wrap: wrap;
+}
 .sidebar-search > i {
     position: absolute;
     left: 12px;
     color: var(--text-secondary);
     font-size: 13px;
     pointer-events: none;
+    z-index: 1;
 }
 .sidebar-search input {
     width: 100%;
-    padding: 10px 32px 10px 32px;
+    padding: 9px 32px 9px 32px;
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    background: var(--bg-secondary);
+    background: var(--bg-primary, var(--bg-secondary));
     color: var(--text-primary);
-    font-size: 13px;
+    font-size: 12.5px;
     outline: none;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -1553,6 +1563,8 @@ textarea:focus-visible,
 #sidebar-search-clear {
     position: absolute;
     right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
     background: transparent;
     border: none;
     color: var(--text-secondary);
@@ -1560,13 +1572,62 @@ textarea:focus-visible,
     padding: 4px;
     border-radius: 5px;
     line-height: 1;
+    z-index: 2;
 }
 #sidebar-search-clear:hover { color: var(--danger-color); background: var(--bg-hover); }
 #sidebar-search-clear[hidden] { display: none; }
 
+.sidebar-search-results {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: calc(100% + 4px);
+    z-index: 40;
+    max-height: min(50vh, 320px);
+    overflow-y: auto;
+    background: var(--bg-secondary, #1e1e2e);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    box-shadow: 0 12px 28px rgba(0,0,0,0.35);
+    padding: 4px;
+}
+.sidebar-search-results[hidden] { display: none; }
+.sidebar-search-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    width: 100%;
+    text-align: left;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    padding: 8px 10px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+.sidebar-search-item:hover,
+.sidebar-search-item.active {
+    background: var(--bg-hover, rgba(88,86,214,0.18));
+}
+.sidebar-search-ic {
+    width: 22px;
+    flex: 0 0 22px;
+    color: var(--accent-color, #7c7cff);
+    margin-top: 2px;
+}
+.sidebar-search-label {
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.25;
+}
+.sidebar-search-sub {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
 .sidebar-search-empty {
-    margin: 6px 15px;
-    padding: 10px 12px;
+    margin-top: 6px;
+    padding: 8px 10px;
     font-size: 12px;
     color: var(--text-secondary);
     text-align: center;
@@ -1575,6 +1636,11 @@ textarea:focus-visible,
     border-radius: 8px;
 }
 .sidebar-search-empty[hidden] { display: none; }
+@media (max-width: 768px) {
+    .sidebar-search-results {
+        max-height: min(40vh, 260px);
+    }
+}
 
 /* ============================================================
    Breadcrumb / page context strip

--- a/public/static/baseTemplate/css/cyberpanel-ui.css
+++ b/public/static/baseTemplate/css/cyberpanel-ui.css
@@ -41,6 +41,26 @@
             --skeleton-base: #e9ebef;
             --skeleton-shine: #f4f5f7;
             --focus-ring: #5856d6;
+            /* Fluid UI scale (viewport-aware; no transform zoom) */
+            --cp-root-font: clamp(15px, 0.28vw + 14.1px, 17.5px);
+            --cp-sidebar-width: clamp(272px, 17vw, 300px);
+            --cp-content-max: min(1680px, 100%);
+            --cp-pad-main-x: clamp(1rem, 2.2vw, 2rem);
+            --cp-pad-main-y: clamp(1.25rem, 2vw, 2rem);
+            --cp-header-height: clamp(4.25rem, 5.5vw, 5rem);
+            --cp-font-xs: 0.75rem;
+            --cp-font-sm: 0.875rem;
+            --cp-font-md: 1rem;
+            --cp-font-lg: 1.125rem;
+            --cp-space-xs: 0.25rem;
+            --cp-space-sm: 0.5rem;
+            --cp-space-md: 1rem;
+            --cp-space-lg: 1.5rem;
+            --cp-space-xl: 2rem;
+        }
+
+        html {
+            font-size: var(--cp-root-font);
         }
         
         /* Dark Theme Colors */
@@ -92,6 +112,7 @@
         
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            font-size: var(--cp-font-md);
             background: var(--bg-primary);
             color: var(--text-primary);
             overflow-x: hidden;
@@ -111,14 +132,14 @@
         /* Header */
         #header {
             background: var(--bg-secondary);
-            height: 80px;
+            height: var(--cp-header-height);
             display: flex;
             align-items: center;
-            padding: 0 30px;
+            padding: 0 var(--cp-pad-main-x);
             box-shadow: 0 2px 12px var(--shadow-color);
             position: fixed;
             top: 0;
-            left: 260px;
+            left: var(--cp-sidebar-width);
             right: 0;
             z-index: 1000;
             transition: background-color 0.12s ease;
@@ -258,7 +279,7 @@
         
         /* Sidebar */
         #sidebar {
-            width: 260px;
+            width: var(--cp-sidebar-width);
             background: var(--bg-sidebar);
             height: 100vh;
             position: fixed;
@@ -595,8 +616,8 @@
         
         /* Main Content */
         #main-content {
-            margin-left: 260px;
-            padding: 110px 30px 30px;
+            margin-left: var(--cp-sidebar-width);
+            padding: calc(var(--cp-header-height) + 1.75rem) var(--cp-pad-main-x) var(--cp-pad-main-y);
             min-height: 100vh;
             background: var(--bg-primary);
             transition: background-color 0.3s ease;
@@ -605,8 +626,8 @@
         /* Notification Banner */
         .notification-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
             border-bottom: 1px solid #f59e0b;
@@ -689,8 +710,8 @@
         /* AI Scanner Security Banner */
         .ai-scanner-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a855f7 100%);
             border-bottom: 2px solid #4f46e5;
@@ -832,8 +853,8 @@
         /* .htaccess Feature Banner */
         .htaccess-feature-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #10b981 0%, #059669 50%, #047857 100%);
             border-bottom: 2px solid #065f46;
@@ -2123,9 +2144,9 @@ button[aria-busy="true"] { opacity: 0.75; cursor: progress; }
 :root { --accent-soft-bg: rgba(88,86,214,0.10); }
 [data-theme="dark"] { --accent-soft-bg: rgba(124,127,243,0.16); }
 
-/* Comfortable base typography */
+/* Comfortable base typography (tracks fluid html root) */
 body {
-    font-size: 14px;
+    font-size: var(--cp-font-md);
     line-height: 1.55;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -2177,7 +2198,7 @@ body {
     color: var(--text-secondary);
     margin: 16px 18px 6px;
     padding: 0;
-    font-size: 10.5px;
+    font-size: clamp(0.7rem, 0.15vw + 0.65rem, 0.78rem);
     letter-spacing: 0.7px;
     font-weight: 700;
     text-align: left;
@@ -2190,10 +2211,10 @@ body {
     background: transparent;
     box-shadow: none;
     margin: 1px 10px;
-    padding: 9px 12px;
+    padding: 0.65rem 0.85rem;
     border-radius: 8px;
-    gap: 11px;
-    font-size: 13.5px;
+    gap: 0.7rem;
+    font-size: clamp(0.9rem, 0.12vw + 0.86rem, 1rem);
     font-weight: 500;
     color: var(--text-secondary);
 }
@@ -2219,7 +2240,7 @@ body {
     height: 22px;
     border-radius: 6px;
 }
-#sidebar .menu-item i { font-size: 15px; color: var(--text-secondary); }
+#sidebar .menu-item i { font-size: 1.05rem; color: var(--text-secondary); }
 #sidebar .menu-item:hover i { color: var(--accent-color); }
 
 /* Keep the promo entry distinctive but a touch softer */
@@ -2259,7 +2280,7 @@ body {
 }
 
 /* Breadcrumb: quieter */
-.cp-breadcrumb { font-size: 12.5px; }
+.cp-breadcrumb { font-size: var(--cp-font-sm); }
 
 /* =================================================================
    v2.4.8 — Service promo banner (e.g. managed Email Delivery)
@@ -2454,4 +2475,92 @@ html[data-theme="light"] #sidebar .menu-item.active,
 html.cp-theme-light #sidebar .menu-item.active {
     background-color: var(--accent-soft-bg);
     color: var(--accent-color);
+}
+
+/* =================================================================
+   Fluid UI scale — readable desktop chrome, adaptive hubs
+   (rem + clamp; no page transform zoom)
+   ================================================================= */
+#main-content .modern-container,
+#main-content .page-container {
+    max-width: var(--cp-content-max);
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: var(--cp-pad-main-x);
+    padding-right: var(--cp-pad-main-x);
+    box-sizing: border-box;
+}
+
+#main-content .form-label,
+#main-content label.form-label {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content .form-control,
+#main-content select.form-control,
+#main-content textarea.form-control,
+#main-content .select-control {
+    font-size: var(--cp-font-md);
+    min-height: 2.65rem;
+}
+
+#main-content .btn,
+#main-content .control-btn,
+#main-content .btn-add,
+#main-content .tab-button {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content table th,
+#main-content .rules-table th {
+    font-size: var(--cp-font-xs);
+}
+
+#main-content table td,
+#main-content .rules-table td {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content .rules-table-section {
+    display: block;
+    visibility: visible;
+    overflow-x: auto;
+}
+
+#sidebar .server-info .info-line {
+    font-size: var(--cp-font-sm);
+}
+
+#sidebar .logo-text .brand {
+    font-size: var(--cp-font-lg);
+}
+
+#sidebar .logo-text .tagline {
+    font-size: var(--cp-font-xs);
+}
+
+.sidebar-search input,
+#sidebar .sidebar-search input {
+    font-size: var(--cp-font-sm);
+}
+
+@media (max-width: 768px) {
+    :root {
+        --cp-sidebar-width: 280px;
+        --cp-root-font: 15.5px;
+        --cp-pad-main-x: 0.9rem;
+    }
+
+    #main-content .modern-container,
+    #main-content .page-container {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
+@media (min-width: 1400px) {
+    :root {
+        --cp-content-max: min(1760px, 100%);
+    }
 }

--- a/public/static/baseTemplate/custom-js/system-status.js
+++ b/public/static/baseTemplate/custom-js/system-status.js
@@ -18,6 +18,15 @@ function getCookie(name) {
             }
         }
     }
+    // Fallback: CSRF seed form in base template (cookie may be missing briefly after login)
+    if (!cookieValue && name === 'csrftoken') {
+        try {
+            var el = document.querySelector('#cp-csrf-seed input[name="csrfmiddlewaretoken"], input[name="csrfmiddlewaretoken"]');
+            if (el && el.value) {
+                cookieValue = el.value;
+            }
+        } catch (e) {}
+    }
     return cookieValue;
 }
 

--- a/public/static/firewall/firewall.js
+++ b/public/static/firewall/firewall.js
@@ -2243,8 +2243,6 @@ app.controller('modSecRulesPack', function ($scope, $http, $timeout, $window) {
 
     var owaspInstalled = false;
     var comodoInstalled = false;
-    var counterOWASP = 0;
-    var counterComodo = 0;
     var updatingOWASPStatus = false;
     var updatingComodoStatus = false;
 
@@ -2253,46 +2251,34 @@ app.controller('modSecRulesPack', function ($scope, $http, $timeout, $window) {
 
         // Prevent triggering installation when status check updates the toggle
         if (updatingOWASPStatus) {
-            counterOWASP = counterOWASP + 1;  // Still increment counter
             return;
         }
 
         owaspInstalled = $(this).prop('checked');
         $scope.ruleFiles = true;
 
-        if (counterOWASP !== 0) {
-            if (owaspInstalled === true) {
-                installModSecRulesPack('installOWASP');
-            } else {
-                installModSecRulesPack('disableOWASP')
-            }
+        if (owaspInstalled === true) {
+            installModSecRulesPack('installOWASP');
+        } else {
+            installModSecRulesPack('disableOWASP');
         }
-
-        counterOWASP = counterOWASP + 1;
     });
 
     $('#comodoInstalled').change(function () {
 
         // Prevent triggering installation when status check updates the toggle
         if (updatingComodoStatus) {
-            counterComodo = counterComodo + 1;  // Still increment counter
             return;
         }
 
         $scope.ruleFiles = true;
         comodoInstalled = $(this).prop('checked');
 
-        if (counterComodo !== 0) {
-
-            if (comodoInstalled === true) {
-                installModSecRulesPack('installComodo');
-            } else {
-                installModSecRulesPack('disableComodo')
-            }
+        if (comodoInstalled === true) {
+            installModSecRulesPack('installComodo');
+        } else {
+            installModSecRulesPack('disableComodo');
         }
-
-        counterComodo = counterComodo + 1;
-
     });
 
 

--- a/public/static/firewall/firewall.js
+++ b/public/static/firewall/firewall.js
@@ -171,9 +171,14 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
 
     firewallStatus();
 
-    // Load both tabs on init; also load on tab change (watch) so content always shows
-    populateCurrentRecords();
-    populateBannedIPs();
+    // Load active tab data on init (avoid flipping UX by always prefetching banned).
+    if ($scope.activeTab === 'banned') {
+        populateBannedIPs();
+    } else if ($scope.activeTab === 'trusted') {
+        populateTrustedSSHWhitelist();
+    } else {
+        populateCurrentRecords();
+    }
 
     $scope.$watch('activeTab', function(newVal, oldVal) {
         if (newVal === oldVal || !newVal) return;
@@ -497,19 +502,24 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         };
     }
     
-    // Load banned IPs on page load - use $timeout for Angular compatibility
-    // Wrap in try-catch to ensure it executes even if there are other errors
+    // Prefetch banned IPs shortly after load only when that tab is active (avoids tab race noise).
     try {
         $timeout(function() {
             try {
-                console.log('=== Calling populateBannedIPs from $timeout on page load ===');
-                populateBannedIPs();
+                if ($scope.activeTab === 'banned') {
+                    console.log('=== Calling populateBannedIPs from $timeout on page load ===');
+                    populateBannedIPs();
+                } else if ($scope.activeTab === 'rules') {
+                    populateCurrentRecords();
+                } else if ($scope.activeTab === 'trusted') {
+                    populateTrustedSSHWhitelist();
+                }
             } catch(e) {
-                console.error('Error in populateBannedIPs from timeout:', e);
+                console.error('Error in firewall tab prefetch from timeout:', e);
             }
         }, 500);
     } catch(e) {
-        console.error('Error setting up timeout for populateBannedIPs:', e);
+        console.error('Error setting up timeout for firewall tab prefetch:', e);
     }
     
     $scope.addRule = function () {
@@ -1030,7 +1040,8 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.ruleAdded = true;
                 $scope.couldNotConnect = true;
 
-                $scope.rulesDetails = true;
+                /* Keep rules UI visible while firewall is stopped so operators can still edit stored rules. */
+                $scope.rulesDetails = false;
 
                 firewallStatus();
 
@@ -1093,19 +1104,17 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
             if (response.data.status == 1) {
 
                 if (response.data.firewallStatus == 1) {
-                    $scope.rulesDetails = false;
                     $scope.status = "ON";
                 }
                 else {
-                    $scope.rulesDetails = true;
                     $scope.status = "OFF";
                 }
             }
             else {
-
-                $scope.rulesDetails = true;
                 $scope.status = "OFF";
             }
+            /* Never hide the rules table/form when firewall is OFF (was rulesDetails=true). */
+            $scope.rulesDetails = false;
 
 
         }

--- a/public/static/firewall/firewall.js
+++ b/public/static/firewall/firewall.js
@@ -711,6 +711,197 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         populateCurrentRecords();
     };
 
+    function renumberDisplayedRuleIds() {
+        var start = $scope.rulesRangeStart() || 1;
+        ($scope.rules || []).forEach(function(rule, idx) {
+            rule.displayId = start + idx;
+            rule.sortOrder = rule.displayId;
+        });
+    }
+
+    function persistPageRuleOrder() {
+        var pageIds = ($scope.rules || []).map(function(r) { return r.id; });
+        if (!pageIds.length) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = {
+            page_ordered_ids: pageIds,
+            page: Math.max(1, parseInt($scope.rulesPage, 10) || 1),
+            page_size: Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10))
+        };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                renumberDisplayedRuleIds();
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                $scope.rulesLoading = false;
+            } else {
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not save rule order';
+                populateCurrentRecords();
+            }
+        }, function() {
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+            populateCurrentRecords();
+        });
+    }
+
+    $scope.canMoveRuleUp = function(index) {
+        var page = Math.max(1, parseInt($scope.rulesPage, 10) || 1);
+        return !(page === 1 && index === 0);
+    };
+
+    $scope.canMoveRuleDown = function(index) {
+        var page = Math.max(1, parseInt($scope.rulesPage, 10) || 1);
+        var size = Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10));
+        var total = $scope.rulesTotalCount || ($scope.rules ? $scope.rules.length : 0) || 0;
+        var globalIndex = (page - 1) * size + index;
+        return globalIndex < (total - 1);
+    };
+
+    $scope.moveRuleUp = function(rule) {
+        if (!rule || !rule.id) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = { id: rule.id, direction: 'up' };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not move rule';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    $scope.moveRuleDown = function(rule) {
+        if (!rule || !rule.id) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = { id: rule.id, direction: 'down' };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not move rule';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    var rulesDragFromIndex = null;
+
+    function bindRulesDragDrop() {
+        var tbody = document.getElementById('firewall-rules-tbody');
+        if (!tbody || tbody.getAttribute('data-dnd-bound') === '1') {
+            return;
+        }
+        tbody.setAttribute('data-dnd-bound', '1');
+
+        tbody.addEventListener('dragstart', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            // Allow drag from row/handle; block from action buttons/inputs
+            if (ev.target.closest && ev.target.closest('button, a, input, select, textarea')) {
+                ev.preventDefault();
+                return;
+            }
+            rulesDragFromIndex = parseInt(row.getAttribute('data-rule-index'), 10);
+            if (isNaN(rulesDragFromIndex)) {
+                rulesDragFromIndex = null;
+                return;
+            }
+            row.classList.add('rule-row-dragging');
+            try {
+                ev.dataTransfer.effectAllowed = 'move';
+                ev.dataTransfer.setData('text/plain', String(rulesDragFromIndex));
+            } catch (ignoreSet) {}
+        });
+
+        tbody.addEventListener('dragover', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            ev.preventDefault();
+            try {
+                ev.dataTransfer.dropEffect = 'move';
+            } catch (ignoreDrop) {}
+        });
+
+        tbody.addEventListener('drop', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            ev.preventDefault();
+            var toIndex = parseInt(row.getAttribute('data-rule-index'), 10);
+            var fromIndex = rulesDragFromIndex;
+            if (fromIndex === null || isNaN(toIndex) || fromIndex === toIndex) {
+                return;
+            }
+            $scope.$applyAsync(function() {
+                var list = $scope.rules || [];
+                if (fromIndex < 0 || fromIndex >= list.length || toIndex < 0 || toIndex >= list.length) {
+                    return;
+                }
+                var moved = list.splice(fromIndex, 1)[0];
+                list.splice(toIndex, 0, moved);
+                $scope.rules = list;
+                renumberDisplayedRuleIds();
+                persistPageRuleOrder();
+            });
+        });
+
+        tbody.addEventListener('dragend', function(ev) {
+            rulesDragFromIndex = null;
+            var dragging = tbody.querySelectorAll('.rule-row-dragging');
+            for (var i = 0; i < dragging.length; i++) {
+                dragging[i].classList.remove('rule-row-dragging');
+            }
+        });
+    }
+
+    // Bind after Angular paints the rules table (tbody is destroyed when rules empty)
+    $scope.$watchCollection('rules', function() {
+        $timeout(bindRulesDragDrop, 0);
+    });
+
     $scope.openModifyRuleModal = function(rule) {
         if (!rule) return;
         $scope.modifyRuleData = {

--- a/public/static/firewall/firewall.js
+++ b/public/static/firewall/firewall.js
@@ -18,6 +18,44 @@ function getCookie(name) {
     return cookieValue;
 }
 
+/**
+ * Confirm destructive firewall actions.
+ * Prefers PNotify confirm (Docker Manager pattern); falls back to window.confirm.
+ */
+function firewallConfirmDelete(title, text, onConfirm) {
+    var msg = text || 'Are you sure?';
+    if (typeof PNotify !== 'undefined') {
+        try {
+            (new PNotify({
+                title: title || 'Confirmation Needed',
+                text: msg,
+                icon: 'fa fa-question-circle',
+                hide: false,
+                confirm: {
+                    confirm: true
+                },
+                buttons: {
+                    closer: false,
+                    sticker: false
+                },
+                history: {
+                    history: false
+                }
+            })).get().on('pnotify.confirm', function () {
+                if (typeof onConfirm === 'function') {
+                    onConfirm();
+                }
+            });
+            return;
+        } catch (e) {
+            /* fall through to window.confirm */
+        }
+    }
+    if (window.confirm(msg) && typeof onConfirm === 'function') {
+        onConfirm();
+    }
+}
+
 /* Java script code to ADD Firewall Rules */
 
 app.controller('firewallController', function ($scope, $http, $timeout) {
@@ -376,30 +414,36 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
 
     $scope.removeTrustedSSHWhitelist = function(ip) {
         if (!ip) return;
-        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
-        $http.post('/base/sshSecurityWhitelistRemove', { ip: ip }, config).then(
-            function(response) {
-                var res = response.data;
-                if (typeof res === 'string') {
-                    try { res = JSON.parse(res); } catch (e) { res = {}; }
-                }
-                if (res && res.status === 1) {
-                    populateTrustedSSHWhitelist();
-                    if (typeof PNotify !== 'undefined') {
-                        new PNotify({ title: 'Trusted IPs', text: 'IP removed', type: 'success', delay: 4000 });
+        firewallConfirmDelete(
+            'Remove Trusted IP',
+            'Are you sure you want to remove trusted SSH IP "' + ip + '" from the whitelist?',
+            function () {
+                var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
+                $http.post('/base/sshSecurityWhitelistRemove', { ip: ip }, config).then(
+                    function(response) {
+                        var res = response.data;
+                        if (typeof res === 'string') {
+                            try { res = JSON.parse(res); } catch (e) { res = {}; }
+                        }
+                        if (res && res.status === 1) {
+                            populateTrustedSSHWhitelist();
+                            if (typeof PNotify !== 'undefined') {
+                                new PNotify({ title: 'Trusted IPs', text: 'IP removed', type: 'success', delay: 4000 });
+                            }
+                        } else {
+                            var errRm = (res && res.error) ? res.error : 'Failed to remove';
+                            if (typeof PNotify !== 'undefined') {
+                                new PNotify({ title: 'Trusted IPs', text: errRm, type: 'error', delay: 6000 });
+                            }
+                        }
+                    },
+                    function(err) {
+                        var em2 = (err.data && err.data.error) ? err.data.error : 'Request failed';
+                        if (typeof PNotify !== 'undefined') {
+                            new PNotify({ title: 'Trusted IPs', text: em2, type: 'error', delay: 6000 });
+                        }
                     }
-                } else {
-                    var errRm = (res && res.error) ? res.error : 'Failed to remove';
-                    if (typeof PNotify !== 'undefined') {
-                        new PNotify({ title: 'Trusted IPs', text: errRm, type: 'error', delay: 6000 });
-                    }
-                }
-            },
-            function(err) {
-                var em2 = (err.data && err.data.error) ? err.data.error : 'Request failed';
-                if (typeof PNotify !== 'undefined') {
-                    new PNotify({ title: 'Trusted IPs', text: em2, type: 'error', delay: 6000 });
-                }
+                );
             }
         );
     };
@@ -963,74 +1007,81 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         });
     };
 
-    $scope.deleteRule = function (id, proto, port, ruleIP) {
+    $scope.deleteRule = function (id, proto, port, ruleIP, ruleName) {
+        var nameLabel = (ruleName && String(ruleName).trim()) ? String(ruleName).trim() : ('#' + id);
+        var detail = nameLabel + ' (' + (proto || '') + '/' + (port || '') + ', ' + (ruleIP || '') + ')';
+        firewallConfirmDelete(
+            'Delete Firewall Rule',
+            'Are you sure you want to delete firewall rule "' + detail + '"? This cannot be undone.',
+            function () {
+                $scope.rulesLoading = true;
 
-        $scope.rulesLoading = true;
+                url = "/firewall/deleteRule";
 
-        url = "/firewall/deleteRule";
+                var data = {
+                    id: id,
+                    proto: proto,
+                    port: port,
+                    ruleIP: ruleIP
+                };
 
-        var data = {
-            id: id,
-            proto: proto,
-            port: port,
-            ruleIP: ruleIP
-        };
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+
+                $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+                function ListInitialDatas(response) {
+
+
+                    if (response.data.delete_status === 1) {
+
+
+                        populateCurrentRecords();
+                        $scope.actionFailed = true;
+                        $scope.actionSuccess = true;
+
+                        $scope.canNotAddRule = true;
+                        $scope.ruleAdded = true;
+                        $scope.couldNotConnect = true;
+
+
+                    }
+                    else {
+
+                        $scope.rulesLoading = false;
+                        $scope.actionFailed = true;
+                        $scope.actionSuccess = true;
+
+                        $scope.canNotAddRule = false;
+                        $scope.ruleAdded = true;
+                        $scope.couldNotConnect = true;
+
+                        $scope.errorMessage = response.data.error_message;
+
+
+                    }
+
+                }
+
+                function cantLoadInitialDatas(response) {
+
+                    $scope.rulesLoading = false;
+                    $scope.actionFailed = true;
+                    $scope.actionSuccess = true;
+
+                    $scope.canNotAddRule = true;
+                    $scope.ruleAdded = true;
+                    $scope.couldNotConnect = false;
+
+
+                }
             }
-        };
-
-
-        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
-
-
-        function ListInitialDatas(response) {
-
-
-            if (response.data.delete_status === 1) {
-
-
-                populateCurrentRecords();
-                $scope.actionFailed = true;
-                $scope.actionSuccess = true;
-
-                $scope.canNotAddRule = true;
-                $scope.ruleAdded = true;
-                $scope.couldNotConnect = true;
-
-
-            }
-            else {
-
-                $scope.rulesLoading = false;
-                $scope.actionFailed = true;
-                $scope.actionSuccess = true;
-
-                $scope.canNotAddRule = false;
-                $scope.ruleAdded = true;
-                $scope.couldNotConnect = true;
-
-                $scope.errorMessage = response.data.error_message;
-
-
-            }
-
-        }
-
-        function cantLoadInitialDatas(response) {
-
-            $scope.rulesLoading = false;
-            $scope.actionFailed = true;
-            $scope.actionSuccess = true;
-
-            $scope.canNotAddRule = true;
-            $scope.ruleAdded = true;
-            $scope.couldNotConnect = false;
-
-
-        }
+        );
 
 
     };
@@ -1380,71 +1431,77 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
     };
 
     $scope.removeBannedIP = function(id, ip) {
-        if (!confirm('Are you sure you want to unban IP address ' + ip + '?')) {
-            return;
-        }
+        var ipLabel = ip || ('#' + id);
+        firewallConfirmDelete(
+            'Unban IP Address',
+            'Are you sure you want to unban IP address "' + ipLabel + '"?',
+            function () {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
 
-        $scope.bannedIPsLoading = true;
-        $scope.bannedIPActionFailed = true;
-        $scope.bannedIPActionSuccess = true;
-        $scope.bannedIPCouldNotConnect = true;
+                var data = { id: id };
 
-        var data = { id: id };
+                var url = "/firewall/removeBannedIP";
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var url = "/firewall/removeBannedIP";
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                $http.post(url, data, config).then(function(response) {
+                    $scope.bannedIPsLoading = false;
+                    if (response.data.status === 1) {
+                        $scope.bannedIPActionSuccess = false;
+                        populateBannedIPs(); // Refresh the list
+                    } else {
+                        $scope.bannedIPActionFailed = false;
+                        $scope.bannedIPErrorMessage = response.data.error_message;
+                    }
+                }, function(error) {
+                    $scope.bannedIPsLoading = false;
+                    $scope.bannedIPCouldNotConnect = false;
+                });
             }
-        };
-
-        $http.post(url, data, config).then(function(response) {
-            $scope.bannedIPsLoading = false;
-            if (response.data.status === 1) {
-                $scope.bannedIPActionSuccess = false;
-                populateBannedIPs(); // Refresh the list
-            } else {
-                $scope.bannedIPActionFailed = false;
-                $scope.bannedIPErrorMessage = response.data.error_message;
-            }
-        }, function(error) {
-            $scope.bannedIPsLoading = false;
-            $scope.bannedIPCouldNotConnect = false;
-        });
+        );
     };
 
     $scope.deleteBannedIP = function(id, ip) {
-        if (!confirm('Are you sure you want to permanently delete the record for IP address ' + ip + '? This action cannot be undone.')) {
-            return;
-        }
+        var ipLabel = ip || ('#' + id);
+        firewallConfirmDelete(
+            'Delete Banned IP Record',
+            'Are you sure you want to permanently delete the record for IP address "' + ipLabel + '"? This action cannot be undone.',
+            function () {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
 
-        $scope.bannedIPsLoading = true;
-        $scope.bannedIPActionFailed = true;
-        $scope.bannedIPActionSuccess = true;
-        $scope.bannedIPCouldNotConnect = true;
+                var data = { id: id };
 
-        var data = { id: id };
+                var url = "/firewall/deleteBannedIP";
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var url = "/firewall/deleteBannedIP";
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                $http.post(url, data, config).then(function(response) {
+                    $scope.bannedIPsLoading = false;
+                    if (response.data.status === 1) {
+                        $scope.bannedIPActionSuccess = false;
+                        populateBannedIPs(); // Refresh the list
+                    } else {
+                        $scope.bannedIPActionFailed = false;
+                        $scope.bannedIPErrorMessage = response.data.error_message;
+                    }
+                }, function(error) {
+                    $scope.bannedIPsLoading = false;
+                    $scope.bannedIPCouldNotConnect = false;
+                });
             }
-        };
-
-        $http.post(url, data, config).then(function(response) {
-            $scope.bannedIPsLoading = false;
-            if (response.data.status === 1) {
-                $scope.bannedIPActionSuccess = false;
-                populateBannedIPs(); // Refresh the list
-            } else {
-                $scope.bannedIPActionFailed = false;
-                $scope.bannedIPErrorMessage = response.data.error_message;
-            }
-        }, function(error) {
-            $scope.bannedIPsLoading = false;
-            $scope.bannedIPCouldNotConnect = false;
-        });
+        );
     };
 
     $scope.openModifyModal = function(bannedIP) {

--- a/public/static/firewall/firewall.js
+++ b/public/static/firewall/firewall.js
@@ -885,6 +885,9 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.ruleAdded = true;
                 $scope.couldNotConnect = true;
 
+                $scope.rulesDetails = false;
+                populateCurrentRecords();
+
 
             }
             else {
@@ -963,6 +966,8 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.rulesDetails = false;
 
                 firewallStatus();
+                /* Reload rules after Start so the table stays visible and populated. */
+                populateCurrentRecords();
 
 
             }
@@ -1044,6 +1049,7 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.rulesDetails = false;
 
                 firewallStatus();
+                populateCurrentRecords();
 
 
             }

--- a/public/static/manageServices/manageServices.js
+++ b/public/static/manageServices/manageServices.js
@@ -12,21 +12,21 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
     $scope.changesApplied = true;
     $scope.slaveIPs = true;
     $scope.masterServerHD = true;
+    $scope.pdnsEnabled = false;
+    if (!$scope.dnsMode) {
+        $scope.dnsMode = 'Default';
+    }
 
-    var pdnsStatus = false;
-
-
-    $('#pdnsStatus').change(function () {
-        pdnsStatus = $(this).prop('checked');
-    });
+    $scope.pdnsToggleChanged = function () {
+        // ng-model already synced; keep for future hooks
+    };
 
     fetchPDNSStatus('powerdns');
 
     function fetchPDNSStatus(service) {
 
         $scope.pdnsLoading = false;
-
-        $('#pdnsStatus').bootstrapToggle('off');
+        $scope.pdnsEnabled = false;
 
         url = "/manageservices/fetchStatus";
 
@@ -50,10 +50,11 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
 
             if (response.data.status === 1) {
 
-                if (response.data.installCheck === 1) {
-                    $('#pdnsStatus').bootstrapToggle('on');
+                $scope.pdnsEnabled = (response.data.installCheck === 1 || response.data.installCheck === '1' || response.data.installCheck === true);
+                if (response.data.dnsMode) {
+                    $scope.dnsMode = response.data.dnsMode;
                 }
-
+                $scope.modeChange();
                 $scope.slaveIPData = response.data.slaveIPData;
 
             } else {
@@ -88,7 +89,7 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
 
         if (service === 'powerdns') {
             var data = {
-                status: pdnsStatus,
+                status: !!$scope.pdnsEnabled,
                 service: service,
                 dnsMode: $scope.dnsMode,
                 slaveServerNS: $scope.slaveServerNS,
@@ -102,7 +103,7 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
             };
         } else {
             var data = {
-                status: pdnsStatus,
+                status: !!$scope.pdnsEnabled,
                 service: service
             };
         }

--- a/public/static/serverStatus/serverStatus.js
+++ b/public/static/serverStatus/serverStatus.js
@@ -1043,11 +1043,31 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
 
     $scope.currentPage = 1;
     $scope.recordsToShow = 10;
+    $scope.currentTab = 'upgrade';
     var globalType;
+    var packageCache = {};
+    var activeFetch = null;
 
-    $scope.fetchPackages = function (type = 'installed') {
-        $scope.cyberpanelLoading = false;
+    $scope.fetchPackages = function (type) {
+        if (typeof type === 'undefined' || type === null || type === '') {
+            type = 'installed';
+        }
+        $scope.currentTab = type;
         globalType = type;
+
+        // Serve cached tab data instantly (All Packages is expensive)
+        var cacheKey = type + '|' + $scope.currentPage + '|' + $scope.recordsToShow;
+        if (packageCache[cacheKey]) {
+            var cached = packageCache[cacheKey];
+            $scope.allPackages = cached.allPackages;
+            $scope.pagination = cached.pagination;
+            $scope.fetchedPackages = cached.fetchedPackages;
+            $scope.totalPackages = cached.totalPackages;
+            $scope.cyberpanelLoading = true;
+            return;
+        }
+
+        $scope.cyberpanelLoading = false;
         var config = {
             headers: {
                 'X-CSRFToken': getCookie('csrftoken')
@@ -1061,16 +1081,27 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
         };
 
         dataurl = "/serverstatus/fetchPackages";
+        var fetchToken = {};
+        activeFetch = fetchToken;
 
         $http.post(dataurl, data, config).then(ListInitialData, cantLoadInitialData);
 
         function ListInitialData(response) {
+            if (activeFetch !== fetchToken) {
+                return; // stale response from another tab
+            }
             $scope.cyberpanelLoading = true;
             if (response.data.status === 1) {
                 $scope.allPackages = JSON.parse(response.data.packages);
                 $scope.pagination = response.data.pagination;
                 $scope.fetchedPackages = response.data.fetchedPackages;
                 $scope.totalPackages = response.data.totalPackages;
+                packageCache[cacheKey] = {
+                    allPackages: $scope.allPackages,
+                    pagination: $scope.pagination,
+                    fetchedPackages: $scope.fetchedPackages,
+                    totalPackages: $scope.totalPackages
+                };
             } else {
                 new PNotify({
                     title: 'Error!',
@@ -1081,6 +1112,9 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
         }
 
         function cantLoadInitialData(response) {
+            if (activeFetch !== fetchToken) {
+                return;
+            }
             $scope.cyberpanelLoading = true;
             new PNotify({
                 title: 'Operation Failed!',
@@ -1091,6 +1125,7 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
 
 
     };
+    // Available Updates first; All Packages loads only when that tab is selected
     $scope.fetchPackages('upgrade');
 
     $scope.fetchPackageDetails = function (packageFetch) {

--- a/public/static/webmail/webmail.css
+++ b/public/static/webmail/webmail.css
@@ -650,10 +650,19 @@ button.wm-nav-link.wm-nav-btn:focus {
 }
 
 .wm-msg-row.unread {
-    font-weight: 600;
+    font-weight: 700;
+    border-left: 3px solid var(--primary-color, #6c5ce7);
+    background: rgba(108, 92, 231, 0.06);
+    padding-left: 9px;
 }
 
 .wm-msg-row.unread .wm-msg-subject {
+    color: var(--primary-color, #6c5ce7);
+    font-weight: 700;
+}
+
+.wm-msg-row.unread .wm-msg-from {
+    font-weight: 700;
     color: var(--text-primary);
 }
 

--- a/public/static/websiteFunctions/websiteFunctions.js
+++ b/public/static/websiteFunctions/websiteFunctions.js
@@ -2966,11 +2966,20 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            // Retry briefly if session/CSRF cookies are still settling after login
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -2992,18 +3001,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);
@@ -6415,11 +6425,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -6441,18 +6459,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);
@@ -10223,11 +10242,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -10249,18 +10276,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);

--- a/serverStatus/static/serverStatus/serverStatus.js
+++ b/serverStatus/static/serverStatus/serverStatus.js
@@ -1043,11 +1043,31 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
 
     $scope.currentPage = 1;
     $scope.recordsToShow = 10;
+    $scope.currentTab = 'upgrade';
     var globalType;
+    var packageCache = {};
+    var activeFetch = null;
 
-    $scope.fetchPackages = function (type = 'installed') {
-        $scope.cyberpanelLoading = false;
+    $scope.fetchPackages = function (type) {
+        if (typeof type === 'undefined' || type === null || type === '') {
+            type = 'installed';
+        }
+        $scope.currentTab = type;
         globalType = type;
+
+        // Serve cached tab data instantly (All Packages is expensive)
+        var cacheKey = type + '|' + $scope.currentPage + '|' + $scope.recordsToShow;
+        if (packageCache[cacheKey]) {
+            var cached = packageCache[cacheKey];
+            $scope.allPackages = cached.allPackages;
+            $scope.pagination = cached.pagination;
+            $scope.fetchedPackages = cached.fetchedPackages;
+            $scope.totalPackages = cached.totalPackages;
+            $scope.cyberpanelLoading = true;
+            return;
+        }
+
+        $scope.cyberpanelLoading = false;
         var config = {
             headers: {
                 'X-CSRFToken': getCookie('csrftoken')
@@ -1061,16 +1081,27 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
         };
 
         dataurl = "/serverstatus/fetchPackages";
+        var fetchToken = {};
+        activeFetch = fetchToken;
 
         $http.post(dataurl, data, config).then(ListInitialData, cantLoadInitialData);
 
         function ListInitialData(response) {
+            if (activeFetch !== fetchToken) {
+                return; // stale response from another tab
+            }
             $scope.cyberpanelLoading = true;
             if (response.data.status === 1) {
                 $scope.allPackages = JSON.parse(response.data.packages);
                 $scope.pagination = response.data.pagination;
                 $scope.fetchedPackages = response.data.fetchedPackages;
                 $scope.totalPackages = response.data.totalPackages;
+                packageCache[cacheKey] = {
+                    allPackages: $scope.allPackages,
+                    pagination: $scope.pagination,
+                    fetchedPackages: $scope.fetchedPackages,
+                    totalPackages: $scope.totalPackages
+                };
             } else {
                 new PNotify({
                     title: 'Error!',
@@ -1081,6 +1112,9 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
         }
 
         function cantLoadInitialData(response) {
+            if (activeFetch !== fetchToken) {
+                return;
+            }
             $scope.cyberpanelLoading = true;
             new PNotify({
                 title: 'Operation Failed!',
@@ -1091,6 +1125,7 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
 
 
     };
+    // Available Updates first; All Packages loads only when that tab is selected
     $scope.fetchPackages('upgrade');
 
     $scope.fetchPackageDetails = function (packageFetch) {

--- a/serverStatus/templates/serverStatus/litespeedStatus.html
+++ b/serverStatus/templates/serverStatus/litespeedStatus.html
@@ -757,11 +757,13 @@
                 </div>
                 
                 <h4 style="font-size: 0.875rem; font-weight: 600; color: var(--text-secondary); margin: 1.5rem 0 1rem 0; text-transform: uppercase; letter-spacing: 0.05em;">
-                    {{ modules }}
+                    {% trans "Module versions" %}
                 </h4>
                 <div class="module-list">
                     {% for item in loadedModules %}
+                        {% if item %}
                         <div class="module-item">{{ item }}</div>
+                        {% endif %}
                     {% endfor %}
                 </div>
             </div>

--- a/serverStatus/templates/serverStatus/packageManager.html
+++ b/serverStatus/templates/serverStatus/packageManager.html
@@ -8,8 +8,8 @@
 <!-- Current language: {{ LANGUAGE_CODE }} -->
 
 <style>
-    /* CSS Variables for Dark Mode Support */
-    :root {
+    /* CSS Variables for Dark Mode Support (scoped to page container) */
+    .modern-container {
         /* Text colors */
         --text-primary: #1e293b;
         --text-secondary: #475569;
@@ -76,7 +76,7 @@
         --empty-icon-bg: #f3f4f6;
     }
     
-    [data-theme="dark"] {
+    [data-theme="dark"] .modern-container {
         /* Dark mode overrides */
         --text-primary: #e4e4e7;
         --text-secondary: #9ca3af;
@@ -134,10 +134,50 @@
         --lock-hover-bg: #252550;
         --empty-icon-bg: #252550;
     }
+
+    [data-theme="dark"] .modern-container .stat-pill,
+    [data-theme="dark"] .modern-container .version-badge,
+    [data-theme="dark"] .modern-container .package-type,
+    [data-theme="dark"] .modern-container .count-badge,
+    [data-theme="dark"] .modern-container .status-pill {
+        color: #f4f4f5 !important;
+    }
+
+    [data-theme="dark"] .modern-container .page-header,
+    [data-theme="dark"] .modern-container .page-header h1,
+    [data-theme="dark"] .modern-container .page-header p {
+        color: #fff !important;
+    }
+
     .modern-container {
         max-width: 1400px;
         margin: 0 auto;
         padding: 2rem;
+    }
+
+    @media (max-width: 768px) {
+        .modern-container {
+            padding: 1rem;
+        }
+        .page-header {
+            padding: 1.5rem 1rem !important;
+            margin-bottom: 1.5rem !important;
+        }
+        .tab-navigation, .tabs-container, .package-tabs {
+            flex-direction: column;
+            align-items: stretch;
+        }
+        .tab-item {
+            width: 100%;
+            justify-content: center;
+        }
+        .table-responsive, .packages-table-wrapper {
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+        table {
+            min-width: 640px;
+        }
     }
     
     .page-header {

--- a/serverStatus/views.py
+++ b/serverStatus/views.py
@@ -75,7 +75,9 @@ def litespeedStatus(request):
                     counter = counter + 1
                     continue
                 else:
-                    loadedModules.append(items)
+                    # Skip blank/whitespace lines from lshttpd -v trailing output
+                    if items and str(items).strip():
+                        loadedModules.append(items.strip())
 
         except BaseException as msg:
             logging.CyberCPLogFileWriter.writeToFile(str(msg) + "[litespeedStatus]")

--- a/static/baseTemplate/css/cyberpanel-ui.css
+++ b/static/baseTemplate/css/cyberpanel-ui.css
@@ -41,6 +41,26 @@
             --skeleton-base: #e9ebef;
             --skeleton-shine: #f4f5f7;
             --focus-ring: #5856d6;
+            /* Fluid UI scale (viewport-aware; no transform zoom) */
+            --cp-root-font: clamp(15px, 0.28vw + 14.1px, 17.5px);
+            --cp-sidebar-width: clamp(272px, 17vw, 300px);
+            --cp-content-max: min(1680px, 100%);
+            --cp-pad-main-x: clamp(1rem, 2.2vw, 2rem);
+            --cp-pad-main-y: clamp(1.25rem, 2vw, 2rem);
+            --cp-header-height: clamp(4.25rem, 5.5vw, 5rem);
+            --cp-font-xs: 0.75rem;
+            --cp-font-sm: 0.875rem;
+            --cp-font-md: 1rem;
+            --cp-font-lg: 1.125rem;
+            --cp-space-xs: 0.25rem;
+            --cp-space-sm: 0.5rem;
+            --cp-space-md: 1rem;
+            --cp-space-lg: 1.5rem;
+            --cp-space-xl: 2rem;
+        }
+
+        html {
+            font-size: var(--cp-root-font);
         }
         
         /* Dark Theme Colors */
@@ -92,6 +112,7 @@
         
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            font-size: var(--cp-font-md);
             background: var(--bg-primary);
             color: var(--text-primary);
             overflow-x: hidden;
@@ -111,14 +132,14 @@
         /* Header */
         #header {
             background: var(--bg-secondary);
-            height: 80px;
+            height: var(--cp-header-height);
             display: flex;
             align-items: center;
-            padding: 0 30px;
+            padding: 0 var(--cp-pad-main-x);
             box-shadow: 0 2px 12px var(--shadow-color);
             position: fixed;
             top: 0;
-            left: 260px;
+            left: var(--cp-sidebar-width);
             right: 0;
             z-index: 1000;
             transition: background-color 0.12s ease;
@@ -258,7 +279,7 @@
         
         /* Sidebar */
         #sidebar {
-            width: 260px;
+            width: var(--cp-sidebar-width);
             background: var(--bg-sidebar);
             height: 100vh;
             position: fixed;
@@ -595,8 +616,8 @@
         
         /* Main Content */
         #main-content {
-            margin-left: 260px;
-            padding: 110px 30px 30px;
+            margin-left: var(--cp-sidebar-width);
+            padding: calc(var(--cp-header-height) + 1.75rem) var(--cp-pad-main-x) var(--cp-pad-main-y);
             min-height: 100vh;
             background: var(--bg-primary);
             transition: background-color 0.3s ease;
@@ -605,8 +626,8 @@
         /* Notification Banner */
         .notification-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
             border-bottom: 1px solid #f59e0b;
@@ -689,8 +710,8 @@
         /* AI Scanner Security Banner */
         .ai-scanner-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a855f7 100%);
             border-bottom: 2px solid #4f46e5;
@@ -832,8 +853,8 @@
         /* .htaccess Feature Banner */
         .htaccess-feature-banner {
             position: fixed;
-            top: 80px;
-            left: 260px;
+            top: var(--cp-header-height);
+            left: var(--cp-sidebar-width);
             right: 0;
             background: linear-gradient(135deg, #10b981 0%, #059669 50%, #047857 100%);
             border-bottom: 2px solid #065f46;
@@ -1519,7 +1540,7 @@ textarea:focus-visible,
 }
 
 /* ============================================================
-   Sidebar quick-filter / jump-to search
+   Sidebar feature/site search (near server-info / uptime)
    ============================================================ */
 .sidebar-search {
     position: relative;
@@ -1527,21 +1548,31 @@ textarea:focus-visible,
     display: flex;
     align-items: center;
 }
+#sidebar .server-info .sidebar-search--server {
+    flex: 1 1 100%;
+    width: 100%;
+    margin: 8px 0 0;
+    order: 3;
+}
+#sidebar .server-info {
+    flex-wrap: wrap;
+}
 .sidebar-search > i {
     position: absolute;
     left: 12px;
     color: var(--text-secondary);
     font-size: 13px;
     pointer-events: none;
+    z-index: 1;
 }
 .sidebar-search input {
     width: 100%;
-    padding: 10px 32px 10px 32px;
+    padding: 9px 32px 9px 32px;
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    background: var(--bg-secondary);
+    background: var(--bg-primary, var(--bg-secondary));
     color: var(--text-primary);
-    font-size: 13px;
+    font-size: 12.5px;
     outline: none;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -1553,6 +1584,8 @@ textarea:focus-visible,
 #sidebar-search-clear {
     position: absolute;
     right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
     background: transparent;
     border: none;
     color: var(--text-secondary);
@@ -1560,13 +1593,62 @@ textarea:focus-visible,
     padding: 4px;
     border-radius: 5px;
     line-height: 1;
+    z-index: 2;
 }
 #sidebar-search-clear:hover { color: var(--danger-color); background: var(--bg-hover); }
 #sidebar-search-clear[hidden] { display: none; }
 
+.sidebar-search-results {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: calc(100% + 4px);
+    z-index: 40;
+    max-height: min(50vh, 320px);
+    overflow-y: auto;
+    background: var(--bg-secondary, #1e1e2e);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    box-shadow: 0 12px 28px rgba(0,0,0,0.35);
+    padding: 4px;
+}
+.sidebar-search-results[hidden] { display: none; }
+.sidebar-search-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    width: 100%;
+    text-align: left;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    padding: 8px 10px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+.sidebar-search-item:hover,
+.sidebar-search-item.active {
+    background: var(--bg-hover, rgba(88,86,214,0.18));
+}
+.sidebar-search-ic {
+    width: 22px;
+    flex: 0 0 22px;
+    color: var(--accent-color, #7c7cff);
+    margin-top: 2px;
+}
+.sidebar-search-label {
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.25;
+}
+.sidebar-search-sub {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+}
 .sidebar-search-empty {
-    margin: 6px 15px;
-    padding: 10px 12px;
+    margin-top: 6px;
+    padding: 8px 10px;
     font-size: 12px;
     color: var(--text-secondary);
     text-align: center;
@@ -1575,6 +1657,11 @@ textarea:focus-visible,
     border-radius: 8px;
 }
 .sidebar-search-empty[hidden] { display: none; }
+@media (max-width: 768px) {
+    .sidebar-search-results {
+        max-height: min(40vh, 260px);
+    }
+}
 
 /* ============================================================
    Breadcrumb / page context strip
@@ -2057,9 +2144,9 @@ button[aria-busy="true"] { opacity: 0.75; cursor: progress; }
 :root { --accent-soft-bg: rgba(88,86,214,0.10); }
 [data-theme="dark"] { --accent-soft-bg: rgba(124,127,243,0.16); }
 
-/* Comfortable base typography */
+/* Comfortable base typography (tracks fluid html root) */
 body {
-    font-size: 14px;
+    font-size: var(--cp-font-md);
     line-height: 1.55;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -2111,7 +2198,7 @@ body {
     color: var(--text-secondary);
     margin: 16px 18px 6px;
     padding: 0;
-    font-size: 10.5px;
+    font-size: clamp(0.7rem, 0.15vw + 0.65rem, 0.78rem);
     letter-spacing: 0.7px;
     font-weight: 700;
     text-align: left;
@@ -2124,10 +2211,10 @@ body {
     background: transparent;
     box-shadow: none;
     margin: 1px 10px;
-    padding: 9px 12px;
+    padding: 0.65rem 0.85rem;
     border-radius: 8px;
-    gap: 11px;
-    font-size: 13.5px;
+    gap: 0.7rem;
+    font-size: clamp(0.9rem, 0.12vw + 0.86rem, 1rem);
     font-weight: 500;
     color: var(--text-secondary);
 }
@@ -2153,7 +2240,7 @@ body {
     height: 22px;
     border-radius: 6px;
 }
-#sidebar .menu-item i { font-size: 15px; color: var(--text-secondary); }
+#sidebar .menu-item i { font-size: 1.05rem; color: var(--text-secondary); }
 #sidebar .menu-item:hover i { color: var(--accent-color); }
 
 /* Keep the promo entry distinctive but a touch softer */
@@ -2193,7 +2280,7 @@ body {
 }
 
 /* Breadcrumb: quieter */
-.cp-breadcrumb { font-size: 12.5px; }
+.cp-breadcrumb { font-size: var(--cp-font-sm); }
 
 /* =================================================================
    v2.4.8 — Service promo banner (e.g. managed Email Delivery)
@@ -2388,4 +2475,92 @@ html[data-theme="light"] #sidebar .menu-item.active,
 html.cp-theme-light #sidebar .menu-item.active {
     background-color: var(--accent-soft-bg);
     color: var(--accent-color);
+}
+
+/* =================================================================
+   Fluid UI scale — readable desktop chrome, adaptive hubs
+   (rem + clamp; no page transform zoom)
+   ================================================================= */
+#main-content .modern-container,
+#main-content .page-container {
+    max-width: var(--cp-content-max);
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: var(--cp-pad-main-x);
+    padding-right: var(--cp-pad-main-x);
+    box-sizing: border-box;
+}
+
+#main-content .form-label,
+#main-content label.form-label {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content .form-control,
+#main-content select.form-control,
+#main-content textarea.form-control,
+#main-content .select-control {
+    font-size: var(--cp-font-md);
+    min-height: 2.65rem;
+}
+
+#main-content .btn,
+#main-content .control-btn,
+#main-content .btn-add,
+#main-content .tab-button {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content table th,
+#main-content .rules-table th {
+    font-size: var(--cp-font-xs);
+}
+
+#main-content table td,
+#main-content .rules-table td {
+    font-size: var(--cp-font-sm);
+}
+
+#main-content .rules-table-section {
+    display: block;
+    visibility: visible;
+    overflow-x: auto;
+}
+
+#sidebar .server-info .info-line {
+    font-size: var(--cp-font-sm);
+}
+
+#sidebar .logo-text .brand {
+    font-size: var(--cp-font-lg);
+}
+
+#sidebar .logo-text .tagline {
+    font-size: var(--cp-font-xs);
+}
+
+.sidebar-search input,
+#sidebar .sidebar-search input {
+    font-size: var(--cp-font-sm);
+}
+
+@media (max-width: 768px) {
+    :root {
+        --cp-sidebar-width: 280px;
+        --cp-root-font: 15.5px;
+        --cp-pad-main-x: 0.9rem;
+    }
+
+    #main-content .modern-container,
+    #main-content .page-container {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
+@media (min-width: 1400px) {
+    :root {
+        --cp-content-max: min(1760px, 100%);
+    }
 }

--- a/static/baseTemplate/custom-js/system-status.js
+++ b/static/baseTemplate/custom-js/system-status.js
@@ -18,6 +18,15 @@ function getCookie(name) {
             }
         }
     }
+    // Fallback: CSRF seed form in base template (cookie may be missing briefly after login)
+    if (!cookieValue && name === 'csrftoken') {
+        try {
+            var el = document.querySelector('#cp-csrf-seed input[name="csrfmiddlewaretoken"], input[name="csrfmiddlewaretoken"]');
+            if (el && el.value) {
+                cookieValue = el.value;
+            }
+        } catch (e) {}
+    }
     return cookieValue;
 }
 

--- a/static/firewall/firewall.js
+++ b/static/firewall/firewall.js
@@ -2243,8 +2243,6 @@ app.controller('modSecRulesPack', function ($scope, $http, $timeout, $window) {
 
     var owaspInstalled = false;
     var comodoInstalled = false;
-    var counterOWASP = 0;
-    var counterComodo = 0;
     var updatingOWASPStatus = false;
     var updatingComodoStatus = false;
 
@@ -2253,46 +2251,34 @@ app.controller('modSecRulesPack', function ($scope, $http, $timeout, $window) {
 
         // Prevent triggering installation when status check updates the toggle
         if (updatingOWASPStatus) {
-            counterOWASP = counterOWASP + 1;  // Still increment counter
             return;
         }
 
         owaspInstalled = $(this).prop('checked');
         $scope.ruleFiles = true;
 
-        if (counterOWASP !== 0) {
-            if (owaspInstalled === true) {
-                installModSecRulesPack('installOWASP');
-            } else {
-                installModSecRulesPack('disableOWASP')
-            }
+        if (owaspInstalled === true) {
+            installModSecRulesPack('installOWASP');
+        } else {
+            installModSecRulesPack('disableOWASP');
         }
-
-        counterOWASP = counterOWASP + 1;
     });
 
     $('#comodoInstalled').change(function () {
 
         // Prevent triggering installation when status check updates the toggle
         if (updatingComodoStatus) {
-            counterComodo = counterComodo + 1;  // Still increment counter
             return;
         }
 
         $scope.ruleFiles = true;
         comodoInstalled = $(this).prop('checked');
 
-        if (counterComodo !== 0) {
-
-            if (comodoInstalled === true) {
-                installModSecRulesPack('installComodo');
-            } else {
-                installModSecRulesPack('disableComodo')
-            }
+        if (comodoInstalled === true) {
+            installModSecRulesPack('installComodo');
+        } else {
+            installModSecRulesPack('disableComodo');
         }
-
-        counterComodo = counterComodo + 1;
-
     });
 
 

--- a/static/firewall/firewall.js
+++ b/static/firewall/firewall.js
@@ -711,6 +711,197 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         populateCurrentRecords();
     };
 
+    function renumberDisplayedRuleIds() {
+        var start = $scope.rulesRangeStart() || 1;
+        ($scope.rules || []).forEach(function(rule, idx) {
+            rule.displayId = start + idx;
+            rule.sortOrder = rule.displayId;
+        });
+    }
+
+    function persistPageRuleOrder() {
+        var pageIds = ($scope.rules || []).map(function(r) { return r.id; });
+        if (!pageIds.length) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = {
+            page_ordered_ids: pageIds,
+            page: Math.max(1, parseInt($scope.rulesPage, 10) || 1),
+            page_size: Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10))
+        };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                renumberDisplayedRuleIds();
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                $scope.rulesLoading = false;
+            } else {
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not save rule order';
+                populateCurrentRecords();
+            }
+        }, function() {
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+            populateCurrentRecords();
+        });
+    }
+
+    $scope.canMoveRuleUp = function(index) {
+        var page = Math.max(1, parseInt($scope.rulesPage, 10) || 1);
+        return !(page === 1 && index === 0);
+    };
+
+    $scope.canMoveRuleDown = function(index) {
+        var page = Math.max(1, parseInt($scope.rulesPage, 10) || 1);
+        var size = Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10));
+        var total = $scope.rulesTotalCount || ($scope.rules ? $scope.rules.length : 0) || 0;
+        var globalIndex = (page - 1) * size + index;
+        return globalIndex < (total - 1);
+    };
+
+    $scope.moveRuleUp = function(rule) {
+        if (!rule || !rule.id) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = { id: rule.id, direction: 'up' };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not move rule';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    $scope.moveRuleDown = function(rule) {
+        if (!rule || !rule.id) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = { id: rule.id, direction: 'down' };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not move rule';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    var rulesDragFromIndex = null;
+
+    function bindRulesDragDrop() {
+        var tbody = document.getElementById('firewall-rules-tbody');
+        if (!tbody || tbody.getAttribute('data-dnd-bound') === '1') {
+            return;
+        }
+        tbody.setAttribute('data-dnd-bound', '1');
+
+        tbody.addEventListener('dragstart', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            // Allow drag from row/handle; block from action buttons/inputs
+            if (ev.target.closest && ev.target.closest('button, a, input, select, textarea')) {
+                ev.preventDefault();
+                return;
+            }
+            rulesDragFromIndex = parseInt(row.getAttribute('data-rule-index'), 10);
+            if (isNaN(rulesDragFromIndex)) {
+                rulesDragFromIndex = null;
+                return;
+            }
+            row.classList.add('rule-row-dragging');
+            try {
+                ev.dataTransfer.effectAllowed = 'move';
+                ev.dataTransfer.setData('text/plain', String(rulesDragFromIndex));
+            } catch (ignoreSet) {}
+        });
+
+        tbody.addEventListener('dragover', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            ev.preventDefault();
+            try {
+                ev.dataTransfer.dropEffect = 'move';
+            } catch (ignoreDrop) {}
+        });
+
+        tbody.addEventListener('drop', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            ev.preventDefault();
+            var toIndex = parseInt(row.getAttribute('data-rule-index'), 10);
+            var fromIndex = rulesDragFromIndex;
+            if (fromIndex === null || isNaN(toIndex) || fromIndex === toIndex) {
+                return;
+            }
+            $scope.$applyAsync(function() {
+                var list = $scope.rules || [];
+                if (fromIndex < 0 || fromIndex >= list.length || toIndex < 0 || toIndex >= list.length) {
+                    return;
+                }
+                var moved = list.splice(fromIndex, 1)[0];
+                list.splice(toIndex, 0, moved);
+                $scope.rules = list;
+                renumberDisplayedRuleIds();
+                persistPageRuleOrder();
+            });
+        });
+
+        tbody.addEventListener('dragend', function(ev) {
+            rulesDragFromIndex = null;
+            var dragging = tbody.querySelectorAll('.rule-row-dragging');
+            for (var i = 0; i < dragging.length; i++) {
+                dragging[i].classList.remove('rule-row-dragging');
+            }
+        });
+    }
+
+    // Bind after Angular paints the rules table (tbody is destroyed when rules empty)
+    $scope.$watchCollection('rules', function() {
+        $timeout(bindRulesDragDrop, 0);
+    });
+
     $scope.openModifyRuleModal = function(rule) {
         if (!rule) return;
         $scope.modifyRuleData = {

--- a/static/firewall/firewall.js
+++ b/static/firewall/firewall.js
@@ -18,6 +18,44 @@ function getCookie(name) {
     return cookieValue;
 }
 
+/**
+ * Confirm destructive firewall actions.
+ * Prefers PNotify confirm (Docker Manager pattern); falls back to window.confirm.
+ */
+function firewallConfirmDelete(title, text, onConfirm) {
+    var msg = text || 'Are you sure?';
+    if (typeof PNotify !== 'undefined') {
+        try {
+            (new PNotify({
+                title: title || 'Confirmation Needed',
+                text: msg,
+                icon: 'fa fa-question-circle',
+                hide: false,
+                confirm: {
+                    confirm: true
+                },
+                buttons: {
+                    closer: false,
+                    sticker: false
+                },
+                history: {
+                    history: false
+                }
+            })).get().on('pnotify.confirm', function () {
+                if (typeof onConfirm === 'function') {
+                    onConfirm();
+                }
+            });
+            return;
+        } catch (e) {
+            /* fall through to window.confirm */
+        }
+    }
+    if (window.confirm(msg) && typeof onConfirm === 'function') {
+        onConfirm();
+    }
+}
+
 /* Java script code to ADD Firewall Rules */
 
 app.controller('firewallController', function ($scope, $http, $timeout) {
@@ -376,30 +414,36 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
 
     $scope.removeTrustedSSHWhitelist = function(ip) {
         if (!ip) return;
-        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
-        $http.post('/base/sshSecurityWhitelistRemove', { ip: ip }, config).then(
-            function(response) {
-                var res = response.data;
-                if (typeof res === 'string') {
-                    try { res = JSON.parse(res); } catch (e) { res = {}; }
-                }
-                if (res && res.status === 1) {
-                    populateTrustedSSHWhitelist();
-                    if (typeof PNotify !== 'undefined') {
-                        new PNotify({ title: 'Trusted IPs', text: 'IP removed', type: 'success', delay: 4000 });
+        firewallConfirmDelete(
+            'Remove Trusted IP',
+            'Are you sure you want to remove trusted SSH IP "' + ip + '" from the whitelist?',
+            function () {
+                var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
+                $http.post('/base/sshSecurityWhitelistRemove', { ip: ip }, config).then(
+                    function(response) {
+                        var res = response.data;
+                        if (typeof res === 'string') {
+                            try { res = JSON.parse(res); } catch (e) { res = {}; }
+                        }
+                        if (res && res.status === 1) {
+                            populateTrustedSSHWhitelist();
+                            if (typeof PNotify !== 'undefined') {
+                                new PNotify({ title: 'Trusted IPs', text: 'IP removed', type: 'success', delay: 4000 });
+                            }
+                        } else {
+                            var errRm = (res && res.error) ? res.error : 'Failed to remove';
+                            if (typeof PNotify !== 'undefined') {
+                                new PNotify({ title: 'Trusted IPs', text: errRm, type: 'error', delay: 6000 });
+                            }
+                        }
+                    },
+                    function(err) {
+                        var em2 = (err.data && err.data.error) ? err.data.error : 'Request failed';
+                        if (typeof PNotify !== 'undefined') {
+                            new PNotify({ title: 'Trusted IPs', text: em2, type: 'error', delay: 6000 });
+                        }
                     }
-                } else {
-                    var errRm = (res && res.error) ? res.error : 'Failed to remove';
-                    if (typeof PNotify !== 'undefined') {
-                        new PNotify({ title: 'Trusted IPs', text: errRm, type: 'error', delay: 6000 });
-                    }
-                }
-            },
-            function(err) {
-                var em2 = (err.data && err.data.error) ? err.data.error : 'Request failed';
-                if (typeof PNotify !== 'undefined') {
-                    new PNotify({ title: 'Trusted IPs', text: em2, type: 'error', delay: 6000 });
-                }
+                );
             }
         );
     };
@@ -963,74 +1007,81 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         });
     };
 
-    $scope.deleteRule = function (id, proto, port, ruleIP) {
+    $scope.deleteRule = function (id, proto, port, ruleIP, ruleName) {
+        var nameLabel = (ruleName && String(ruleName).trim()) ? String(ruleName).trim() : ('#' + id);
+        var detail = nameLabel + ' (' + (proto || '') + '/' + (port || '') + ', ' + (ruleIP || '') + ')';
+        firewallConfirmDelete(
+            'Delete Firewall Rule',
+            'Are you sure you want to delete firewall rule "' + detail + '"? This cannot be undone.',
+            function () {
+                $scope.rulesLoading = true;
 
-        $scope.rulesLoading = true;
+                url = "/firewall/deleteRule";
 
-        url = "/firewall/deleteRule";
+                var data = {
+                    id: id,
+                    proto: proto,
+                    port: port,
+                    ruleIP: ruleIP
+                };
 
-        var data = {
-            id: id,
-            proto: proto,
-            port: port,
-            ruleIP: ruleIP
-        };
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+
+                $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+                function ListInitialDatas(response) {
+
+
+                    if (response.data.delete_status === 1) {
+
+
+                        populateCurrentRecords();
+                        $scope.actionFailed = true;
+                        $scope.actionSuccess = true;
+
+                        $scope.canNotAddRule = true;
+                        $scope.ruleAdded = true;
+                        $scope.couldNotConnect = true;
+
+
+                    }
+                    else {
+
+                        $scope.rulesLoading = false;
+                        $scope.actionFailed = true;
+                        $scope.actionSuccess = true;
+
+                        $scope.canNotAddRule = false;
+                        $scope.ruleAdded = true;
+                        $scope.couldNotConnect = true;
+
+                        $scope.errorMessage = response.data.error_message;
+
+
+                    }
+
+                }
+
+                function cantLoadInitialDatas(response) {
+
+                    $scope.rulesLoading = false;
+                    $scope.actionFailed = true;
+                    $scope.actionSuccess = true;
+
+                    $scope.canNotAddRule = true;
+                    $scope.ruleAdded = true;
+                    $scope.couldNotConnect = false;
+
+
+                }
             }
-        };
-
-
-        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
-
-
-        function ListInitialDatas(response) {
-
-
-            if (response.data.delete_status === 1) {
-
-
-                populateCurrentRecords();
-                $scope.actionFailed = true;
-                $scope.actionSuccess = true;
-
-                $scope.canNotAddRule = true;
-                $scope.ruleAdded = true;
-                $scope.couldNotConnect = true;
-
-
-            }
-            else {
-
-                $scope.rulesLoading = false;
-                $scope.actionFailed = true;
-                $scope.actionSuccess = true;
-
-                $scope.canNotAddRule = false;
-                $scope.ruleAdded = true;
-                $scope.couldNotConnect = true;
-
-                $scope.errorMessage = response.data.error_message;
-
-
-            }
-
-        }
-
-        function cantLoadInitialDatas(response) {
-
-            $scope.rulesLoading = false;
-            $scope.actionFailed = true;
-            $scope.actionSuccess = true;
-
-            $scope.canNotAddRule = true;
-            $scope.ruleAdded = true;
-            $scope.couldNotConnect = false;
-
-
-        }
+        );
 
 
     };
@@ -1380,71 +1431,77 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
     };
 
     $scope.removeBannedIP = function(id, ip) {
-        if (!confirm('Are you sure you want to unban IP address ' + ip + '?')) {
-            return;
-        }
+        var ipLabel = ip || ('#' + id);
+        firewallConfirmDelete(
+            'Unban IP Address',
+            'Are you sure you want to unban IP address "' + ipLabel + '"?',
+            function () {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
 
-        $scope.bannedIPsLoading = true;
-        $scope.bannedIPActionFailed = true;
-        $scope.bannedIPActionSuccess = true;
-        $scope.bannedIPCouldNotConnect = true;
+                var data = { id: id };
 
-        var data = { id: id };
+                var url = "/firewall/removeBannedIP";
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var url = "/firewall/removeBannedIP";
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                $http.post(url, data, config).then(function(response) {
+                    $scope.bannedIPsLoading = false;
+                    if (response.data.status === 1) {
+                        $scope.bannedIPActionSuccess = false;
+                        populateBannedIPs(); // Refresh the list
+                    } else {
+                        $scope.bannedIPActionFailed = false;
+                        $scope.bannedIPErrorMessage = response.data.error_message;
+                    }
+                }, function(error) {
+                    $scope.bannedIPsLoading = false;
+                    $scope.bannedIPCouldNotConnect = false;
+                });
             }
-        };
-
-        $http.post(url, data, config).then(function(response) {
-            $scope.bannedIPsLoading = false;
-            if (response.data.status === 1) {
-                $scope.bannedIPActionSuccess = false;
-                populateBannedIPs(); // Refresh the list
-            } else {
-                $scope.bannedIPActionFailed = false;
-                $scope.bannedIPErrorMessage = response.data.error_message;
-            }
-        }, function(error) {
-            $scope.bannedIPsLoading = false;
-            $scope.bannedIPCouldNotConnect = false;
-        });
+        );
     };
 
     $scope.deleteBannedIP = function(id, ip) {
-        if (!confirm('Are you sure you want to permanently delete the record for IP address ' + ip + '? This action cannot be undone.')) {
-            return;
-        }
+        var ipLabel = ip || ('#' + id);
+        firewallConfirmDelete(
+            'Delete Banned IP Record',
+            'Are you sure you want to permanently delete the record for IP address "' + ipLabel + '"? This action cannot be undone.',
+            function () {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
 
-        $scope.bannedIPsLoading = true;
-        $scope.bannedIPActionFailed = true;
-        $scope.bannedIPActionSuccess = true;
-        $scope.bannedIPCouldNotConnect = true;
+                var data = { id: id };
 
-        var data = { id: id };
+                var url = "/firewall/deleteBannedIP";
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
 
-        var url = "/firewall/deleteBannedIP";
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                $http.post(url, data, config).then(function(response) {
+                    $scope.bannedIPsLoading = false;
+                    if (response.data.status === 1) {
+                        $scope.bannedIPActionSuccess = false;
+                        populateBannedIPs(); // Refresh the list
+                    } else {
+                        $scope.bannedIPActionFailed = false;
+                        $scope.bannedIPErrorMessage = response.data.error_message;
+                    }
+                }, function(error) {
+                    $scope.bannedIPsLoading = false;
+                    $scope.bannedIPCouldNotConnect = false;
+                });
             }
-        };
-
-        $http.post(url, data, config).then(function(response) {
-            $scope.bannedIPsLoading = false;
-            if (response.data.status === 1) {
-                $scope.bannedIPActionSuccess = false;
-                populateBannedIPs(); // Refresh the list
-            } else {
-                $scope.bannedIPActionFailed = false;
-                $scope.bannedIPErrorMessage = response.data.error_message;
-            }
-        }, function(error) {
-            $scope.bannedIPsLoading = false;
-            $scope.bannedIPCouldNotConnect = false;
-        });
+        );
     };
 
     $scope.openModifyModal = function(bannedIP) {

--- a/static/firewall/firewall.js
+++ b/static/firewall/firewall.js
@@ -171,9 +171,14 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
 
     firewallStatus();
 
-    // Load both tabs on init; also load on tab change (watch) so content always shows
-    populateCurrentRecords();
-    populateBannedIPs();
+    // Load active tab data on init (avoid flipping UX by always prefetching banned).
+    if ($scope.activeTab === 'banned') {
+        populateBannedIPs();
+    } else if ($scope.activeTab === 'trusted') {
+        populateTrustedSSHWhitelist();
+    } else {
+        populateCurrentRecords();
+    }
 
     $scope.$watch('activeTab', function(newVal, oldVal) {
         if (newVal === oldVal || !newVal) return;
@@ -497,19 +502,24 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
         };
     }
     
-    // Load banned IPs on page load - use $timeout for Angular compatibility
-    // Wrap in try-catch to ensure it executes even if there are other errors
+    // Prefetch banned IPs shortly after load only when that tab is active (avoids tab race noise).
     try {
         $timeout(function() {
             try {
-                console.log('=== Calling populateBannedIPs from $timeout on page load ===');
-                populateBannedIPs();
+                if ($scope.activeTab === 'banned') {
+                    console.log('=== Calling populateBannedIPs from $timeout on page load ===');
+                    populateBannedIPs();
+                } else if ($scope.activeTab === 'rules') {
+                    populateCurrentRecords();
+                } else if ($scope.activeTab === 'trusted') {
+                    populateTrustedSSHWhitelist();
+                }
             } catch(e) {
-                console.error('Error in populateBannedIPs from timeout:', e);
+                console.error('Error in firewall tab prefetch from timeout:', e);
             }
         }, 500);
     } catch(e) {
-        console.error('Error setting up timeout for populateBannedIPs:', e);
+        console.error('Error setting up timeout for firewall tab prefetch:', e);
     }
     
     $scope.addRule = function () {
@@ -875,6 +885,9 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.ruleAdded = true;
                 $scope.couldNotConnect = true;
 
+                $scope.rulesDetails = false;
+                populateCurrentRecords();
+
 
             }
             else {
@@ -953,6 +966,8 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.rulesDetails = false;
 
                 firewallStatus();
+                /* Reload rules after Start so the table stays visible and populated. */
+                populateCurrentRecords();
 
 
             }
@@ -1030,9 +1045,11 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
                 $scope.ruleAdded = true;
                 $scope.couldNotConnect = true;
 
-                $scope.rulesDetails = true;
+                /* Keep rules UI visible while firewall is stopped so operators can still edit stored rules. */
+                $scope.rulesDetails = false;
 
                 firewallStatus();
+                populateCurrentRecords();
 
 
             }
@@ -1093,19 +1110,17 @@ app.controller('firewallController', function ($scope, $http, $timeout) {
             if (response.data.status == 1) {
 
                 if (response.data.firewallStatus == 1) {
-                    $scope.rulesDetails = false;
                     $scope.status = "ON";
                 }
                 else {
-                    $scope.rulesDetails = true;
                     $scope.status = "OFF";
                 }
             }
             else {
-
-                $scope.rulesDetails = true;
                 $scope.status = "OFF";
             }
+            /* Never hide the rules table/form when firewall is OFF (was rulesDetails=true). */
+            $scope.rulesDetails = false;
 
 
         }

--- a/static/manageServices/manageServices.js
+++ b/static/manageServices/manageServices.js
@@ -12,21 +12,21 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
     $scope.changesApplied = true;
     $scope.slaveIPs = true;
     $scope.masterServerHD = true;
+    $scope.pdnsEnabled = false;
+    if (!$scope.dnsMode) {
+        $scope.dnsMode = 'Default';
+    }
 
-    var pdnsStatus = false;
-
-
-    $('#pdnsStatus').change(function () {
-        pdnsStatus = $(this).prop('checked');
-    });
+    $scope.pdnsToggleChanged = function () {
+        // ng-model already synced; keep for future hooks
+    };
 
     fetchPDNSStatus('powerdns');
 
     function fetchPDNSStatus(service) {
 
         $scope.pdnsLoading = false;
-
-        $('#pdnsStatus').bootstrapToggle('off');
+        $scope.pdnsEnabled = false;
 
         url = "/manageservices/fetchStatus";
 
@@ -50,10 +50,11 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
 
             if (response.data.status === 1) {
 
-                if (response.data.installCheck === 1) {
-                    $('#pdnsStatus').bootstrapToggle('on');
+                $scope.pdnsEnabled = (response.data.installCheck === 1 || response.data.installCheck === '1' || response.data.installCheck === true);
+                if (response.data.dnsMode) {
+                    $scope.dnsMode = response.data.dnsMode;
                 }
-
+                $scope.modeChange();
                 $scope.slaveIPData = response.data.slaveIPData;
 
             } else {
@@ -88,7 +89,7 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
 
         if (service === 'powerdns') {
             var data = {
-                status: pdnsStatus,
+                status: !!$scope.pdnsEnabled,
                 service: service,
                 dnsMode: $scope.dnsMode,
                 slaveServerNS: $scope.slaveServerNS,
@@ -102,7 +103,7 @@ app.controller('powerDNS', function ($scope, $http, $timeout, $window) {
             };
         } else {
             var data = {
-                status: pdnsStatus,
+                status: !!$scope.pdnsEnabled,
                 service: service
             };
         }

--- a/static/serverStatus/serverStatus.js
+++ b/static/serverStatus/serverStatus.js
@@ -1043,11 +1043,31 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
 
     $scope.currentPage = 1;
     $scope.recordsToShow = 10;
+    $scope.currentTab = 'upgrade';
     var globalType;
+    var packageCache = {};
+    var activeFetch = null;
 
-    $scope.fetchPackages = function (type = 'installed') {
-        $scope.cyberpanelLoading = false;
+    $scope.fetchPackages = function (type) {
+        if (typeof type === 'undefined' || type === null || type === '') {
+            type = 'installed';
+        }
+        $scope.currentTab = type;
         globalType = type;
+
+        // Serve cached tab data instantly (All Packages is expensive)
+        var cacheKey = type + '|' + $scope.currentPage + '|' + $scope.recordsToShow;
+        if (packageCache[cacheKey]) {
+            var cached = packageCache[cacheKey];
+            $scope.allPackages = cached.allPackages;
+            $scope.pagination = cached.pagination;
+            $scope.fetchedPackages = cached.fetchedPackages;
+            $scope.totalPackages = cached.totalPackages;
+            $scope.cyberpanelLoading = true;
+            return;
+        }
+
+        $scope.cyberpanelLoading = false;
         var config = {
             headers: {
                 'X-CSRFToken': getCookie('csrftoken')
@@ -1061,16 +1081,27 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
         };
 
         dataurl = "/serverstatus/fetchPackages";
+        var fetchToken = {};
+        activeFetch = fetchToken;
 
         $http.post(dataurl, data, config).then(ListInitialData, cantLoadInitialData);
 
         function ListInitialData(response) {
+            if (activeFetch !== fetchToken) {
+                return; // stale response from another tab
+            }
             $scope.cyberpanelLoading = true;
             if (response.data.status === 1) {
                 $scope.allPackages = JSON.parse(response.data.packages);
                 $scope.pagination = response.data.pagination;
                 $scope.fetchedPackages = response.data.fetchedPackages;
                 $scope.totalPackages = response.data.totalPackages;
+                packageCache[cacheKey] = {
+                    allPackages: $scope.allPackages,
+                    pagination: $scope.pagination,
+                    fetchedPackages: $scope.fetchedPackages,
+                    totalPackages: $scope.totalPackages
+                };
             } else {
                 new PNotify({
                     title: 'Error!',
@@ -1081,6 +1112,9 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
         }
 
         function cantLoadInitialData(response) {
+            if (activeFetch !== fetchToken) {
+                return;
+            }
             $scope.cyberpanelLoading = true;
             new PNotify({
                 title: 'Operation Failed!',
@@ -1091,6 +1125,7 @@ app.controller('listOSPackages', function ($scope, $http, $timeout) {
 
 
     };
+    // Available Updates first; All Packages loads only when that tab is selected
     $scope.fetchPackages('upgrade');
 
     $scope.fetchPackageDetails = function (packageFetch) {

--- a/static/webmail/webmail.css
+++ b/static/webmail/webmail.css
@@ -650,10 +650,19 @@ button.wm-nav-link.wm-nav-btn:focus {
 }
 
 .wm-msg-row.unread {
-    font-weight: 600;
+    font-weight: 700;
+    border-left: 3px solid var(--primary-color, #6c5ce7);
+    background: rgba(108, 92, 231, 0.06);
+    padding-left: 9px;
 }
 
 .wm-msg-row.unread .wm-msg-subject {
+    color: var(--primary-color, #6c5ce7);
+    font-weight: 700;
+}
+
+.wm-msg-row.unread .wm-msg-from {
+    font-weight: 700;
     color: var(--text-primary);
 }
 

--- a/static/websiteFunctions/websiteFunctions.js
+++ b/static/websiteFunctions/websiteFunctions.js
@@ -2867,6 +2867,55 @@ app.controller('listWebsites', function ($scope, $http, $window) {
 
     $scope.convertingToChild = {};
 
+    $scope.recreatingDNS = {};
+    $scope.recreateWebsiteDNS = function (domain) {
+        if (!domain) {
+            return;
+        }
+        if (!$window.confirm(
+            'Recreate DNS for ' + domain + ' (and its child domains)?\n\n' +
+            'This repairs local PowerDNS (including wrong A records), upserts SPF, and syncs to Cloudflare when enabled. '
+            + 'If Cloudflare is pending nameservers, set those NS at your registrar (DNSSEC off). Custom records are kept.'
+        )) {
+            return;
+        }
+        $scope.recreatingDNS[domain] = true;
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+        $http.post('/websites/recreateWebsiteDNS', {
+            domainName: domain,
+            includeChildren: true
+        }, config).then(function (response) {
+            $scope.recreatingDNS[domain] = false;
+            if (response.data.status === 1) {
+                var cf = response.data.cloudflare || {};
+                var pending = cf.zone_status && cf.zone_status !== 'active';
+                new PNotify({
+                    title: pending ? 'DNS updated (Cloudflare pending)' : 'Success',
+                    text: response.data.success_message || 'DNS recreated.',
+                    type: pending ? 'warning' : 'success',
+                    delay: pending ? 15000 : 5000
+                });
+            } else {
+                new PNotify({
+                    title: 'Error',
+                    text: response.data.error_message || 'DNS recreate failed.',
+                    type: 'error'
+                });
+            }
+        }, function () {
+            $scope.recreatingDNS[domain] = false;
+            new PNotify({
+                title: 'Error',
+                text: 'Could not connect to server.',
+                type: 'error'
+            });
+        });
+    };
+
     $scope.convertToChildDomain = function(web) {
         if (!web || !web.canConvertToChild) {
             return;
@@ -2917,11 +2966,20 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            // Retry briefly if session/CSRF cookies are still settling after login
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -2943,18 +3001,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);
@@ -6267,6 +6326,55 @@ app.controller('listWebsites', function ($scope, $http, $window) {
 
     $scope.convertingToChild = {};
 
+    $scope.recreatingDNS = {};
+    $scope.recreateWebsiteDNS = function (domain) {
+        if (!domain) {
+            return;
+        }
+        if (!$window.confirm(
+            'Recreate DNS for ' + domain + ' (and its child domains)?\n\n' +
+            'This repairs local PowerDNS (including wrong A records), upserts SPF, and syncs to Cloudflare when enabled. '
+            + 'If Cloudflare is pending nameservers, set those NS at your registrar (DNSSEC off). Custom records are kept.'
+        )) {
+            return;
+        }
+        $scope.recreatingDNS[domain] = true;
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+        $http.post('/websites/recreateWebsiteDNS', {
+            domainName: domain,
+            includeChildren: true
+        }, config).then(function (response) {
+            $scope.recreatingDNS[domain] = false;
+            if (response.data.status === 1) {
+                var cf = response.data.cloudflare || {};
+                var pending = cf.zone_status && cf.zone_status !== 'active';
+                new PNotify({
+                    title: pending ? 'DNS updated (Cloudflare pending)' : 'Success',
+                    text: response.data.success_message || 'DNS recreated.',
+                    type: pending ? 'warning' : 'success',
+                    delay: pending ? 15000 : 5000
+                });
+            } else {
+                new PNotify({
+                    title: 'Error',
+                    text: response.data.error_message || 'DNS recreate failed.',
+                    type: 'error'
+                });
+            }
+        }, function () {
+            $scope.recreatingDNS[domain] = false;
+            new PNotify({
+                title: 'Error',
+                text: 'Could not connect to server.',
+                type: 'error'
+            });
+        });
+    };
+
     $scope.convertToChildDomain = function(web) {
         if (!web || !web.canConvertToChild) {
             return;
@@ -6317,11 +6425,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -6343,18 +6459,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);
@@ -10026,6 +10143,55 @@ app.controller('listWebsites', function ($scope, $http, $window) {
 
     $scope.convertingToChild = {};
 
+    $scope.recreatingDNS = {};
+    $scope.recreateWebsiteDNS = function (domain) {
+        if (!domain) {
+            return;
+        }
+        if (!$window.confirm(
+            'Recreate DNS for ' + domain + ' (and its child domains)?\n\n' +
+            'This repairs local PowerDNS (including wrong A records), upserts SPF, and syncs to Cloudflare when enabled. '
+            + 'If Cloudflare is pending nameservers, set those NS at your registrar (DNSSEC off). Custom records are kept.'
+        )) {
+            return;
+        }
+        $scope.recreatingDNS[domain] = true;
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+        $http.post('/websites/recreateWebsiteDNS', {
+            domainName: domain,
+            includeChildren: true
+        }, config).then(function (response) {
+            $scope.recreatingDNS[domain] = false;
+            if (response.data.status === 1) {
+                var cf = response.data.cloudflare || {};
+                var pending = cf.zone_status && cf.zone_status !== 'active';
+                new PNotify({
+                    title: pending ? 'DNS updated (Cloudflare pending)' : 'Success',
+                    text: response.data.success_message || 'DNS recreated.',
+                    type: pending ? 'warning' : 'success',
+                    delay: pending ? 15000 : 5000
+                });
+            } else {
+                new PNotify({
+                    title: 'Error',
+                    text: response.data.error_message || 'DNS recreate failed.',
+                    type: 'error'
+                });
+            }
+        }, function () {
+            $scope.recreatingDNS[domain] = false;
+            new PNotify({
+                title: 'Error',
+                text: 'Could not connect to server.',
+                type: 'error'
+            });
+        });
+    };
+
     $scope.convertToChildDomain = function(web) {
         if (!web || !web.canConvertToChild) {
             return;
@@ -10076,11 +10242,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -10102,18 +10276,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);
@@ -11397,6 +11572,56 @@ app.controller('websitePages', function ($scope, $http, $timeout, $window) {
             }
         }, function () {
             $scope.convertingToChild = false;
+            new PNotify({
+                title: 'Error',
+                text: 'Could not connect to server.',
+                type: 'error'
+            });
+        });
+    };
+
+    $scope.recreatingDNS = false;
+    $scope.recreateWebsiteDNS = function () {
+        var domain = $("#domainNamePage").text();
+        if (!domain) {
+            return;
+        }
+        if (!$window.confirm(
+            'Recreate DNS for ' + domain + ' (and its child domains)?\n\n' +
+            'This repairs local PowerDNS (including wrong A records), upserts SPF, and syncs to Cloudflare when enabled. '
+            + 'If Cloudflare is pending nameservers, set those NS at your registrar (DNSSEC off). Custom records are kept.'
+        )) {
+            return;
+        }
+        $scope.recreatingDNS = true;
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+        $http.post('/websites/recreateWebsiteDNS', {
+            domainName: domain,
+            includeChildren: true
+        }, config).then(function (response) {
+            $scope.recreatingDNS = false;
+            if (response.data.status === 1) {
+                var cf = response.data.cloudflare || {};
+                var pending = cf.zone_status && cf.zone_status !== 'active';
+                new PNotify({
+                    title: pending ? 'DNS updated (Cloudflare pending)' : 'Success',
+                    text: response.data.success_message || 'DNS recreated.',
+                    type: pending ? 'warning' : 'success',
+                    delay: pending ? 15000 : 5000
+                });
+            } else {
+                new PNotify({
+                    title: 'Error',
+                    text: response.data.error_message || 'DNS recreate failed.',
+                    type: 'error'
+                });
+            }
+        }, function () {
+            $scope.recreatingDNS = false;
             new PNotify({
                 title: 'Error',
                 text: 'Could not connect to server.',
@@ -18418,6 +18643,59 @@ app.controller('launchChild', function ($scope, $http) {
             $scope.installMagentoURL = "/websites/" + $scope.childDomainName + "/installMagento";
         }
     });
+
+    $scope.recreatingDNS = false;
+    $scope.recreateWebsiteDNS = function () {
+        var domain = $scope.childDomainName || '';
+        if (!domain && document.getElementById('childDomain')) {
+            domain = document.getElementById('childDomain').textContent.trim();
+        }
+        if (!domain) {
+            return;
+        }
+        if (!window.confirm(
+            'Recreate DNS for ' + domain + '?\n\n' +
+            'This repairs local PowerDNS (including wrong A records), upserts SPF, and syncs to Cloudflare when enabled. '
+            + 'If Cloudflare is pending nameservers, set those NS at your registrar (DNSSEC off). Custom records are kept.'
+        )) {
+            return;
+        }
+        $scope.recreatingDNS = true;
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+        $http.post('/websites/recreateWebsiteDNS', {
+            domainName: domain,
+            includeChildren: false
+        }, config).then(function (response) {
+            $scope.recreatingDNS = false;
+            if (response.data.status === 1) {
+                var cf = response.data.cloudflare || {};
+                var pending = cf.zone_status && cf.zone_status !== 'active';
+                new PNotify({
+                    title: pending ? 'DNS updated (Cloudflare pending)' : 'Success',
+                    text: response.data.success_message || 'DNS recreated.',
+                    type: pending ? 'warning' : 'success',
+                    delay: pending ? 15000 : 5000
+                });
+            } else {
+                new PNotify({
+                    title: 'Error',
+                    text: response.data.error_message || 'DNS recreate failed.',
+                    type: 'error'
+                });
+            }
+        }, function () {
+            $scope.recreatingDNS = false;
+            new PNotify({
+                title: 'Error',
+                text: 'Could not connect to server.',
+                type: 'error'
+            });
+        });
+    };
 
     var logType = 0;
     $scope.pageNumber = 1;

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-{"version":"2.5.5","build":2}
+{"version":"2.5.5","build":3}

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-{"version":"2.5.5","build":1}
+{"version":"2.5.5","build":2}

--- a/webmail/static/webmail/webmail.css
+++ b/webmail/static/webmail/webmail.css
@@ -650,10 +650,19 @@ button.wm-nav-link.wm-nav-btn:focus {
 }
 
 .wm-msg-row.unread {
-    font-weight: 600;
+    font-weight: 700;
+    border-left: 3px solid var(--primary-color, #6c5ce7);
+    background: rgba(108, 92, 231, 0.06);
+    padding-left: 9px;
 }
 
 .wm-msg-row.unread .wm-msg-subject {
+    color: var(--primary-color, #6c5ce7);
+    font-weight: 700;
+}
+
+.wm-msg-row.unread .wm-msg-from {
+    font-weight: 700;
     color: var(--text-primary);
 }
 

--- a/webmail/templates/webmail/index.html
+++ b/webmail/templates/webmail/index.html
@@ -6,9 +6,10 @@
 
 <link rel="stylesheet" href="{% static 'webmail/webmail.css' %}">
 
-<div class="webmail-container" ng-controller="webmailCtrl" ng-init="init()">
+<div class="webmail-container" ng-controller="webmailCtrl" ng-init="init()" ng-cloak>
 
-    <div id="cybermailBanner" style="display:none;flex-shrink:0;">
+    {% if not cosmetic.HidePromotions %}
+<div id="cybermailBanner" style="display:none;flex-shrink:0;">
       <div style="padding:10px 20px;display:flex;align-items:center;gap:14px;background:linear-gradient(135deg,#4f46e5 0%,#7c3aed 50%,#9333ea 100%);">
         <div style="flex-shrink:0;font-size:22px;">&#9993;</div>
         <div style="flex:1;min-width:0;font-size:12.5px;color:rgba(255,255,255,0.85);">
@@ -22,8 +23,8 @@
     (function(){if(!document.cookie.includes('cybermail_dismiss=1')){document.getElementById('cybermailBanner').style.display='';}})();
     function dismissCyberMailBanner(){document.getElementById('cybermailBanner').style.display='none';document.cookie='cybermail_dismiss=1; path=/; max-age='+7*86400;}
     </script>
-
-    <!-- Account Switcher Bar -->
+{% endif %}
+<!-- Account Switcher Bar -->
     <div class="wm-account-bar" ng-show="managedAccounts.length > 1">
         <div class="wm-account-current">
             <i class="fa fa-envelope"></i>

--- a/websiteFunctions/static/websiteFunctions/websiteFunctions.js
+++ b/websiteFunctions/static/websiteFunctions/websiteFunctions.js
@@ -2966,11 +2966,20 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            // Retry briefly if session/CSRF cookies are still settling after login
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -2992,18 +3001,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);
@@ -6415,11 +6425,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -6441,18 +6459,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);
@@ -10223,11 +10242,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
     };
 
     // Initial fetch of websites
+    var _listWebsitesFetchAttempts = 0;
     $scope.getFurtherWebsitesFromDB = function () {
         $scope.loading = true; // Set loading to true when starting fetch
+        var csrf = getCookie('csrftoken');
+        if (!csrf && _listWebsitesFetchAttempts < 10) {
+            _listWebsitesFetchAttempts += 1;
+            setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 150);
+            return;
+        }
+        _listWebsitesFetchAttempts = 0;
         var config = {
             headers: {
-                'X-CSRFToken': getCookie('csrftoken')
+                'X-CSRFToken': csrf || ''
             }
         };
 
@@ -10249,18 +10276,19 @@ app.controller('listWebsites', function ($scope, $http, $window) {
                 }
             } else {
                 $("#listFail").fadeIn();
-                $scope.errorMessage = response.data.error_message;
+                $scope.errorMessage = response.data.error_message || response.data.errorMessage;
             }
             $scope.loading = false; // Set loading to false when done
         }).catch(function(error) {
             $("#listFail").fadeIn();
-            $scope.errorMessage = error.message || 'An error occurred while fetching websites';
+            var body = (error && error.data) ? error.data : {};
+            $scope.errorMessage = body.error_message || body.errorMessage || error.message || 'An error occurred while fetching websites';
             $scope.loading = false; // Set loading to false on error
         });
     };
 
-    // Call it immediately
-    $scope.getFurtherWebsitesFromDB();
+    // Call after tick so CSRF seed / cookies are available
+    setTimeout(function () { $scope.$applyAsync(function () { $scope.getFurtherWebsitesFromDB(); }); }, 0);
 
     $scope.showWPSites = function(domain) {
         console.log('showWPSites called for domain:', domain);


### PR DESCRIPTION
## Summary

This PR syncs **master3395/cyberpanel `v2.5.5-dev`** into **usmannasir/cyberpanel `v2.5.5-dev`**.

It carries the latest fork UI and firewall work that is not yet on upstream, and the description below also documents **what the whole `v2.5.5-dev` line adds versus `v2.4.9`** (stable/dev 2.4.x) so reviewers can see the full picture.

**Head:** `master3395:v2.5.5-dev`  
**Base:** `usmannasir:v2.5.5-dev`  
**Author:** master3395

---

## What this PR adds on top of current upstream `v2.5.5-dev`

These commits are unique to the fork tip (not yet in upstream):

1. **Hide promotional content gaps** – Honor Design → Hide promotional content on dashboard Build Services cards, site workspace nudge, backup notification, email hub banner, and all CyberMail promo strips; restore emailMarketing JS load; SSH Trusted IPs APIs (`/base/sshSecurityWhitelist*`).
2. **Sidebar search** – Search box under IP/uptime for features + websites/subdomains (shares Ctrl+K index).
3. **Firewall rules when OFF** – Rules table stays visible while firewall is stopped (was hidden by `rulesDetails`).
4. **Faster managePHP** – Filesystem PHP detection instead of slow `yum list` on every page; lighter `editPHPConfigs` scripts; cached extension list.
5. **Firewall status color** – Green **ON** / red **OFF** (`fw-status-on` / `fw-status-off`); reload rules after Start/Stop/Reload.
6. **Firewall rule reorder** – Drag/drop + up/down; display IDs `#1…n`; persisted `sortOrder` + `POST /firewall/reorderRules`.
7. **Delete confirmations** – Confirm before delete on firewall rules, banned IPs (unban/delete), and SSH trusted IPs (PNotify + fallback).
8. **Fluid viewport scaling** – Shared `clamp()` root font / sidebar / content tokens so the panel is readable at 100% zoom and scales with device size.

---

## `v2.5.5-dev` vs `v2.4.9`: features and fixes (line overview)

Compared with the **2.4.9** line, **v2.5.5-dev** is the modern panel generation (hub navigation, dark theme stack, Build Services, and ongoing 2.5.5 work). Highlights from the 2.5.5-dev changelog and fork work:

### Navigation, UX, and Design
- Flat Hosting / Account / Administration / Help sidebar + category hub pages (Email, Databases & FTP, Backups, Users & Plans, Server, Security, Settings).
- Dark / light theme with design tokens; File Manager dark modal and logo fixes.
- **Hide promotional content** (Design setting) for self-hosters: Build Services / HIRE US, promo notifications, CyberMail banners when enabled.
- Sidebar **Search features & sites** (plus Ctrl+K command palette).
- Fluid UI scaling for readable 100% zoom.
- List Domains / Full Settings / List Websites / WP list: card layouts, unclipped selects, mobile-friendly cards, full PHP patch display, PHP selection heal vs live OLS handler.
- Log source dropdown on Server Log viewers; quieter OLS gzip WARN noise in Error Logs.

### Websites, DNS, SSL, Cloudflare
- **Recreate DNS** (UI + API + CLI) with PowerDNS repair, SPF upsert, Cloudflare sync / activation guidance.
- SPF follows deployment type (CyberPersons vs self-hosted).
- DNS/Cloudflare lifecycle fixes (parent zone walk, scoped deletes, NATIVE SOA serial, alias/child cleanup).
- Sensitive web file denials (`.env`, `.git`, etc.) in vhost templates (#1859).
- Issue SSL no longer fails on `python-cloudflare` 2.20 deprecation warning text.
- Domain alias create/ACL/SSL persistence fixes (incl. 2.4.9 ports).

### Backups and PHP
- Backup tar readiness / remote transfer wait (#1855, #1856); abort on mysqldump failure (#1823).
- PHP Basic UI no longer corrupts `max_memory_limit` (#1784).
- managePHP install/edit pages much faster (no full `yum list` on every render).
- PHP 8.5 map / full patch version on List Websites.

### Mail and webmail
- Sieve install-first guard (#1733).
- Email list disk usage badge; forwarding UI spinner fix; dark mode email pages.
- SnappyMail data-dir permissions helpers; UI static sync on upgrade.
- CyberMail / Email Delivery surfaces respect Hide promotions.

### Firewall and security hub
- Firewall Rules visible when OFF; green ON status; rules reload after Start.
- Drag/drop + up/down rule order with renumbered IDs.
- Confirm before delete (rules / banned / trusted IPs).
- SSH Trusted IPs list/add/remove/update APIs wired to whitelist utilities.

### OLS / upgrade / security (ported or 2.5.x)
- CyberPanel-OLS stack updates (core/module) addressing 4xx segfault / CF 520 class issues.
- Upgrade reliability (#1727, #1853); upgrade script HTTP validation (#1835).
- Security ports from 2.4.8/2.4.9: cron quoting, 2FA secret handling, backup ownership, File Manager Fix Permissions, SSL renew `--ecc` + reloadcmd, etc.
- PluginHolder Fail2ban name-collision spam fix.

---

## Test plan

- [ ] Design → enable **Hide promotional content**: no hub Email Delivery banner, no CyberMail strips, no Build Services dashboard cards; sidebar search still works.
- [ ] Firewall OFF: rules table visible; Start → ON is **green**; rules still list; drag/up-down renumbers `#1…n` and survives refresh.
- [ ] Delete rule / unban IP / remove trusted IP: confirmation required; Cancel aborts.
- [ ] Trusted IPs tab: `POST /base/sshSecurityWhitelistList` returns 200 (not 404).
- [ ] `/managephp/installExtensions` and `/managephp/editPHPConfigs` load in ~1s (not multi-second yum stalls).
- [ ] Hard-refresh: sidebar text/forms readable at 100% zoom; dark theme still OK.
- [ ] Spot-check List Websites, Email hub, and SnappyMail after static sync / `lscpd` restart.

## Notes for maintainers

- Fork-only history after merged #1871–#1874 / HidePromotions stack; this PR is intentionally small (firewall + promo gaps + search + PHP speed + scaling).
- DB migration for firewall `sortOrder` runs with Django migrations on upgrade.
- No secrets in this PR. Author: **master3395**.
