### PR TITLE
feat(ui): human-readable sizes and domain/subdomain search

### DIFF
--- a/CyberCP/settings.py
+++ b/CyberCP/settings.py
@@ -138,6 +138,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'baseTemplate.context_processors.version_context',
                 'baseTemplate.context_processors.cosmetic_context',
+                'baseTemplate.context_processors.size_display_unit_context',
             ],
         },
     },

--- a/baseTemplate/context_processors.py
+++ b/baseTemplate/context_processors.py
@@ -192,3 +192,16 @@ def plugin_sidebar_context(request):
         return defaults
     except Exception:
         return defaults
+
+
+def size_display_unit_context(request):
+    """Expose viewing admin's sizeDisplayUnit for JS formatters."""
+    try:
+        if 'userID' not in request.session:
+            return {'sizeDisplayUnit': 'auto'}
+        from loginSystem.models import Administrator
+        from plogical.humanSize import get_admin_size_mode
+        admin = Administrator.objects.get(pk=request.session['userID'])
+        return {'sizeDisplayUnit': get_admin_size_mode(admin)}
+    except Exception:
+        return {'sizeDisplayUnit': 'auto'}

--- a/baseTemplate/static/baseTemplate/custom-js/system-status.js
+++ b/baseTemplate/static/baseTemplate/custom-js/system-status.js
@@ -316,6 +316,11 @@ app.controller('systemStatusInfo', function ($scope, $http, $timeout) {
                 $scope.ramTotalMB = response.data.ramTotalMB;
                 $scope.diskTotalGB = response.data.diskTotalGB;
                 $scope.diskFreeGB = response.data.diskFreeGB;
+                $scope.ramTotalLabel = response.data.ramTotalLabel;
+                $scope.diskTotalLabel = response.data.diskTotalLabel;
+                $scope.diskFreeLabel = response.data.diskFreeLabel;
+                $scope.sizeDisplayUnit = response.data.sizeDisplayUnit || 'auto';
+                try { window.CPSizeDisplayUnit = $scope.sizeDisplayUnit; } catch (e) {}
                 $scope.uptime = response.data.uptime || 'N/A';
                 $scope.uptimeLoaded = true;
             } else {

--- a/baseTemplate/templates/baseTemplate/design.html
+++ b/baseTemplate/templates/baseTemplate/design.html
@@ -222,6 +222,16 @@
                         <p class="page-subtitle" style="margin: 6px 0 0 26px;">{% trans "Removes Build Services / \"Hire Us\" entries and service advertisements from the menu, command palette, and notifications." %}</p>
                     </div>
 
+                    <div class="form-group" style="margin-top: 1.5rem;">
+                        <label class="form-label" for="sizeDisplayUnit">{% trans "Size units" %}</label>
+                        <select id="sizeDisplayUnit" name="sizeDisplayUnit" class="form-select">
+                            <option value="auto" {% if sizeDisplayUnit == 'auto' %}selected{% endif %}>{% trans "Auto (KB / MB / GB / TB)" %}</option>
+                            <option value="MB" {% if sizeDisplayUnit == 'MB' %}selected{% endif %}>{% trans "Always MB" %}</option>
+                            <option value="GB" {% if sizeDisplayUnit == 'GB' %}selected{% endif %}>{% trans "Always GB" %}</option>
+                        </select>
+                        <p class="page-subtitle" style="margin: 6px 0 0;">{% trans "Your preference for disk, bandwidth, and memory labels across the panel." %}</p>
+                    </div>
+
                     <div class="form-group" style="margin-top: 2rem;">
                         <button type="submit" class="btn btn-primary">
                             <i class="fa fa-save"></i> {% trans "Save Changes" %}

--- a/baseTemplate/templates/baseTemplate/homePage.html
+++ b/baseTemplate/templates/baseTemplate/homePage.html
@@ -165,7 +165,8 @@
                 </div>
                 <div class="stat-card-info">
                     <span class="cp-skeleton cp-skeleton-line" ng-if="ramTotalMB === undefined" style="max-width:160px;" aria-hidden="true"></span>
-                    <span ng-if="ramTotalMB !== undefined">You've {$ ramTotalMB $} MB Memory.</span>
+                    <span ng-if="ramTotalLabel !== undefined">You've {$ ramTotalLabel $} Memory.</span>
+                    <span ng-if="ramTotalLabel === undefined && ramTotalMB !== undefined">You've {$ ramTotalMB $} MB Memory.</span>
                 </div>
             </div>
 
@@ -186,7 +187,8 @@
                 </div>
                 <div class="stat-card-info">
                     <span class="cp-skeleton cp-skeleton-line" ng-if="diskFreeGB === undefined" style="max-width:200px;" aria-hidden="true"></span>
-                    <span ng-if="diskFreeGB !== undefined">You've {$ diskFreeGB $} GB remaining out of {$ diskTotalGB $} GB.</span>
+                    <span ng-if="diskFreeLabel !== undefined">You've {$ diskFreeLabel $} remaining out of {$ diskTotalLabel $}.</span>
+                    <span ng-if="diskFreeLabel === undefined && diskFreeGB !== undefined">You've {$ diskFreeGB $} GB remaining out of {$ diskTotalGB $} GB.</span>
                 </div>
             </div>
         </div>

--- a/baseTemplate/templates/baseTemplate/index.html
+++ b/baseTemplate/templates/baseTemplate/index.html
@@ -31,6 +31,7 @@
     </style>
     
     <!-- Core Scripts -->
+    <script>try { window.CPSizeDisplayUnit = "{{ sizeDisplayUnit|default:'auto'|escapejs }}"; } catch (e) {}</script>
     <script src="{% static 'baseTemplate/angularjs.1.6.5.js' %}?v={{ CP_VERSION }}" data-cfasync="false"></script>
     <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
     <!-- Bootstrap JavaScript -->
@@ -465,22 +466,49 @@
             list.forEach(function (row) {
                 var domain = (row && row.domain) ? String(row.domain) : '';
                 if (!domain) { return; }
-                var href = '/websites/' + encodeURIComponent(domain) + '/settings';
+                var master = (row && row.masterDomain) ? String(row.masterDomain) : '';
+                var href;
+                if (master) {
+                    href = '/websites/' + encodeURIComponent(master) + '/' + encodeURIComponent(domain);
+                } else {
+                    href = '/websites/' + encodeURIComponent(domain);
+                }
                 if (seen[href]) { return; }
                 seen[href] = 1;
                 var label = domain;
-                if (row.masterDomain) { label = domain + ' (' + row.masterDomain + ')'; }
-                items.push({label: label, href: href, icon: iconClass, group: groupLabel, target: ''});
+                if (master) { label = domain + ' (' + master + ')'; }
+                var hay = (domain + ' ' + master).toLowerCase();
+                items.push({label: label, href: href, icon: iconClass, group: groupLabel, target: '', hay: hay});
             });
         }
 
-        function ensureSites(done) {
-            if (sitesLoaded || sitesLoading) { if (done) done(); return; }
-            sitesLoading = true;
+        function fetchPagedList(url, page, recordsToShow, headers, acc) {
+            acc = acc || [];
+            var body = JSON.stringify({page: page, recordsToShow: recordsToShow});
+            return fetch(url, {method: 'POST', credentials: 'same-origin', headers: headers, body: body})
+                .then(function (resp) { return resp.json(); })
+                .then(function (data) {
+                    if (!data || data.listWebSiteStatus !== 1) { return acc; }
+                    var rows = [];
+                    try {
+                        rows = (typeof data.data === 'string') ? JSON.parse(data.data) : (data.data || []);
+                    } catch (e) { rows = []; }
+                    if (!Array.isArray(rows)) { rows = []; }
+                    acc = acc.concat(rows);
+                    var pages = data.pagination;
+                    if (Array.isArray(pages) && page < pages.length) {
+                        return fetchPagedList(url, page + 1, recordsToShow, headers, acc);
+                    }
+                    return acc;
+                }).catch(function () { return acc; });
+        }
+
+        function searchRemoteSites(term, done) {
+            term = (term || '').trim();
+            if (!term || term.length < 2) { if (done) done(); return; }
             var csrf = getCookie('csrftoken') || '';
             var headers = {'Content-Type': 'application/json', 'X-CSRFToken': csrf};
-            var bodySites = JSON.stringify({page: 1, recordsToShow: 100});
-            var bodyChild = JSON.stringify({page: 1, recordsToShow: 100});
+            var body = JSON.stringify({patternAdded: term});
             function parseList(resp) {
                 return resp.json().then(function (data) {
                     if (!data || data.listWebSiteStatus !== 1) { return []; }
@@ -490,8 +518,22 @@
                 }).catch(function () { return []; });
             }
             Promise.all([
-                fetch('/websites/fetchWebsitesList', {method: 'POST', credentials: 'same-origin', headers: headers, body: bodySites}).then(parseList),
-                fetch('/websites/fetchChildDomainsMain', {method: 'POST', credentials: 'same-origin', headers: headers, body: bodyChild}).then(parseList)
+                fetch('/websites/searchWebsites', {method: 'POST', credentials: 'same-origin', headers: headers, body: body}).then(parseList),
+                fetch('/websites/searchChilds', {method: 'POST', credentials: 'same-origin', headers: headers, body: body}).then(parseList)
+            ]).then(function (pair) {
+                mergeSiteItems(pair[0], '{% trans "Websites" %}', 'fas fa-globe');
+                mergeSiteItems(pair[1], '{% trans "Subdomains" %}', 'fas fa-diagram-project');
+            }).catch(function () {}).then(function () { if (done) done(); });
+        }
+
+        function ensureSites(done) {
+            if (sitesLoaded || sitesLoading) { if (done) done(); return; }
+            sitesLoading = true;
+            var csrf = getCookie('csrftoken') || '';
+            var headers = {'Content-Type': 'application/json', 'X-CSRFToken': csrf};
+            Promise.all([
+                fetchPagedList('/websites/fetchWebsitesList', 1, 100, headers, []),
+                fetchPagedList('/websites/fetchChildDomainsMain', 1, 100, headers, [])
             ]).then(function (pair) {
                 if (!items.length) { buildIndex(); }
                 mergeSiteItems(pair[0], '{% trans "Websites" %}', 'fas fa-globe');
@@ -534,14 +576,22 @@
         function search(term) {
             term = term.trim().toLowerCase();
             if (!term) { filtered = items.slice(0, 8); }
-            else { filtered = items.filter(function (it) { return it.label.toLowerCase().indexOf(term) !== -1 || (it.group || '').toLowerCase().indexOf(term) !== -1; }); }
+            else {
+                filtered = items.filter(function (it) {
+                    var hay = (it.hay || it.label || '').toLowerCase();
+                    return hay.indexOf(term) !== -1 || (it.group || '').toLowerCase().indexOf(term) !== -1;
+                });
+            }
             activeIdx = 0; render();
         }
         function open(initialTerm) {
             if (!items.length) { buildIndex(); }
             overlay.hidden = false;
             input.value = initialTerm || '';
-            ensureSites(function () { search(input.value); });
+            ensureSites(function () {
+                searchRemoteSites(input.value, function () { search(input.value); });
+                search(input.value);
+            });
             search(input.value);
             setTimeout(function () { input.focus(); }, 10);
             document.addEventListener('keydown', onKey, true);
@@ -557,7 +607,8 @@
             if (!term) { out = items.slice(0, limit || 8); }
             else {
                 out = items.filter(function (it) {
-                    return it.label.toLowerCase().indexOf(term) !== -1 || (it.group || '').toLowerCase().indexOf(term) !== -1;
+                    var hay = (it.hay || it.label || '').toLowerCase();
+                    return hay.indexOf(term) !== -1 || (it.group || '').toLowerCase().indexOf(term) !== -1;
                 });
                 if (limit) { out = out.slice(0, limit); }
             }
@@ -568,6 +619,7 @@
             close: close,
             ensureIndex: function () { if (!items.length) buildIndex(); },
             ensureSites: ensureSites,
+            searchRemoteSites: searchRemoteSites,
             query: queryItems,
             go: function (it) {
                 if (!it) { return; }
@@ -598,7 +650,11 @@
             results = document.getElementById('cp-cmdk-results');
             emptyEl = document.getElementById('cp-cmdk-empty');
             if (!overlay) { return; }
-            input.addEventListener('input', function () { search(input.value); });
+            input.addEventListener('input', function () {
+                var t = input.value;
+                search(t);
+                searchRemoteSites(t, function () { search(input.value); });
+            });
             overlay.addEventListener('click', function (e) { if (e.target === overlay) { close(); } });
             var trigger = document.getElementById('cp-cmdk-trigger');
             if (trigger) { trigger.addEventListener('click', open); }
@@ -832,6 +888,11 @@
                 if (!window.CPSearch) { return; }
                 window.CPSearch.ensureIndex();
                 window.CPSearch.ensureSites(function () {
+                    if (window.CPSearch.searchRemoteSites) {
+                        window.CPSearch.searchRemoteSites(term, function () {
+                            render(window.CPSearch.query(term, 12));
+                        });
+                    }
                     render(window.CPSearch.query(term, 12));
                 });
                 render(window.CPSearch.query(term, 12));

--- a/baseTemplate/views.py
+++ b/baseTemplate/views.py
@@ -156,8 +156,28 @@ def getSystemStatus(request):
     default_fallback = {
         'cpuUsage': 0, 'ramUsage': 0, 'diskUsage': 0,
         'cpuCores': 2, 'ramTotalMB': 4096, 'diskTotalGB': 100,
-        'diskFreeGB': 100, 'uptime': 'N/A'
+        'diskFreeGB': 100, 'uptime': 'N/A',
+        'sizeDisplayUnit': 'auto', 'ramTotalLabel': '4 096 MB',
+        'diskTotalLabel': '100 GB', 'diskFreeLabel': '100 GB',
     }
+
+    def _annotate_size_labels(payload, admin_obj):
+        from plogical.humanSize import format_mb, get_admin_size_mode
+        mode = get_admin_size_mode(admin_obj)
+        out = dict(payload) if isinstance(payload, dict) else {}
+        out['sizeDisplayUnit'] = mode
+        ram_mb = out.get('ramTotalMB', 0)
+        out['ramTotalLabel'] = format_mb(ram_mb, mode)
+        try:
+            disk_total_gb = float(out.get('diskTotalGB') or 0)
+            disk_free_gb = float(out.get('diskFreeGB') or 0)
+        except (TypeError, ValueError):
+            disk_total_gb = 0
+            disk_free_gb = 0
+        out['diskTotalLabel'] = format_mb(disk_total_gb * 1024.0, mode)
+        out['diskFreeLabel'] = format_mb(disk_free_gb * 1024.0, mode)
+        return out
+
     try:
         val = request.session['userID']
         currentACL = ACLManager.loadedACL(val)
@@ -169,13 +189,13 @@ def getSystemStatus(request):
             cache_key = 'cp_admin_sysstatus'
             cached = cache.get(cache_key)
             if cached is not None:
-                return HttpResponse(json.dumps(cached))
+                return HttpResponse(json.dumps(_annotate_size_labels(cached, admin)))
             HTTPData = SystemInformation.getSystemInformation()
             try:
                 cache.set(cache_key, HTTPData, 45)
             except Exception:
                 pass
-            json_data = json.dumps(HTTPData)
+            json_data = json.dumps(_annotate_size_labels(HTTPData, admin))
             return HttpResponse(json_data)
         else:
             # Non-admin users get user-specific resource information.
@@ -184,7 +204,7 @@ def getSystemStatus(request):
             cache_key = 'cp_user_sysstatus_%s' % val
             cached = cache.get(cache_key)
             if cached is not None:
-                return HttpResponse(json.dumps(cached))
+                return HttpResponse(json.dumps(_annotate_size_labels(cached, admin)))
 
             import subprocess
             import os
@@ -260,7 +280,7 @@ def getSystemStatus(request):
             except Exception:
                 pass
 
-            json_data = json.dumps(user_data)
+            json_data = json.dumps(_annotate_size_labels(user_data, admin))
             return HttpResponse(json_data)
             
     except KeyError as e:
@@ -586,6 +606,14 @@ def design(request):
         cosmetic.MainDashboardCSS = MainDashboardCSS
         cosmetic.HidePromotions = 1 if request.POST.get('HidePromotions') else 0
         cosmetic.save()
+        size_unit = request.POST.get('sizeDisplayUnit', 'auto')
+        try:
+            from loginSystem.models import Administrator
+            from plogical.humanSize import set_admin_size_mode
+            self_admin = Administrator.objects.get(pk=val)
+            set_admin_size_mode(self_admin, size_unit, save=True)
+        except Exception:
+            pass
         finalData['saved'] = 1
 
     ####### Fetch sha...
@@ -606,6 +634,12 @@ def design(request):
 
     template = 'baseTemplate/design.html'
     finalData['cosmetic'] = cosmetic
+    try:
+        from loginSystem.models import Administrator
+        from plogical.humanSize import get_admin_size_mode
+        finalData['sizeDisplayUnit'] = get_admin_size_mode(Administrator.objects.get(pk=val))
+    except Exception:
+        finalData['sizeDisplayUnit'] = 'auto'
 
     proc = httpProc(request, template, finalData, 'versionManagement')
     return proc.render()

--- a/plogical/acl.py
+++ b/plogical/acl.py
@@ -673,7 +673,7 @@ class ACLManager:
     def searchWebsiteObjects(currentACL, userID, searchTerm):
         if currentACL['admin'] == 1:
             # Get websites that match the search term
-            websites = Websites.objects.filter(domain__istartswith=searchTerm)
+            websites = Websites.objects.filter(domain__icontains=searchTerm)
             # Get WordPress sites that match the search term
             wp_sites = WPSites.objects.filter(title__icontains=searchTerm)
             # Add WordPress sites' parent websites to the results
@@ -686,7 +686,7 @@ class ACLManager:
             admin = Administrator.objects.get(pk=userID)
 
             # Get websites that match the search term
-            websites = admin.websites_set.filter(domain__istartswith=searchTerm)
+            websites = admin.websites_set.filter(domain__icontains=searchTerm)
             for items in websites:
                 websiteList.append(items)
 
@@ -699,7 +699,7 @@ class ACLManager:
             admins = Administrator.objects.filter(owner=admin.pk)
             for items in admins:
                 # Get websites that match the search term
-                webs = items.websites_set.filter(domain__istartswith=searchTerm)
+                webs = items.websites_set.filter(domain__icontains=searchTerm)
                 for web in webs:
                     if web not in websiteList:
                         websiteList.append(web)

--- a/plogical/humanSize.py
+++ b/plogical/humanSize.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""Human-readable size labels from megabyte values (panel stats)."""
+
+from __future__ import annotations
+
+import json
+
+VALID_SIZE_MODES = ("auto", "MB", "GB")
+SIZE_DISPLAY_UNIT_KEY = "sizeDisplayUnit"
+
+
+def normalize_size_mode(mode):
+    if mode is None:
+        return "auto"
+    m = str(mode).strip()
+    if m.lower() == "auto":
+        return "auto"
+    if m.upper() == "MB":
+        return "MB"
+    if m.upper() == "GB":
+        return "GB"
+    return "auto"
+
+
+def group_int(n):
+    """Space-grouped integer digits, e.g. 47914 -> '47 914'."""
+    try:
+        n = int(round(float(n)))
+    except (TypeError, ValueError):
+        return "0"
+    sign = "-" if n < 0 else ""
+    s = str(abs(n))
+    parts = []
+    while s:
+        parts.append(s[-3:])
+        s = s[:-3]
+    return sign + " ".join(reversed(parts))
+
+
+def _to_mb_float(value):
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def format_mb(value, mode="auto"):
+    """
+    Format a size that is measured in megabytes.
+
+    mode:
+      auto - pick KB/MB/GB/TB
+      MB   - always megabytes with thousands grouping
+      GB   - always gigabytes
+    """
+    mode = normalize_size_mode(mode)
+    mb = _to_mb_float(value)
+    if mb < 0:
+        mb = 0.0
+
+    if mode == "MB":
+        return "%s MB" % group_int(mb)
+
+    if mode == "GB":
+        gb = mb / 1024.0
+        if abs(gb - round(gb)) < 0.005 and abs(gb) >= 10:
+            return "%s GB" % group_int(round(gb))
+        return "%.2f GB" % gb
+
+    # auto
+    bytes_val = mb * 1024.0 * 1024.0
+    if bytes_val >= 1024.0 ** 4:
+        return "%.2f TB" % (bytes_val / (1024.0 ** 4))
+    if bytes_val >= 1024.0 ** 3:
+        return "%.2f GB" % (bytes_val / (1024.0 ** 3))
+    if bytes_val >= 1024.0 ** 2:
+        # Whole MB often for small-ish values; group if large
+        if mb >= 1000:
+            return "%s MB" % group_int(mb)
+        if abs(mb - round(mb)) < 0.005:
+            return "%s MB" % group_int(round(mb))
+        return "%.2f MB" % mb
+    if bytes_val >= 1024.0:
+        return "%.1f KB" % (bytes_val / 1024.0)
+    return "%s B" % group_int(bytes_val)
+
+
+def format_quota_mb(value, mode="auto"):
+    """Quota in MB; 0 / empty means Unlimited."""
+    if value is None:
+        return "Unlimited"
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "Unlimited"
+    if v <= 0:
+        return "Unlimited"
+    return format_mb(v, mode)
+
+
+def get_admin_size_mode(admin):
+    """Read sizeDisplayUnit from Administrator.config JSON."""
+    if admin is None:
+        return "auto"
+    raw = getattr(admin, "config", None) or ""
+    if not raw or raw in ("None", "{}"):
+        return "auto"
+    try:
+        cfg = json.loads(raw) if isinstance(raw, str) else raw
+        if not isinstance(cfg, dict):
+            return "auto"
+        return normalize_size_mode(cfg.get(SIZE_DISPLAY_UNIT_KEY, "auto"))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return "auto"
+
+
+def set_admin_size_mode(admin, mode, save=True):
+    """Write sizeDisplayUnit into Administrator.config. Returns normalized mode."""
+    mode = normalize_size_mode(mode)
+    raw = getattr(admin, "config", None) or ""
+    cfg = {}
+    if raw and raw not in ("None",):
+        try:
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+            if isinstance(parsed, dict):
+                cfg = parsed
+        except (TypeError, ValueError, json.JSONDecodeError):
+            cfg = {}
+    cfg[SIZE_DISPLAY_UNIT_KEY] = mode
+    admin.config = json.dumps(cfg)
+    if save:
+        admin.save()
+    return mode
+
+
+def size_mode_for_request(request):
+    """Session viewing admin's size preference."""
+    try:
+        from loginSystem.models import Administrator
+        user_id = request.session.get("userID")
+        if not user_id:
+            return "auto"
+        admin = Administrator.objects.get(pk=user_id)
+        return get_admin_size_mode(admin)
+    except Exception:
+        return "auto"

--- a/public/static/baseTemplate/custom-js/system-status.js
+++ b/public/static/baseTemplate/custom-js/system-status.js
@@ -316,6 +316,11 @@ app.controller('systemStatusInfo', function ($scope, $http, $timeout) {
                 $scope.ramTotalMB = response.data.ramTotalMB;
                 $scope.diskTotalGB = response.data.diskTotalGB;
                 $scope.diskFreeGB = response.data.diskFreeGB;
+                $scope.ramTotalLabel = response.data.ramTotalLabel;
+                $scope.diskTotalLabel = response.data.diskTotalLabel;
+                $scope.diskFreeLabel = response.data.diskFreeLabel;
+                $scope.sizeDisplayUnit = response.data.sizeDisplayUnit || 'auto';
+                try { window.CPSizeDisplayUnit = $scope.sizeDisplayUnit; } catch (e) {}
                 $scope.uptime = response.data.uptime || 'N/A';
                 $scope.uptimeLoaded = true;
             } else {

--- a/public/static/userManagment/userManagment.js
+++ b/public/static/userManagment/userManagment.js
@@ -482,6 +482,7 @@ app.controller('modifyUser', function ($scope, $http, $timeout) {
                 $scope.email = userDetails.email;
                 $scope.securityLevel = userDetails.securityLevel;
                 $scope.currentSecurityLevel = userDetails.securityLevel;
+                $scope.sizeDisplayUnit = userDetails.sizeDisplayUnit || 'auto';
                 $scope.twofa = Boolean(userDetails.twofa);
                 
                 // Format secret key with spaces for better readability
@@ -596,7 +597,8 @@ app.controller('modifyUser', function ($scope, $http, $timeout) {
             lastName: lastName,
             email: email,
             securityLevel: $scope.securityLevel,
-            twofa: $scope.twofa
+            twofa: $scope.twofa,
+            sizeDisplayUnit: $scope.sizeDisplayUnit || 'auto'
         };
         if ($scope.newUserName && String($scope.newUserName).trim()) {
             data.newUserName = String($scope.newUserName).trim();

--- a/public/static/websiteFunctions/websiteFunctions.js
+++ b/public/static/websiteFunctions/websiteFunctions.js
@@ -2755,21 +2755,57 @@ $("#listFail").hide();
 
 app.controller('listWebsites', function ($scope, $http, $window) {
 
+    function groupInt(n) {
+        n = Math.round(Number(n) || 0);
+        var sign = n < 0 ? '-' : '';
+        var s = String(Math.abs(n));
+        var parts = [];
+        while (s.length > 3) {
+            parts.unshift(s.slice(-3));
+            s = s.slice(0, -3);
+        }
+        if (s) { parts.unshift(s); }
+        return sign + parts.join(' ');
+    }
+
     function formatDiskLabel(val) {
         if (val === null || val === undefined || val === '') {
             return '0 MB';
         }
+        var mode = (window.CPSizeDisplayUnit || 'auto');
         var s = String(val).trim();
+        if (/unlimited/i.test(s)) {
+            return 'Unlimited';
+        }
         if (/^\d+(\.\d+)?\s*(B|KB|MB|GB|TB)$/i.test(s)) {
+            // Already labeled; still apply space + optional regroup for MB mode
+            var pre = s.match(/^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB)$/i);
+            if (pre && mode === 'MB' && /MB/i.test(pre[2])) {
+                return groupInt(parseFloat(pre[1])) + ' MB';
+            }
             return s.replace(/(\d)([A-Za-z])/g, '$1 $2');
         }
         var m = s.match(/^(\d+(?:\.\d+)?)\s*MB$/i);
-        if (!m) {
+        var mb;
+        if (m) {
+            mb = parseFloat(m[1]);
+        } else if (/^\d+(\.\d+)?$/.test(s)) {
+            mb = parseFloat(s);
+        } else {
             return s;
         }
-        var mb = parseFloat(m[1]);
         if (!isFinite(mb) || mb < 0) {
             return '0 MB';
+        }
+        if (mode === 'MB') {
+            return groupInt(mb) + ' MB';
+        }
+        if (mode === 'GB') {
+            var gbFixed = mb / 1024;
+            if (Math.abs(gbFixed - Math.round(gbFixed)) < 0.005 && Math.abs(gbFixed) >= 10) {
+                return groupInt(Math.round(gbFixed)) + ' GB';
+            }
+            return gbFixed.toFixed(2) + ' GB';
         }
         var bytes = mb * 1024 * 1024;
         if (bytes >= 1024 * 1024 * 1024 * 1024) {
@@ -2779,12 +2815,15 @@ app.controller('listWebsites', function ($scope, $http, $window) {
             return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
         }
         if (bytes >= 1024 * 1024) {
-            return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+            if (mb >= 1000) {
+                return groupInt(mb) + ' MB';
+            }
+            return (Math.abs(mb - Math.round(mb)) < 0.005 ? groupInt(Math.round(mb)) : mb.toFixed(2)) + ' MB';
         }
         if (bytes >= 1024) {
             return (bytes / 1024).toFixed(1) + ' KB';
         }
-        return Math.round(bytes) + ' B';
+        return groupInt(bytes) + ' B';
     }
 
     function normalizeWebsiteRow(web) {

--- a/userManagment/static/userManagment/userManagment.js
+++ b/userManagment/static/userManagment/userManagment.js
@@ -482,6 +482,7 @@ app.controller('modifyUser', function ($scope, $http, $timeout) {
                 $scope.email = userDetails.email;
                 $scope.securityLevel = userDetails.securityLevel;
                 $scope.currentSecurityLevel = userDetails.securityLevel;
+                $scope.sizeDisplayUnit = userDetails.sizeDisplayUnit || 'auto';
                 $scope.twofa = Boolean(userDetails.twofa);
                 
                 // Format secret key with spaces for better readability
@@ -596,7 +597,8 @@ app.controller('modifyUser', function ($scope, $http, $timeout) {
             lastName: lastName,
             email: email,
             securityLevel: $scope.securityLevel,
-            twofa: $scope.twofa
+            twofa: $scope.twofa,
+            sizeDisplayUnit: $scope.sizeDisplayUnit || 'auto'
         };
         if ($scope.newUserName && String($scope.newUserName).trim()) {
             data.newUserName = String($scope.newUserName).trim();

--- a/userManagment/templates/userManagment/modifyUser.html
+++ b/userManagment/templates/userManagment/modifyUser.html
@@ -325,6 +325,16 @@
                         </div>
                     </div>
                     <div class="form-group">
+                        <label class="form-label">{% trans "Size units" %}</label>
+                        <select ng-model="sizeDisplayUnit" class="form-control"
+                                ng-init="sizeDisplayUnit = sizeDisplayUnit || 'auto'">
+                            <option value="auto">{% trans "Auto (KB / MB / GB / TB)" %}</option>
+                            <option value="MB">{% trans "Always MB" %}</option>
+                            <option value="GB">{% trans "Always GB" %}</option>
+                        </select>
+                        <p class="help-text">{% trans "How disk, bandwidth, and memory sizes appear for this user in the panel." %}</p>
+                    </div>
+                    <div class="form-group">
                         <label class="form-label">{% trans "Additional Features" %}</label>
                         <div class="checkbox-wrapper">
                             <label>

--- a/userManagment/views.py
+++ b/userManagment/views.py
@@ -492,6 +492,8 @@ def fetchUserDetails(request):
 
                 otpauth = pyotp.totp.TOTP(user.secretKey).provisioning_uri(email, issuer_name="CyberPanel")
 
+                from plogical.humanSize import get_admin_size_mode
+
                 userDetails = {
                     "id": user.id,
                     "firstName": firstName,
@@ -501,7 +503,8 @@ def fetchUserDetails(request):
                     "websitesLimit": websitesLimit,
                     "securityLevel": SecurityLevel(user.securityLevel).name,
                     "otpauth": otpauth,
-                    'twofa': user.twoFA
+                    'twofa': user.twoFA,
+                    "sizeDisplayUnit": get_admin_size_mode(user),
                 }
 
                 data_ret = {'fetchStatus': 1, 'error_message': 'None', "userDetails": userDetails}
@@ -612,6 +615,10 @@ def saveModifications(request):
                 user.securityLevel = secMiddleware.LOW
             else:
                 user.securityLevel = secMiddleware.HIGH
+
+            if isinstance(data, dict) and 'sizeDisplayUnit' in data:
+                from plogical.humanSize import set_admin_size_mode
+                set_admin_size_mode(user, data.get('sizeDisplayUnit'), save=False)
 
             user.save()
 

--- a/websiteFunctions/static/websiteFunctions/websiteFunctions.js
+++ b/websiteFunctions/static/websiteFunctions/websiteFunctions.js
@@ -2755,21 +2755,57 @@ $("#listFail").hide();
 
 app.controller('listWebsites', function ($scope, $http, $window) {
 
+    function groupInt(n) {
+        n = Math.round(Number(n) || 0);
+        var sign = n < 0 ? '-' : '';
+        var s = String(Math.abs(n));
+        var parts = [];
+        while (s.length > 3) {
+            parts.unshift(s.slice(-3));
+            s = s.slice(0, -3);
+        }
+        if (s) { parts.unshift(s); }
+        return sign + parts.join(' ');
+    }
+
     function formatDiskLabel(val) {
         if (val === null || val === undefined || val === '') {
             return '0 MB';
         }
+        var mode = (window.CPSizeDisplayUnit || 'auto');
         var s = String(val).trim();
+        if (/unlimited/i.test(s)) {
+            return 'Unlimited';
+        }
         if (/^\d+(\.\d+)?\s*(B|KB|MB|GB|TB)$/i.test(s)) {
+            // Already labeled; still apply space + optional regroup for MB mode
+            var pre = s.match(/^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB)$/i);
+            if (pre && mode === 'MB' && /MB/i.test(pre[2])) {
+                return groupInt(parseFloat(pre[1])) + ' MB';
+            }
             return s.replace(/(\d)([A-Za-z])/g, '$1 $2');
         }
         var m = s.match(/^(\d+(?:\.\d+)?)\s*MB$/i);
-        if (!m) {
+        var mb;
+        if (m) {
+            mb = parseFloat(m[1]);
+        } else if (/^\d+(\.\d+)?$/.test(s)) {
+            mb = parseFloat(s);
+        } else {
             return s;
         }
-        var mb = parseFloat(m[1]);
         if (!isFinite(mb) || mb < 0) {
             return '0 MB';
+        }
+        if (mode === 'MB') {
+            return groupInt(mb) + ' MB';
+        }
+        if (mode === 'GB') {
+            var gbFixed = mb / 1024;
+            if (Math.abs(gbFixed - Math.round(gbFixed)) < 0.005 && Math.abs(gbFixed) >= 10) {
+                return groupInt(Math.round(gbFixed)) + ' GB';
+            }
+            return gbFixed.toFixed(2) + ' GB';
         }
         var bytes = mb * 1024 * 1024;
         if (bytes >= 1024 * 1024 * 1024 * 1024) {
@@ -2779,12 +2815,15 @@ app.controller('listWebsites', function ($scope, $http, $window) {
             return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
         }
         if (bytes >= 1024 * 1024) {
-            return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+            if (mb >= 1000) {
+                return groupInt(mb) + ' MB';
+            }
+            return (Math.abs(mb - Math.round(mb)) < 0.005 ? groupInt(Math.round(mb)) : mb.toFixed(2)) + ' MB';
         }
         if (bytes >= 1024) {
             return (bytes / 1024).toFixed(1) + ' KB';
         }
-        return Math.round(bytes) + ' B';
+        return groupInt(bytes) + ' B';
     }
 
     function normalizeWebsiteRow(web) {

--- a/websiteFunctions/templates/websiteFunctions/launchChild.html
+++ b/websiteFunctions/templates/websiteFunctions/launchChild.html
@@ -875,11 +875,15 @@
                     <i class="fas fa-hdd"></i>
                 </div>
                 <div class="resource-title">{% trans "Disk Usage" %}</div>
-                <div class="resource-value">{{ diskInMB }} MB</div>
-                <div class="resource-limit">{% trans "of" %} {{ diskInMBTotal }} MB</div>
+                <div class="resource-value">{{ diskUsedLabel|default:diskInMB }}{% if not diskUsedLabel %} MB{% endif %}</div>
+                {% if diskUnlimited or diskInMBTotal == 0 %}
+                <div class="resource-limit">{% trans "Unlimited" %}</div>
+                {% else %}
+                <div class="resource-limit">{% trans "of" %} {{ diskTotalLabel|default:diskInMBTotal }}{% if not diskTotalLabel %} MB{% endif %}</div>
                 <div class="resource-progress">
                     <div class="resource-progress-bar" style="width: {{ diskUsage }}%;"></div>
                 </div>
+                {% endif %}
             </div>
 
             <!-- Bandwidth Card -->
@@ -888,11 +892,15 @@
                     <i class="fas fa-wifi"></i>
                 </div>
                 <div class="resource-title">{% trans "Bandwidth Usage" %}</div>
-                <div class="resource-value">{{ bwInMB }} MB</div>
-                <div class="resource-limit">{% trans "of" %} {{ bwInMBTotal }} MB</div>
+                <div class="resource-value">{{ bwUsedLabel|default:bwInMB }}{% if not bwUsedLabel %} MB{% endif %}</div>
+                {% if bwUnlimited or bwInMBTotal == 0 %}
+                <div class="resource-limit">{% trans "Unlimited" %}</div>
+                {% else %}
+                <div class="resource-limit">{% trans "of" %} {{ bwTotalLabel|default:bwInMBTotal }}{% if not bwTotalLabel %} MB{% endif %}</div>
                 <div class="resource-progress">
                     <div class="resource-progress-bar" style="width: {{ bwUsage }}%;"></div>
                 </div>
+                {% endif %}
             </div>
 
             <!-- Database Card -->

--- a/websiteFunctions/templates/websiteFunctions/listWebsites.html
+++ b/websiteFunctions/templates/websiteFunctions/listWebsites.html
@@ -828,7 +828,7 @@
                                 </span>
                             </div>
                             <div class="row-actions">
-                                <a href="/websites/{$ web.domain $}" class="btn btn-primary btn-sm" title="{% trans 'Manage' %}">
+                                <a ng-href="{$ web.manageUrl || ('/websites/' + web.domain) $}" class="btn btn-primary btn-sm" title="{% trans 'Manage' %}">
                                     Manage
                                 </a>
                                 <button ng-click="recreateWebsiteDNS(web.domain); $event.stopPropagation();"

--- a/websiteFunctions/templates/websiteFunctions/website.html
+++ b/websiteFunctions/templates/websiteFunctions/website.html
@@ -1861,11 +1861,11 @@
                     <i class="fas fa-hdd"></i>
                 </div>
                 <div class="resource-title">{% trans "Disk Usage" %}</div>
-                <div class="resource-value">{{ diskInMB }} MB</div>
-                {% if diskInMBTotal == 0 %}
+                <div class="resource-value">{{ diskUsedLabel|default:diskInMB }}{% if not diskUsedLabel %} MB{% endif %}</div>
+                {% if diskUnlimited or diskInMBTotal == 0 %}
                 <div class="resource-limit">{% trans "Unlimited" %}</div>
                 {% else %}
-                <div class="resource-limit">{% trans "of" %} {{ diskInMBTotal }} MB</div>
+                <div class="resource-limit">{% trans "of" %} {{ diskTotalLabel|default:diskInMBTotal }}{% if not diskTotalLabel %} MB{% endif %}</div>
                 <div class="resource-progress">
                     <div class="resource-progress-bar" style="width: {{ diskUsage }}%;"></div>
                 </div>
@@ -1878,11 +1878,15 @@
                     <i class="fas fa-chart-line"></i>
                 </div>
                 <div class="resource-title">{% trans "Bandwidth" %}</div>
-                <div class="resource-value">{{ bwInMB }} MB</div>
-                <div class="resource-limit">{% trans "of" %} {{ bwInMBTotal }} MB</div>
+                <div class="resource-value">{{ bwUsedLabel|default:bwInMB }}{% if not bwUsedLabel %} MB{% endif %}</div>
+                {% if bwUnlimited or bwInMBTotal == 0 %}
+                <div class="resource-limit">{% trans "Unlimited" %}</div>
+                {% else %}
+                <div class="resource-limit">{% trans "of" %} {{ bwTotalLabel|default:bwInMBTotal }}{% if not bwTotalLabel %} MB{% endif %}</div>
                 <div class="resource-progress">
                     <div class="resource-progress-bar" style="width: {{ bwUsage }}%;"></div>
                 </div>
+                {% endif %}
             </div>
             
             <!-- Database Card -->

--- a/websiteFunctions/website.py
+++ b/websiteFunctions/website.py
@@ -60,6 +60,25 @@ class WebsiteManager:
         self.domain = domain
         self.childDomain = childDomain
 
+    def _resourceSizeLabels(self, userID, disk_mb, disk_total, bw_mb, bw_total):
+        from plogical.humanSize import format_mb, format_quota_mb, get_admin_size_mode
+        from loginSystem.models import Administrator
+        mode = 'auto'
+        try:
+            if userID is not None:
+                mode = get_admin_size_mode(Administrator.objects.get(pk=userID))
+        except BaseException:
+            mode = 'auto'
+        return {
+            'diskUsedLabel': format_mb(disk_mb, mode),
+            'diskTotalLabel': format_quota_mb(disk_total, mode),
+            'bwUsedLabel': format_mb(bw_mb, mode),
+            'bwTotalLabel': format_quota_mb(bw_total, mode),
+            'sizeDisplayUnit': mode,
+            'diskUnlimited': format_quota_mb(disk_total, mode) == 'Unlimited',
+            'bwUnlimited': format_quota_mb(bw_total, mode) == 'Unlimited',
+        }
+
     def createWebsite(self, request=None, userID=None, data=None):
 
         url = "https://platform.cyberpersons.com/CyberpanelAdOns/Adonpermission"
@@ -2429,12 +2448,66 @@ Require valid-user
     def searchWebsites(self, userID=None, data=None):
         try:
             currentACL = ACLManager.loadedACL(userID)
+            pattern = data.get('patternAdded', '') if isinstance(data, dict) else ''
             try:
-                json_data = self.searchWebsitesJson(currentACL, userID, data['patternAdded'])
+                json_data = self.searchWebsitesJson(currentACL, userID, pattern)
             except BaseException as msg:
                 tempData = {}
                 tempData['page'] = 1
                 return self.getFurtherAccounts(userID, tempData)
+
+            # Also include matching child domains so List Websites search finds subdomains.
+            try:
+                master_rows = json.loads(json_data) if isinstance(json_data, str) else (json_data or [])
+            except Exception:
+                master_rows = []
+            if not isinstance(master_rows, list):
+                master_rows = []
+
+            child_rows = []
+            try:
+                websites = ACLManager.findWebsiteObjects(currentACL, userID)
+                seen = set()
+                for web in websites:
+                    qs = web.childdomains_set.filter(domain__icontains=pattern)
+                    for child in qs:
+                        if child.alais == 1:
+                            continue
+                        if child.domain == 'mail.%s' % web.domain:
+                            continue
+                        if child.domain in seen:
+                            continue
+                        seen.add(child.domain)
+                        DiskUsage = 0
+                        try:
+                            DiskUsage, DiskUsagePercentage, bwInMB, bwUsage = virtualHostUtilities.FindStats(child.master)
+                        except Exception:
+                            pass
+                        child_rows.append({
+                            'domain': child.domain,
+                            'masterDomain': child.master.domain,
+                            'adminEmail': child.master.adminEmail,
+                            'ipAddress': master_rows[0]['ipAddress'] if master_rows else '',
+                            'admin': child.master.admin.userName,
+                            'package': child.master.package.packageName,
+                            'state': 'Active' if child.master.state == 1 else 'Suspended',
+                            'diskUsed': '%sMB' % str(DiskUsage),
+                            'phpVersion': child.phpSelection or child.master.phpSelection or '',
+                            'wp_sites': [],
+                            'isChild': 1,
+                            'manageUrl': '/websites/%s/%s' % (child.master.domain, child.domain),
+                        })
+            except Exception as child_err:
+                logging.CyberCPLogFileWriter.writeToFile('searchWebsites child merge: %s' % str(child_err))
+
+            for row in master_rows:
+                if 'isChild' not in row:
+                    row['isChild'] = 0
+                if 'manageUrl' not in row:
+                    row['manageUrl'] = '/websites/%s' % row.get('domain', '')
+
+            merged = master_rows + child_rows
+            json_data = json.dumps(merged)
 
             pagination = self.websitePagination(currentACL, userID)
             final_dic = {'status': 1, 'listWebSiteStatus': 1, 'error_message': "None", "data": json_data,
@@ -2452,9 +2525,11 @@ Require valid-user
 
             websites = ACLManager.findWebsiteObjects(currentACL, userID)
             childDomains = []
+            pattern = data.get('patternAdded', '') if isinstance(data, dict) else ''
 
             for web in websites:
-                for child in web.childdomains_set.filter(domain__istartswith=data['patternAdded']):
+                qs = web.childdomains_set.filter(domain__icontains=pattern)
+                for child in qs:
                     childDomains.append(child)
 
             json_data = self.findChildsListJson(childDomains)
@@ -3678,6 +3753,7 @@ context /cyberpanel_suspension_page.html {
             Data['diskUsage'] = DiskUsagePercentage
             Data['diskInMB'] = DiskUsage
             Data['diskInMBTotal'] = website.package.diskSpace
+            Data.update(self._resourceSizeLabels(userID, DiskUsage, website.package.diskSpace, bwInMB, website.package.bandwidth))
 
             Data['phps'] = PHPManager.findPHPVersions()
             import os
@@ -3950,6 +4026,7 @@ context /cyberpanel_suspension_page.html {
             Data['diskUsage'] = DiskUsagePercentage
             Data['diskInMB'] = DiskUsage
             Data['diskInMBTotal'] = website.package.diskSpace
+            Data.update(self._resourceSizeLabels(userID, DiskUsage, website.package.diskSpace, bwInMB, website.package.bandwidth))
 
             Data['phps'] = PHPManager.findPHPVersions()
 


### PR DESCRIPTION
## Summary

This PR syncs **master3395/cyberpanel `v2.5.5-dev`** into **usmannasir/cyberpanel `v2.5.5-dev`**.

It adds human-readable size labels (with a per-user unit preference) and makes domain/subdomain search find child sites from the sidebar and List Websites. The description below also documents **what the whole `v2.5.5-dev` line adds versus `v2.4.9`** so reviewers can see the full picture.

**Head:** `master3395:v2.5.5-dev`  
**Base:** `usmannasir:v2.5.5-dev`  
**Author:** master3395  
**PR:** https://github.com/usmannasir/cyberpanel/pull/1883

---

## What this PR adds on top of current upstream `v2.5.5-dev`

These commits are unique to the fork tip (not yet in upstream):

1. **Human-readable sizes** – Shared `plogical/humanSize.py` formats disk/bandwidth/memory as KB/MB/GB/TB (`auto`), or forced MB/GB; space between number and unit; thousands grouping (e.g. `47 914 MB`); package quota `0` shows **Unlimited** (not `of 0 MB`).
2. **Per-user size preference** – `Administrator.config` key `sizeDisplayUnit` (`auto` | `MB` | `GB`, default `auto`). Editable on **Modify Users** and **Settings → Design**. Rendering uses the **viewing** admin’s preference.
3. **Website / child / dashboard labels** – Parent and child site pages pass `diskUsedLabel` / `diskTotalLabel` / `bwUsedLabel` / `bwTotalLabel`; dashboard `getSystemStatus` adds `ramTotalLabel` / disk labels; List Websites `formatDiskLabel` respects the same mode.
4. **Sidebar / Cmd-K site search** – Child hrefs use `/websites/{master}/{child}` (not `/settings`); paginated load of all sites/children; remote search via `searchWebsites` / `searchChilds` with `icontains` so `plex` matches `plex.example.com`.
5. **List Websites search includes subdomains** – Merges matching child domains into results with `manageUrl`; ACL master search and `searchChilds` use `domain__icontains`.

Related already on upstream: opaque CPUI modal styles (PR #1882 / `e57d298`).

---

## `v2.5.5-dev` vs `v2.4.9`: features and fixes (line overview)

Compared with the **2.4.9** line, **v2.5.5-dev** is the modern panel generation (hub navigation, dark theme stack, Build Services, and ongoing 2.5.5 work). Highlights from the 2.5.5-dev changelog and fork work:

### Navigation, UX, and Design
- Flat Hosting / Account / Administration / Help sidebar + category hub pages (Email, Databases & FTP, Backups, Users & Plans, Server, Security, Settings).
- Dark / light theme with design tokens; File Manager dark modal and logo fixes.
- **Hide promotional content** (Design setting) for self-hosters: Build Services / HIRE US, promo notifications, CyberMail banners when enabled.
- Sidebar **Search features & sites** (plus Ctrl+K command palette), including correct subdomain URLs and remote `icontains` lookup.
- Fluid UI scaling for readable 100% zoom.
- Human-readable disk / bandwidth / memory labels with per-user Auto / MB / GB preference.
- List Domains / Full Settings / List Websites / WP list: card layouts, unclipped selects, mobile-friendly cards, full PHP patch display, PHP selection heal vs live OLS handler.
- Log source dropdown on Server Log viewers; quieter OLS gzip WARN noise in Error Logs.

### Websites, DNS, SSL, Cloudflare
- **Recreate DNS** (UI + API + CLI) with PowerDNS repair, SPF upsert, Cloudflare sync / activation guidance.
- SPF follows deployment type (CyberPersons vs self-hosted).
- DNS/Cloudflare lifecycle fixes (parent zone walk, scoped deletes, NATIVE SOA serial, alias/child cleanup).
- Sensitive web file denials (`.env`, `.git`, etc.) in vhost templates (#1859).
- Issue SSL no longer fails on `python-cloudflare` 2.20 deprecation warning text.
- Domain alias create/ACL/SSL persistence fixes (incl. 2.4.9 ports).

### Backups and PHP
- Backup tar readiness / remote transfer wait (#1855, #1856); abort on mysqldump failure (#1823).
- PHP Basic UI no longer corrupts `max_memory_limit` (#1784).
- managePHP install/edit pages much faster (no full `yum list` on every render).
- PHP 8.5 map / full patch version on List Websites.

### Mail and webmail
- Sieve install-first guard (#1733).
- Email list disk usage badge; forwarding UI spinner fix; dark mode email pages.
- SnappyMail data-dir permissions helpers; UI static sync on upgrade.
- CyberMail / Email Delivery surfaces respect Hide promotions.

### Firewall and security hub
- Firewall Rules visible when OFF; green ON status; rules reload after Start.
- Drag/drop + up/down rule order with renumbered IDs.
- Confirm before delete (rules / banned / trusted IPs).
- SSH Trusted IPs list/add/remove/update APIs wired to whitelist utilities.

### OLS / upgrade / security (ported or 2.5.x)
- CyberPanel-OLS stack updates (core/module) addressing 4xx segfault / CF 520 class issues.
- Upgrade reliability (#1727, #1853); upgrade script HTTP validation (#1835).
- Security ports from 2.4.8/2.4.9: cron quoting, 2FA secret handling, backup ownership, File Manager Fix Permissions, SSL renew `--ecc` + reloadcmd, etc.
- PluginHolder Fail2ban name-collision spam fix; opaque CPUI modal styles (#1882).

---

## Test plan

### Human-readable sizes
- [ ] Subdomain page (e.g. `/websites/{master}/{child}`): used disk/bandwidth scale in Auto mode (e.g. `114.39 GB`), totals show **Unlimited** when package quota is `0` (not `of 0 MB`).
- [ ] Parent website page: same label rules for disk and bandwidth.
- [ ] Dashboard: memory/disk lines use scaled labels (e.g. `46.79 GB`), not a raw MB digit run like `47914 MB`.
- [ ] Modify Users → **Size units**: set Always MB → save → refresh site/dashboard → labels like `47 914 MB`; Always GB and Auto behave as expected for that user after refresh.
- [ ] Settings → Design → **Size units**: self-pref for the logged-in admin persists and applies without opening Modify Users.
- [ ] List Websites disk column respects the same mode / grouping (`formatDiskLabel`).

### Domain / subdomain search
- [ ] Sidebar search `plex` (or another known child): result appears under Subdomains and opens `/websites/{master}/{child}` (not `/websites/{child}/settings`).
- [ ] Ctrl/Cmd-K command palette finds the same child with the correct URL.
- [ ] List Websites search returns matching subdomains with working Manage links (`manageUrl`).
- [ ] Partial mid-string match works (`icontains`), not only prefix (`istartswith`).

### Smoke (after static sync / `lscpd` restart)
- [ ] Hard-refresh: size labels and search still work; dark theme OK.
- [ ] Spot-check List Websites, Design, and Modify Users after deploy.

## Notes for maintainers

- Unique delta vs current upstream tip is primarily human-size formatting + search fixes (`d5319665` and merge with upstream #1882).
- Preference lives in existing `Administrator.config` JSON (no new DB migration).
- No secrets in this PR. Author: **master3395**.
