### PR TITLE
fix(git): private Git hosts and custom SSH ports (#342)

### DIFF
--- a/plogical/applicationInstaller.py
+++ b/plogical/applicationInstaller.py
@@ -91,6 +91,14 @@ class ApplicationInstaller(multi.Thread):
                 self.UpgradeCP()
             elif self.installApp == 'StartOCRestore':
                 self.StartOCRestore()
+            elif self.installApp == 'git':
+                self.setupGit()
+            elif self.installApp == 'pull':
+                self.gitPull()
+            elif self.installApp == 'detach':
+                self.detachRepo()
+            elif self.installApp == 'changeBranch':
+                self.changeBranch()
 
         except BaseException as msg:
             logging.writeToFile(str(msg) + ' [ApplicationInstaller.run]')
@@ -6852,6 +6860,198 @@ class ApplicationInstaller(multi.Thread):
             statusFile = open(self.tempStatusPath, 'w')
             statusFile.writelines(str(msg) + " [404]")
             statusFile.close()
+            return 0
+
+
+
+    def _writeGitStatus(self, message):
+        try:
+            statusFile = open(self.tempStatusPath, 'w')
+            statusFile.writelines(message)
+            statusFile.close()
+        except BaseException:
+            pass
+
+    def setupGit(self):
+        """Attach a Git repository to a website document root (setupGit UI)."""
+        try:
+            from plogical.gitSSH import build_ssh_remote_url, resolve_provider_host, parse_git_host
+            from plogical.vhost import vhost
+            from plogical import mailUtilities
+
+            tempStatusPath = self.extraArgs['tempStatusPath']
+            self.tempStatusPath = tempStatusPath
+            domainName = self.extraArgs['domainName']
+            username = self.extraArgs['username']
+            reponame = self.extraArgs['reponame']
+            branch = self.extraArgs['branch']
+            admin = self.extraArgs['admin']
+            defaultProvider = self.extraArgs.get('defaultProvider', 'github')
+            customHost = self.extraArgs.get('gitHost', '')
+
+            self._writeGitStatus('Checking if GIT installed..,0')
+            try:
+                ProcessUtilities.outputExecutioner('git --help')
+            except BaseException:
+                self._writeGitStatus('Installing GIT..,0')
+                self.installGit()
+            self._writeGitStatus('GIT successfully installed,20')
+
+            host, err = resolve_provider_host(defaultProvider, customHost)
+            if err:
+                self._writeGitStatus(err + ' [404]')
+                return 0
+            domain_part, port_or_err = parse_git_host(host)
+            if domain_part is None:
+                self._writeGitStatus(str(port_or_err) + ' [404]')
+                return 0
+            if not ACLManager.validateInput(username) or not ACLManager.validateInput(reponame):
+                self._writeGitStatus('Invalid characters in your input. [404]')
+                return 0
+            if not ACLManager.validateInput(branch):
+                self._writeGitStatus('Invalid characters in your input. [404]')
+                return 0
+
+            try:
+                website = ChildDomains.objects.get(domain=domainName)
+                externalApp = website.master.externalApp
+                masterDomain = website.master.domain
+                if admin.type != 1 and website.master.admin != admin:
+                    self._writeGitStatus('You do not own this website. [404]')
+                    return 0
+            except BaseException:
+                website = Websites.objects.get(domain=domainName)
+                externalApp = website.externalApp
+                masterDomain = website.domain
+                if admin.type != 1 and website.admin != admin:
+                    self._writeGitStatus('You do not own this website. [404]')
+                    return 0
+
+            finalPath = '/home/%s/public_html/' % domainName
+            if finalPath.find('..') > -1:
+                self._writeGitStatus('Specified path must be inside virtual host home. [404]')
+                return 0
+
+            self._writeGitStatus('Setting up directories..,20')
+            if not os.path.exists(finalPath):
+                ProcessUtilities.executioner('mkdir -p %s' % finalPath)
+
+            dirFiles = os.listdir(finalPath)
+            if len(dirFiles) == 1 and dirFiles[0] == '.well-known':
+                pass
+            elif len(dirFiles) == 0:
+                pass
+            else:
+                self._writeGitStatus(
+                    'Target directory should be empty before attaching GIT, otherwise data loss could occur. [404]')
+                return 0
+
+            identity = '/home/%s/.ssh/%s' % (masterDomain, externalApp)
+            remote_url = build_ssh_remote_url(host, username, reponame)
+            self._writeGitStatus('Cloning the repo..,40')
+            command = (
+                'GIT_SSH_COMMAND="ssh -i %s -o StrictHostKeyChecking=no" '
+                'git clone --depth 1 --no-single-branch %s -b %s %s'
+            ) % (identity, remote_url, branch, finalPath)
+            result = ProcessUtilities.outputExecutioner(command)
+            if result.find('Permission denied') > -1 or result.find('Could not read from remote') > -1 \
+                    or result.find('fatal:') > -1:
+                self._writeGitStatus(
+                    'Failed to clone repository, make sure you deployed your key to repository. [404]')
+                return 0
+
+            ProcessUtilities.executioner(
+                'chown -R %s:%s %s' % (externalApp, externalApp, finalPath))
+            try:
+                vhost.addRewriteRules(domainName)
+                installUtilities.reStartLiteSpeed()
+            except BaseException as msg:
+                logging.writeToFile(str(msg) + ' [ApplicationInstaller.setupGit.restart]')
+
+            mailUtilities.checkHome()
+            gitPath = '/home/cyberpanel/%s.git' % domainName
+            writeToFile = open(gitPath, 'w')
+            writeToFile.write('%s:%s:%s' % (username, reponame, host))
+            writeToFile.close()
+
+            self._writeGitStatus('GIT Repository successfully attached. [200]')
+            return 0
+        except BaseException as msg:
+            try:
+                os.remove('/home/cyberpanel/%s.git' % self.extraArgs.get('domainName', ''))
+            except BaseException:
+                pass
+            self._writeGitStatus(str(msg) + ' [404]')
+            logging.writeToFile(str(msg) + ' [ApplicationInstaller.setupGit]')
+            return 0
+
+    def gitPull(self):
+        try:
+            domain = self.extraArgs['domain']
+            try:
+                website = ChildDomains.objects.get(domain=domain)
+                externalApp = website.master.externalApp
+                masterDomain = website.master.domain
+            except BaseException:
+                website = Websites.objects.get(domain=domain)
+                externalApp = website.externalApp
+                masterDomain = website.domain
+            identity = '/home/%s/.ssh/%s' % (masterDomain, externalApp)
+            path = '/home/%s/public_html/' % domain
+            command = (
+                'GIT_SSH_COMMAND="ssh -i %s -o StrictHostKeyChecking=no" '
+                'git -C %s pull'
+            ) % (identity, path)
+            ProcessUtilities.outputExecutioner(command, externalApp)
+            ProcessUtilities.executioner('chown -R %s:%s %s' % (externalApp, externalApp, path))
+            return 0
+        except BaseException as msg:
+            logging.writeToFile(str(msg) + ' [ApplicationInstaller.gitPull]')
+            return 0
+
+    def detachRepo(self):
+        try:
+            domainName = self.extraArgs['domainName']
+            try:
+                website = ChildDomains.objects.get(domain=domainName)
+                externalApp = website.master.externalApp
+            except BaseException:
+                website = Websites.objects.get(domain=domainName)
+                externalApp = website.externalApp
+            path = '/home/%s/public_html/' % domainName
+            ProcessUtilities.executioner('rm -rf %s.git' % path.rstrip('/'), externalApp)
+            gitPath = '/home/cyberpanel/%s.git' % domainName
+            if os.path.exists(gitPath):
+                os.remove(gitPath)
+            return 0
+        except BaseException as msg:
+            logging.writeToFile(str(msg) + ' [ApplicationInstaller.detachRepo]')
+            return 0
+
+    def changeBranch(self):
+        try:
+            domainName = self.extraArgs['domainName']
+            branch = self.extraArgs['githubBranch']
+            try:
+                website = ChildDomains.objects.get(domain=domainName)
+                externalApp = website.master.externalApp
+                masterDomain = website.master.domain
+            except BaseException:
+                website = Websites.objects.get(domain=domainName)
+                externalApp = website.externalApp
+                masterDomain = website.domain
+            if not ACLManager.validateInput(branch):
+                return 0
+            identity = '/home/%s/.ssh/%s' % (masterDomain, externalApp)
+            path = '/home/%s/public_html/' % domainName
+            command = (
+                'GIT_SSH_COMMAND="ssh -i %s -o StrictHostKeyChecking=no" '
+                'git -C %s checkout %s'
+            ) % (identity, path, branch)
+            ProcessUtilities.outputExecutioner(command, externalApp)
+            return 0
+        except BaseException as msg:
+            logging.writeToFile(str(msg) + ' [ApplicationInstaller.changeBranch]')
             return 0
 
 

--- a/plogical/gitSSH.py
+++ b/plogical/gitSSH.py
@@ -1,0 +1,110 @@
+#!/usr/local/CyberCP/bin/python
+"""Helpers for CyberPanel Git remotes (custom hosts and non-default SSH ports)."""
+
+from __future__ import print_function
+
+
+def parse_git_host(git_host):
+    """
+    Parse host or host:port.
+
+    Returns (domain, port_or_None) or (None, error_message).
+    """
+    if git_host is None:
+        return None, 'Git host is required.'
+    host = str(git_host).strip()
+    if not host:
+        return None, 'Git host is required.'
+    if host.find('://') > -1:
+        return None, 'Use host or host:port (no URL scheme).'
+    if host.find('/') > -1:
+        return None, 'Invalid characters in Git host.'
+
+    port = None
+    domain = host
+    if host.find(':') > -1:
+        parts = host.rsplit(':', 1)
+        domain = parts[0].strip()
+        try:
+            port = int(parts[1].strip())
+        except (TypeError, ValueError):
+            return None, 'Invalid port in Git host.'
+        if port < 1 or port > 65535:
+            return None, 'Invalid port in Git host.'
+
+    if not domain or domain.find(' ') > -1:
+        return None, 'Invalid Git host.'
+    return domain, port
+
+
+def build_ssh_remote_url(git_host, username, reponame):
+    """
+    Build a clone/remote URL.
+
+    Default port 22: git@host:user/repo.git
+    Custom port: ssh://git@host:port/user/repo.git
+    """
+    domain, port = parse_git_host(git_host)
+    if domain is None:
+        raise ValueError(port)
+    user = str(username).strip().strip('/')
+    repo = str(reponame).strip().strip('/')
+    if repo.endswith('.git'):
+        repo = repo[:-4]
+    if port is None:
+        return 'git@%s:%s/%s.git' % (domain, user, repo)
+    return 'ssh://git@%s:%s/%s/%s.git' % (domain, port, user, repo)
+
+
+def resolve_provider_host(default_provider, custom_host=None):
+    """
+    Map setupGit provider id to a host string.
+
+    github / gitlab -> github.com / gitlab.com
+    custom / private -> custom_host (required)
+    """
+    provider = (default_provider or 'github').strip().lower()
+    if provider in ('custom', 'private'):
+        host = (custom_host or '').strip()
+        if not host:
+            return None, 'Custom Git host is required.'
+        domain, port_or_err = parse_git_host(host)
+        if domain is None:
+            return None, port_or_err
+        return host, None
+    if provider == 'gitlab':
+        return 'gitlab.com', None
+    if provider == 'github':
+        return 'github.com', None
+    if provider.find('.') > -1:
+        return provider, None
+    return '%s.com' % provider, None
+
+
+def build_ssh_config(identity_file, hosts):
+    """
+    Build ~/.ssh/config content for one or more hosts.
+
+    hosts: iterable of host strings (domain or domain:port).
+    """
+    blocks = []
+    seen = set()
+    for raw in hosts:
+        domain, port = parse_git_host(raw)
+        if domain is None:
+            continue
+        key = '%s:%s' % (domain, port or 22)
+        if key in seen:
+            continue
+        seen.add(key)
+        lines = [
+            'Host %s' % domain,
+            '  HostName %s' % domain,
+            '  IdentityFile %s' % identity_file,
+            '  IdentitiesOnly yes',
+            '  StrictHostKeyChecking no',
+        ]
+        if port is not None:
+            lines.append('  Port %s' % port)
+        blocks.append('\n'.join(lines))
+    return '\n\n'.join(blocks) + ('\n' if blocks else '')

--- a/static/websiteFunctions/websiteFunctions.js
+++ b/static/websiteFunctions/websiteFunctions.js
@@ -5100,7 +5100,9 @@ app.controller('setupGit', function ($scope, $http, $timeout, $window) {
 
     $scope.setProvider = function (provider) {
         defaultProvider = provider;
+        $scope.showCustomGitHost = (provider === 'custom' || provider === 'private');
     };
+    $scope.showCustomGitHost = false;
 
 
     var statusFile;
@@ -5211,7 +5213,8 @@ app.controller('setupGit', function ($scope, $http, $timeout, $window) {
             username: $scope.githubUserName,
             reponame: $scope.githubRepo,
             branch: $scope.githubBranch,
-            defaultProvider: defaultProvider
+            defaultProvider: defaultProvider,
+            gitHost: $scope.customGitHost || ''
         };
 
         var config = {

--- a/websiteFunctions/static/websiteFunctions/websiteFunctions.js
+++ b/websiteFunctions/static/websiteFunctions/websiteFunctions.js
@@ -14923,7 +14923,9 @@ app.controller('setupGit', function ($scope, $http, $timeout, $window) {
 
     $scope.setProvider = function (provider) {
         defaultProvider = provider;
+        $scope.showCustomGitHost = (provider === 'custom' || provider === 'private');
     };
+    $scope.showCustomGitHost = false;
 
 
     var statusFile;
@@ -15034,7 +15036,8 @@ app.controller('setupGit', function ($scope, $http, $timeout, $window) {
             username: $scope.githubUserName,
             reponame: $scope.githubRepo,
             branch: $scope.githubBranch,
-            defaultProvider: defaultProvider
+            defaultProvider: defaultProvider,
+            gitHost: $scope.customGitHost || ''
         };
 
         var config = {

--- a/websiteFunctions/templates/websiteFunctions/manageGIT.html
+++ b/websiteFunctions/templates/websiteFunctions/manageGIT.html
@@ -628,7 +628,7 @@
                                         <div ng-hide="installationDetailsForm" class="form-group">
                                             <label class="col-sm-3 control-label">{% trans "Git Host" %}</label>
                                             <div class="col-sm-6">
-                                                <input placeholder="Ex. github.com or gitlab.com"
+                                                <input placeholder="Ex. github.com, gitlab.com, or git.example.com:9008"
                                                        name="gitHost" type="text" class="form-control"
                                                        ng-model="$parent.gitHost" required>
                                             </div>
@@ -852,7 +852,7 @@
                                             <div ng-hide="installationDetailsForm" class="form-group">
                                                 <label class="col-sm-3 control-label">{% trans "Git Host" %}</label>
                                                 <div class="col-sm-6">
-                                                    <input placeholder="Ex. github.com or gitlab.com"
+                                                    <input placeholder="Ex. github.com, gitlab.com, or git.example.com:9008"
                                                            name="gitHost" type="text" class="form-control"
                                                            ng-model="$parent.gitHost" required>
                                                 </div>
@@ -1289,7 +1289,7 @@
                                                     <div ng-hide="installationDetailsForm" class="form-group">
                                                         <label class="col-sm-3 control-label">{% trans "Git Host" %}</label>
                                                         <div class="col-sm-6">
-                                                            <input placeholder="Ex. github.com or gitlab.com"
+                                                            <input placeholder="Ex. github.com, gitlab.com, or git.example.com:9008"
                                                                    name="gitHost" type="text" class="form-control"
                                                                    ng-model="$parent.gitHost" required>
                                                         </div>

--- a/websiteFunctions/templates/websiteFunctions/setupGit.html
+++ b/websiteFunctions/templates/websiteFunctions/setupGit.html
@@ -59,6 +59,12 @@
                                             <i class="glyph-icon font-green icon-chevron-right"></i>
                                         </a>
                                     </li>
+                                    <li class="col-md-3">
+                                        <a href="" ng-click="setProvider('custom')" class="list-group-item">
+                                             {% trans "Custom / Private Git" %}
+                                            <i class="glyph-icon font-orange icon-chevron-right"></i>
+                                        </a>
+                                    </li>
                                 </ul>
 
                                 <form  action="/" class="form-horizontal bordered-row">
@@ -66,6 +72,14 @@
                                     <div ng-hide="installationDetailsForm" class="form-group">
                                         <label style="color: green;" class="col-sm-10 control-label">{% trans "Before attaching repo to your website, make sure to place your Development key in your GIT repository." %}</label>
                                      </div>
+
+                                    <div ng-show="showCustomGitHost && !installationDetailsForm" class="form-group">
+                                        <label class="col-sm-3 control-label">{% trans "Git Host" %}</label>
+                                        <div class="col-sm-6">
+                                            <input placeholder="Ex. git.example.com or git.example.com:9008"
+                                                   type="text" class="form-control" ng-model="customGitHost">
+                                        </div>
+                                    </div>
 
                                      <div ng-hide="installationDetailsForm" class="form-group">
                                         <label class="col-sm-3 control-label">{% trans "Username" %}</label>

--- a/websiteFunctions/website.py
+++ b/websiteFunctions/website.py
@@ -4957,14 +4957,15 @@ context /cyberpanel_suspension_page.html {
 
             ###
 
-            configContent = """Host github.com
-IdentityFile /home/%s/.ssh/%s
-StrictHostKeyChecking no
-""" % (self.domain, website.externalApp)
+            from plogical.gitSSH import build_ssh_config
+            identity = '/home/%s/.ssh/%s' % (self.domain, website.externalApp)
+            # Include common providers plus any custom host the admin may use later.
+            configContent = build_ssh_config(
+                identity, ['github.com', 'gitlab.com'])
 
             path = "/home/cyberpanel/config"
             writeToFile = open(path, 'w')
-            writeToFile.writelines(configContent)
+            writeToFile.write(configContent)
             writeToFile.close()
 
             command = 'mv %s /home/%s/.ssh/config' % (path, self.domain)
@@ -5007,6 +5008,7 @@ StrictHostKeyChecking no
             extraArgs['branch'] = data['branch']
             extraArgs['tempStatusPath'] = "/home/cyberpanel/" + str(randint(1000, 9999))
             extraArgs['defaultProvider'] = data['defaultProvider']
+            extraArgs['gitHost'] = data.get('gitHost', '')
 
             background = ApplicationInstaller('git', extraArgs)
             background.start()
@@ -6418,10 +6420,23 @@ StrictHostKeyChecking no
             else:
                 return ACLManager.loadErrorJson('status', 'Invalid characters in your input.')
 
-            ### set default ssh key
+            ### set default ssh key and ensure Host/Port entry for custom Git hosts
 
-            command = 'git -C %s config --local core.sshCommand "ssh -i /home/%s/.ssh/%s -o "StrictHostKeyChecking=no""' % (
-                self.folder, self.masterDomain, self.externalAppLocal)
+            from plogical.gitSSH import build_ssh_config, parse_git_host
+            identity = '/home/%s/.ssh/%s' % (self.masterDomain, self.externalAppLocal)
+            ssh_config_path = '/home/%s/.ssh/config' % self.masterDomain
+            hosts = ['github.com', 'gitlab.com', self.gitHost]
+            config_body = build_ssh_config(identity, hosts)
+            tmp_cfg = '/home/cyberpanel/git_ssh_config_%s' % self.masterDomain
+            writeToFile = open(tmp_cfg, 'w')
+            writeToFile.write(config_body)
+            writeToFile.close()
+            ProcessUtilities.executioner('mv %s %s' % (tmp_cfg, ssh_config_path))
+            ProcessUtilities.executioner(
+                'chown %s:%s %s' % (self.externalAppLocal, self.externalAppLocal, ssh_config_path))
+
+            command = 'git -C %s config --local core.sshCommand "ssh -i %s -o StrictHostKeyChecking=no"' % (
+                self.folder, identity)
             ProcessUtilities.executioner(command, self.externalAppLocal)
 
             ## Check if remote exists
@@ -6431,12 +6446,13 @@ StrictHostKeyChecking no
 
             ## Set new remote
 
+            from plogical.gitSSH import build_ssh_remote_url
+            remote_url = build_ssh_remote_url(
+                self.gitHost, self.gitUsername, self.gitReponame)
             if remoteResult.find('origin') == -1:
-                command = 'git -C %s remote add origin git@%s:%s/%s.git' % (
-                    self.folder, self.gitHost, self.gitUsername, self.gitReponame)
+                command = 'git -C %s remote add origin %s' % (self.folder, remote_url)
             else:
-                command = 'git -C %s remote set-url origin git@%s:%s/%s.git' % (
-                    self.folder, self.gitHost, self.gitUsername, self.gitReponame)
+                command = 'git -C %s remote set-url origin %s' % (self.folder, remote_url)
 
             possibleError = ProcessUtilities.outputExecutioner(command, self.externalAppLocal)
 
@@ -6850,7 +6866,10 @@ StrictHostKeyChecking no
 
             ##
 
-            command = 'git clone git@%s:%s/%s.git %s' % (self.gitHost, self.gitUsername, self.gitReponame, self.folder)
+            from plogical.gitSSH import build_ssh_remote_url
+            remote_url = build_ssh_remote_url(
+                self.gitHost, self.gitUsername, self.gitReponame)
+            command = 'git clone %s %s' % (remote_url, self.folder)
             commandStatus = ProcessUtilities.outputExecutioner(command, self.externalApp)
 
             if commandStatus.find('already exists') == -1 and commandStatus.find('Permission denied') == -1:


### PR DESCRIPTION
## Summary
- Addresses https://github.com/usmannasir/cyberpanel/issues/342 and reports that privately hosted Git is missing from setup.
- Adds **Custom / Private Git** provider with `host` or `host:port` (e.g. `git.example.com:9008`).
- Builds correct remotes: `git@host:user/repo.git` or `ssh://git@host:port/user/repo.git`.
- Writes SSH config `Host` / `Port` / `IdentityFile` entries (not only `github.com`).
- Restores missing `ApplicationInstaller` handlers for `git` / `pull` / `detach` / `changeBranch` so Attach Git works again.

## Test plan
- [ ] Attach via Github / GitLab providers (unchanged).
- [ ] Custom provider with `git.example.com` and with `git.example.com:9008`; confirm remote URL form.
- [ ] manageGIT placeholders accept `host:port`; clone/set-url use `ssh://` when port set.