### PR TITLE
Fix Imunify installation and generic-panel integration

### DIFF
--- a/CLManager/CageFS.py
+++ b/CLManager/CageFS.py
@@ -2,7 +2,7 @@
 import sys
 import os
 import django
-sys.path.append('/usr/local/CyberCP')
+sys.path.insert(0, '/usr/local/CyberCP')
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "CyberCP.settings")
 
 django.setup()
@@ -13,6 +13,18 @@ from plogical.processUtilities import ProcessUtilities
 from plogical.firewallUtilities import FirewallUtilities
 from firewall.models import FirewallRules
 from serverStatus.serverStatusUtil import ServerStatusUtil
+from plogical.imunify_integration import (
+    IMUNIFY_360_UI,
+    IMUNIFY_AV_UI,
+    build_deploy_commands,
+    build_imunify360_integration_conf,
+    build_imunifyav_integration_conf,
+    chmod_imunify_execute_files,
+    ensure_clscripts_executable,
+    ensure_install_status_file,
+    run_deploy_commands,
+    write_integration_conf,
+)
 
 
 class CageFS:
@@ -148,74 +160,43 @@ class CageFS:
     @staticmethod
     def submitinstallImunify(key):
         try:
-
-            imunifyKeyPath = '/home/cyberpanel/imunifyKeyPath'
-
-            ##
-
-            writeToFile = open(imunifyKeyPath, 'w')
-            writeToFile.write(key)
-            writeToFile.close()
-
-            ##
+            if key is None or not str(key).strip():
+                raise ValueError('An Imunify360 license key is required.')
+            key = str(key).strip()
 
             mailUtilities.checkHome()
+            ensure_install_status_file()
 
-            statusFile = open(ServerStatusUtil.lswsInstallStatusPath, 'w')
+            imunifyKeyPath = '/home/cyberpanel/imunifyKeyPath'
+            keyFileDescriptor = os.open(
+                imunifyKeyPath,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(keyFileDescriptor, 'w') as writeToFile:
+                writeToFile.write(key)
+            os.chmod(imunifyKeyPath, 0o600)
 
-            logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath,
-                                                      "Starting Imunify Installation..\n", 1)
+            with open(ServerStatusUtil.lswsInstallStatusPath, 'w') as statusFile:
+                logging.CyberCPLogFileWriter.statusWriter(
+                    ServerStatusUtil.lswsInstallStatusPath,
+                    "Starting Imunify360 Installation..\n", 1)
 
-            ##
+                os.makedirs('/etc/sysconfig/imunify360/generic', exist_ok=True)
+                with open('/etc/sysconfig/imunify360/generic/modsec.conf', 'a'):
+                    pass
+                os.makedirs(IMUNIFY_360_UI, exist_ok=True)
 
-            command = 'mkdir -p /etc/sysconfig/imunify360/generic'
-            ServerStatusUtil.executioner(command, statusFile)
+                write_integration_conf(build_imunify360_integration_conf())
+                ensure_clscripts_executable()
 
-            command = 'touch /etc/sysconfig/imunify360/generic/modsec.conf'
-            ServerStatusUtil.executioner(command, statusFile)
+                commands = build_deploy_commands('360', key=key)
+                run_deploy_commands(commands, statusFile)
+                chmod_imunify_execute_files(IMUNIFY_360_UI)
 
-            integrationFile = '/etc/sysconfig/imunify360/integration.conf'
-
-            content = """[paths]
-ui_path =/usr/local/CyberCP/public/imunify
-[web_server]
-server_type = litespeed
-graceful_restart_script = /usr/local/lsws/bin/lswsctrl restart
-modsec_audit_log = /usr/local/lsws/logs/auditmodsec.log
-modsec_audit_logdir = /usr/local/lsws/logs/
-
-[malware]
-basedir = /home
-pattern_to_watch = ^/home/.+?/(public_html|public_ftp|private_html)(/.*)?$
-"""
-
-            writeToFile = open(integrationFile, 'w')
-            writeToFile.write(content)
-            writeToFile.close()
-
-            ##
-
-            ### address issue to create imunify dir - https://app.clickup.com/t/86engx249
-
-            command = 'mkdir /usr/local/CyberCP/public/imunify'
-            ProcessUtilities.executioner(command)
-
-            command = 'pkill -f "bash i360deploy.sh"'
-            ServerStatusUtil.executioner(command, statusFile)
-
-            if not os.path.exists('i360deploy.sh'):
-                command = 'wget https://repo.imunify360.cloudlinux.com/defence360/i360deploy.sh'
-                ServerStatusUtil.executioner(command, statusFile)
-
-            command = 'bash i360deploy.sh --uninstall --yes'
-            ServerStatusUtil.executioner(command, statusFile)
-
-            command = 'bash i360deploy.sh --key %s --yes' % (key)
-            ServerStatusUtil.executioner(command, statusFile)
-
-
-            logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath,
-                                                      "Imunify reinstalled..\n", 1)
+                logging.CyberCPLogFileWriter.statusWriter(
+                    ServerStatusUtil.lswsInstallStatusPath,
+                    "Imunify360 reinstalled..\n", 1)
 
             logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath,
                                                       "Packages successfully installed.[200]\n", 1)
@@ -226,54 +207,29 @@ pattern_to_watch = ^/home/.+?/(public_html|public_ftp|private_html)(/.*)?$
     @staticmethod
     def submitinstallImunifyAV():
         try:
-
-
             mailUtilities.checkHome()
+            ensure_install_status_file()
 
-            statusFile = open(ServerStatusUtil.lswsInstallStatusPath, 'w')
+            with open(ServerStatusUtil.lswsInstallStatusPath, 'w') as statusFile:
+                logging.CyberCPLogFileWriter.statusWriter(
+                    ServerStatusUtil.lswsInstallStatusPath,
+                    "Starting ImunifyAV Installation..\n", 1)
 
-            logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath,
-                                                      "Starting ImunifyAV Installation..\n", 1)
+                os.makedirs('/etc/sysconfig/imunify360/generic', exist_ok=True)
+                with open('/etc/sysconfig/imunify360/generic/modsec.conf', 'a'):
+                    pass
+                os.makedirs(IMUNIFY_AV_UI, exist_ok=True)
 
-            ##
+                write_integration_conf(build_imunifyav_integration_conf())
+                ensure_clscripts_executable()
 
-            command = 'mkdir -p /etc/sysconfig/imunify360'
-            ServerStatusUtil.executioner(command, statusFile)
+                commands = build_deploy_commands('av')
+                run_deploy_commands(commands, statusFile)
+                chmod_imunify_execute_files(IMUNIFY_AV_UI)
 
-
-            integrationFile = '/etc/sysconfig/imunify360/integration.conf'
-
-            content = """[paths]
-ui_path = /usr/local/CyberCP/public/imunifyav
-ui_path_owner = lscpd:lscpd
-"""
-
-            writeToFile = open(integrationFile, 'w')
-            writeToFile.write(content)
-            writeToFile.close()
-
-            ##
-
-            ### address issue to create imunify dir - https://app.clickup.com/t/86engx249
-
-            command = 'pkill -f "bash imav-deploy.sh"'
-            ServerStatusUtil.executioner(command, statusFile)
-
-            if not os.path.exists('imav-deploy.sh'):
-                command = 'wget https://repo.imunify360.cloudlinux.com/defence360/imav-deploy.sh'
-                ServerStatusUtil.executioner(command, statusFile)
-
-            command = 'bash imav-deploy.sh --uninstall --yes'
-            ServerStatusUtil.executioner(command, statusFile)
-
-            command = 'mkdir -p /usr/local/CyberCP/public/imunifyav'
-            ServerStatusUtil.executioner(command, statusFile)
-
-            command = 'bash imav-deploy.sh --yes'
-            ServerStatusUtil.executioner(command, statusFile)
-
-            logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath,
-                                                      "ImunifyAV reinstalled..\n", 1)
+                logging.CyberCPLogFileWriter.statusWriter(
+                    ServerStatusUtil.lswsInstallStatusPath,
+                    "ImunifyAV reinstalled..\n", 1)
 
             logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath,
                                                       "Packages successfully installed.[200]\n", 1)
@@ -299,4 +255,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/firewall/firewallManager.py
+++ b/firewall/firewallManager.py
@@ -1651,9 +1651,18 @@ class FirewallManager:
                 return 0
 
             data = json.loads(self.request.body)
+            key = str(data.get('key', '')).strip()
+            if not key:
+                data_ret = {'status': 0, 'error_message': 'An Imunify360 license key is required.'}
+                return HttpResponse(json.dumps(data_ret))
 
-            execPath = "/usr/local/CyberCP/bin/python /usr/local/CyberCP/CLManager/CageFS.py"
-            execPath = execPath + " --function submitinstallImunify --key %s" % (data['key'])
+            from plogical.imunify_integration import (
+                build_install_worker_command,
+                ensure_install_status_file,
+            )
+            ensure_install_status_file(reset=True)
+
+            execPath = build_install_worker_command('360', key=key)
             ProcessUtilities.popenExecutioner(execPath)
 
             data_ret = {'status': 1, 'error_message': 'None'}
@@ -1701,8 +1710,13 @@ class FirewallManager:
                                                           1)
                 return 0
 
-            execPath = "/usr/local/CyberCP/bin/python /usr/local/CyberCP/CLManager/CageFS.py"
-            execPath = execPath + " --function submitinstallImunifyAV"
+            from plogical.imunify_integration import (
+                build_install_worker_command,
+                ensure_install_status_file,
+            )
+            ensure_install_status_file(reset=True)
+
+            execPath = build_install_worker_command('av')
             ProcessUtilities.popenExecutioner(execPath)
 
             data_ret = {'status': 1, 'error_message': 'None'}
@@ -1800,11 +1814,6 @@ class FirewallManager:
             final_dic = {'status': 0, 'error_message': str(msg)}
             final_json = json.dumps(final_dic)
             return HttpResponse(final_json)
-
-
-
-
-
 
 
 

--- a/plogical/imunify_integration.py
+++ b/plogical/imunify_integration.py
@@ -1,0 +1,261 @@
+# -*- coding: utf-8 -*-
+"""Build and maintain CyberPanel's Imunify generic-panel integration."""
+
+from __future__ import print_function
+
+import os
+import pwd
+import grp
+import shlex
+import stat
+import subprocess
+import tempfile
+
+
+INTEGRATION_CONF = '/etc/sysconfig/imunify360/integration.conf'
+IMUNIFY_AV_UI = '/usr/local/CyberCP/public/imunifyav'
+IMUNIFY_360_UI = '/usr/local/CyberCP/public/imunify'
+CLSCRIPT_DIR = '/usr/local/CyberCP/CLScript'
+DEPLOY_TMP = '/tmp/cyberpanel-imunify-deploy'
+INSTALL_STATUS_PATH = '/home/cyberpanel/switchLSWSStatus'
+PANEL_PYTHON = '/usr/local/CyberCP/bin/python'
+CAGEFS_MANAGER = '/usr/local/CyberCP/CLManager/CageFS.py'
+
+CLSCRIPT_OPTIONS = (
+    ('panel_info', 'panel_info.py'),
+    ('users', 'CloudLinuxUsers.py'),
+    ('domains', 'CloudLinuxDomains.py'),
+    ('packages', 'CloudLinuxPackages.py'),
+    ('resellers', 'CloudLinuxResellers.py'),
+    ('admins', 'CloudLinuxAdmins.py'),
+    ('db_info', 'CloudLinuxDB.py'),
+)
+
+
+def _integration_scripts_block():
+    lines = ['[integration_scripts]']
+    for option, filename in CLSCRIPT_OPTIONS:
+        lines.append('%s = %s/%s' % (option, CLSCRIPT_DIR, filename))
+    return '\n'.join(lines) + '\n\n'
+
+
+def _common_integration_blocks():
+    return (
+        '[pam]\n'
+        'service_name = system-auth\n\n'
+        '%s'
+        '[malware]\n'
+        'basedir = /home\n'
+        'pattern_to_watch = ^/home/.+?/(public_html|public_ftp|private_html)(/.*)?$\n\n'
+        '[web_server]\n'
+        'server_type = litespeed\n'
+        'graceful_restart_script = /usr/local/lsws/bin/lswsctrl restart\n'
+        'modsec_audit_log = /usr/local/lsws/logs/auditmodsec.log\n'
+        'modsec_audit_logdir = /usr/local/lsws/logs/\n'
+    ) % _integration_scripts_block()
+
+
+def _build_integration_conf(ui_path):
+    return (
+        '[paths]\n'
+        'ui_path = %s\n'
+        'ui_path_owner = lscpd:lscpd\n\n'
+        '%s'
+    ) % (ui_path, _common_integration_blocks())
+
+
+def build_imunifyav_integration_conf():
+    return _build_integration_conf(IMUNIFY_AV_UI)
+
+
+def build_imunify360_integration_conf():
+    return _build_integration_conf(IMUNIFY_360_UI)
+
+
+def detect_imunify_product(config_content):
+    """Return ``av``, ``360``, or ``None`` from an integration.conf body."""
+    for raw_line in config_content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(('#', ';')):
+            continue
+        option, separator, value = line.partition('=')
+        if not separator or option.strip().lower() != 'ui_path':
+            continue
+        ui_path = value.strip().rstrip('/')
+        if ui_path == IMUNIFY_AV_UI:
+            return 'av'
+        if ui_path == IMUNIFY_360_UI:
+            return '360'
+    return None
+
+
+def _read_config(config_path):
+    try:
+        with open(config_path, 'r') as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def write_integration_conf(content, config_path=INTEGRATION_CONF):
+    config_dir = os.path.dirname(config_path)
+    if config_dir:
+        os.makedirs(config_dir, exist_ok=True)
+
+    temporary = tempfile.NamedTemporaryFile(
+        mode='w',
+        dir=config_dir or '.',
+        prefix='.integration.conf.',
+        delete=False,
+    )
+    try:
+        with temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.chmod(temporary.name, 0o644)
+        os.replace(temporary.name, config_path)
+    except BaseException:
+        try:
+            os.unlink(temporary.name)
+        except OSError:
+            pass
+        raise
+
+
+def integration_conf_needs_repair(config_path=INTEGRATION_CONF):
+    body = _read_config(config_path)
+    if body is None or detect_imunify_product(body) is None:
+        return True
+    if '[integration_scripts]' not in body:
+        return True
+    return any(
+        '%s/%s' % (CLSCRIPT_DIR, filename) not in body
+        for _option, filename in CLSCRIPT_OPTIONS
+    )
+
+
+def repair_integration_conf(config_path=INTEGRATION_CONF):
+    body = _read_config(config_path)
+    if body is None:
+        return None
+
+    product = detect_imunify_product(body)
+    if product == 'av':
+        content = build_imunifyav_integration_conf()
+    elif product == '360':
+        content = build_imunify360_integration_conf()
+    else:
+        return None
+
+    write_integration_conf(content, config_path)
+    return product
+
+
+def ensure_clscripts_executable(script_dir=CLSCRIPT_DIR):
+    if not os.path.isdir(script_dir):
+        return
+    for _option, filename in CLSCRIPT_OPTIONS:
+        path = os.path.join(script_dir, filename)
+        if not os.path.isfile(path):
+            continue
+        mode = os.stat(path).st_mode
+        os.chmod(path, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def chmod_imunify_execute_files(ui_root):
+    if not ui_root or not os.path.isdir(ui_root):
+        return
+    for directory, _subdirectories, filenames in os.walk(ui_root):
+        if 'execute.py' in filenames:
+            os.chmod(os.path.join(directory, 'execute.py'), 0o755)
+
+
+def ensure_install_status_file(
+    status_path=INSTALL_STATUS_PATH,
+    owner=('cyberpanel', 'cyberpanel'),
+    reset=False,
+):
+    status_dir = os.path.dirname(status_path)
+    status_dir_created = False
+    if status_dir:
+        status_dir_created = not os.path.isdir(status_dir)
+        os.makedirs(status_dir, exist_ok=True)
+    with open(status_path, 'w' if reset else 'a'):
+        pass
+    os.chmod(status_path, 0o644)
+
+    if owner is not None:
+        try:
+            uid = pwd.getpwnam(owner[0]).pw_uid
+            gid = grp.getgrnam(owner[1]).gr_gid
+            if status_dir_created:
+                os.chown(status_dir, uid, gid)
+            os.chown(status_path, uid, gid)
+        except (KeyError, OSError):
+            pass
+
+
+def read_install_status(status_path=INSTALL_STATUS_PATH):
+    try:
+        with open(status_path, 'r') as status_file:
+            return status_file.read()
+    except FileNotFoundError:
+        return None
+
+
+def build_deploy_commands(product, key=None, deploy_tmp=DEPLOY_TMP):
+    if product == 'av':
+        filename = 'imav-deploy.sh'
+        url = 'https://repo.imunify360.cloudlinux.com/defence360/imav-deploy.sh'
+    elif product == '360':
+        if key is None or not str(key).strip():
+            raise ValueError('An Imunify360 license key is required.')
+        filename = 'i360deploy.sh'
+        url = 'https://repo.imunify360.cloudlinux.com/defence360/i360deploy.sh'
+    else:
+        raise ValueError('Unsupported Imunify product.')
+
+    script_path = os.path.join(deploy_tmp, filename)
+    commands = [
+        ['mkdir', '-p', deploy_tmp],
+        ['pkill', '-f', '[%s]%s' % (filename[0], filename[1:])],
+        ['wget', '-qO', script_path, url],
+        ['bash', script_path, '--uninstall', '--yes'],
+    ]
+    if product == '360':
+        commands.append(['bash', script_path, '--key', str(key), '--yes'])
+    else:
+        commands.append(['bash', script_path, '--yes'])
+    return commands
+
+
+def build_install_worker_command(product, key=None):
+    arguments = [PANEL_PYTHON, CAGEFS_MANAGER, '--function']
+    if product == '360':
+        if key is None or not str(key).strip():
+            raise ValueError('An Imunify360 license key is required.')
+        arguments.extend(('submitinstallImunify', '--key', str(key)))
+    elif product == 'av':
+        arguments.append('submitinstallImunifyAV')
+    else:
+        raise ValueError('Unsupported Imunify product.')
+    return ' '.join(shlex.quote(argument) for argument in arguments)
+
+
+def run_deploy_commands(commands, status_file):
+    failure_messages = (
+        'Could not create the Imunify deployment directory.',
+        'Could not stop an existing Imunify installer.',
+        'Imunify installer download failed.',
+        'Existing Imunify uninstall failed.',
+        'Imunify installation failed.',
+    )
+    for index, command in enumerate(commands):
+        return_code = subprocess.call(
+            command,
+            stdout=status_file,
+            stderr=status_file,
+        )
+        if return_code != 0 and index not in (1, 3):
+            raise RuntimeError(failure_messages[index])

--- a/plogical/test_imunify_integration.py
+++ b/plogical/test_imunify_integration.py
@@ -1,0 +1,147 @@
+import os
+import pathlib
+import shlex
+import stat
+import tempfile
+import unittest
+from unittest import mock
+
+from plogical.imunify_integration import (
+    CLSCRIPT_OPTIONS,
+    IMUNIFY_360_UI,
+    IMUNIFY_AV_UI,
+    build_deploy_commands,
+    build_install_worker_command,
+    build_imunify360_integration_conf,
+    build_imunifyav_integration_conf,
+    chmod_imunify_execute_files,
+    detect_imunify_product,
+    ensure_install_status_file,
+    ensure_clscripts_executable,
+    integration_conf_needs_repair,
+    read_install_status,
+    repair_integration_conf,
+    run_deploy_commands,
+)
+
+
+class ImunifyIntegrationTests(unittest.TestCase):
+
+    def test_cagefs_prefers_cyberpanel_modules_over_system_packages(self):
+        cagefs_source = (
+            pathlib.Path(__file__).parents[1] / 'CLManager' / 'CageFS.py'
+        ).read_text(encoding='utf-8')
+        path_setup = "sys.path.insert(0, '/usr/local/CyberCP')"
+        self.assertIn(path_setup, cagefs_source)
+        self.assertLess(cagefs_source.index(path_setup), cagefs_source.index('django.setup()'))
+
+    def test_detects_ui_path_independent_of_equals_spacing(self):
+        for separator in ('=', '= ', ' =', ' = '):
+            av_config = '[paths]\nui_path%s%s\n' % (separator, IMUNIFY_AV_UI)
+            full_config = '[paths]\nui_path%s%s\n' % (separator, IMUNIFY_360_UI)
+            self.assertEqual('av', detect_imunify_product(av_config))
+            self.assertEqual('360', detect_imunify_product(full_config))
+
+    def test_detection_only_uses_the_ui_path_setting(self):
+        config = '[paths]\nui_path = /srv/security\n# old imunifyav path\n'
+        self.assertIsNone(detect_imunify_product(config))
+
+    def test_generated_configs_include_required_panel_integrations(self):
+        for config in (
+            build_imunifyav_integration_conf(),
+            build_imunify360_integration_conf(),
+        ):
+            self.assertIn('[integration_scripts]', config)
+            self.assertIn('panel_info = /usr/local/CyberCP/CLScript/panel_info.py', config)
+            self.assertIn('users = /usr/local/CyberCP/CLScript/CloudLinuxUsers.py', config)
+            self.assertIn('domains = /usr/local/CyberCP/CLScript/CloudLinuxDomains.py', config)
+            self.assertIn('[malware]', config)
+            self.assertIn('[web_server]', config)
+
+    def test_repair_preserves_the_detected_product(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = os.path.join(directory, 'integration.conf')
+            pathlib.Path(config_path).write_text(
+                '[paths]\nui_path = %s\n' % IMUNIFY_AV_UI,
+                encoding='utf-8',
+            )
+
+            self.assertTrue(integration_conf_needs_repair(config_path))
+            self.assertEqual('av', repair_integration_conf(config_path))
+            repaired = pathlib.Path(config_path).read_text(encoding='utf-8')
+            self.assertEqual('av', detect_imunify_product(repaired))
+            self.assertFalse(integration_conf_needs_repair(config_path))
+
+    def test_unknown_config_is_not_rewritten(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = os.path.join(directory, 'integration.conf')
+            original = '[paths]\nui_path = /srv/security\n'
+            pathlib.Path(config_path).write_text(original, encoding='utf-8')
+
+            self.assertIsNone(repair_integration_conf(config_path))
+            self.assertEqual(
+                original,
+                pathlib.Path(config_path).read_text(encoding='utf-8'),
+            )
+
+    def test_deploy_commands_pass_the_license_key_as_one_argument(self):
+        key = 'license-key; touch /tmp/should-not-run'
+        commands = build_deploy_commands('360', key=key, deploy_tmp='/tmp/imunify test')
+        install_args = commands[-1]
+
+        self.assertEqual('bash', install_args[0])
+        self.assertEqual('/tmp/imunify test/i360deploy.sh', install_args[1])
+        self.assertEqual(key, install_args[3])
+        self.assertEqual(5, len(install_args))
+
+        worker_args = shlex.split(build_install_worker_command('360', key=key))
+        self.assertEqual('/usr/local/CyberCP/CLManager/CageFS.py', worker_args[1])
+        self.assertEqual(key, worker_args[-1])
+        self.assertEqual(6, len(worker_args))
+
+    def test_deploy_runner_rejects_a_failed_install(self):
+        commands = build_deploy_commands('av')
+        return_codes = [0, 1, 0, 1, 2]
+        with tempfile.TemporaryFile(mode='w+') as status_file:
+            with mock.patch(
+                'plogical.imunify_integration.subprocess.call',
+                side_effect=return_codes,
+            ) as process_call:
+                with self.assertRaisesRegex(RuntimeError, 'installation failed'):
+                    run_deploy_commands(commands, status_file)
+                self.assertNotIn('shell', process_call.call_args.kwargs)
+
+    def test_status_file_and_ui_executables_receive_safe_modes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            status_path = os.path.join(directory, 'status', 'install.log')
+            self.assertIsNone(read_install_status(status_path))
+            ensure_install_status_file(status_path, owner=None)
+            self.assertTrue(os.path.isfile(status_path))
+            self.assertEqual(0o644, stat.S_IMODE(os.stat(status_path).st_mode))
+            pathlib.Path(status_path).write_text('working\n', encoding='utf-8')
+            self.assertEqual('working\n', read_install_status(status_path))
+            ensure_install_status_file(status_path, owner=None, reset=True)
+            self.assertEqual('', read_install_status(status_path))
+
+            execute_path = os.path.join(directory, 'ui', 'bin', 'execute.py')
+            os.makedirs(os.path.dirname(execute_path))
+            pathlib.Path(execute_path).write_text('#!/usr/bin/env python3\n', encoding='utf-8')
+            os.chmod(execute_path, 0o640)
+            chmod_imunify_execute_files(os.path.join(directory, 'ui'))
+            self.assertEqual(0o755, stat.S_IMODE(os.stat(execute_path).st_mode))
+
+            script_dir = os.path.join(directory, 'scripts')
+            os.makedirs(script_dir)
+            for _option, filename in CLSCRIPT_OPTIONS:
+                script_path = os.path.join(script_dir, filename)
+                pathlib.Path(script_path).write_text('#!/usr/bin/env python3\n', encoding='utf-8')
+                os.chmod(script_path, 0o640)
+            ensure_clscripts_executable(script_dir)
+            self.assertEqual(
+                0o751,
+                stat.S_IMODE(os.stat(os.path.join(script_dir, 'panel_info.py')).st_mode),
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plogical/upgrade.py
+++ b/plogical/upgrade.py
@@ -5390,8 +5390,19 @@ pm.max_spare_servers = 3
                 with open(integrationConfig, 'r') as f:
                     configContent = f.read()
 
-                # Check which product the config file is for by looking at the ui_path
-                if 'ui_path =/usr/local/CyberCP/public/imunifyav' in configContent:
+                from plogical.imunify_integration import (
+                    detect_imunify_product,
+                    ensure_clscripts_executable,
+                    integration_conf_needs_repair,
+                    repair_integration_conf,
+                )
+
+                product = detect_imunify_product(configContent)
+                if product and integration_conf_needs_repair(integrationConfig):
+                    repair_integration_conf(integrationConfig)
+                ensure_clscripts_executable()
+
+                if product == 'av':
                     # This is ImunifyAV configuration
                     Upgrade.stdOut("Detected ImunifyAV configuration, reconfiguring...")
                     imunifyAVPath = '/usr/local/CyberCP/public/imunifyav'
@@ -5412,7 +5423,7 @@ pm.max_spare_servers = 3
                     else:
                         Upgrade.stdOut("ImunifyAV directory not found despite config file existing")
 
-                elif 'ui_path =/usr/local/CyberCP/public/imunify' in configContent:
+                elif product == '360':
                     # This is Imunify360 configuration
                     Upgrade.stdOut("Detected Imunify360 configuration, checking system installation...")
                     imunify360Path = '/usr/local/CyberCP/public/imunify'

--- a/serverStatus/views.py
+++ b/serverStatus/views.py
@@ -402,19 +402,27 @@ def securityruleUpdate(request):
 
 def switchTOLSWSStatus(request):
     try:
+        from plogical.imunify_integration import read_install_status
 
-        command = 'sudo cat ' + serverStatusUtil.ServerStatusUtil.lswsInstallStatusPath
-        output = ProcessUtilities.outputExecutioner(command)
+        statusPath = serverStatusUtil.ServerStatusUtil.lswsInstallStatusPath
+        output = read_install_status(statusPath)
+        if output is None:
+            data_ret = {'status': 1, 'abort': 0, 'requestStatus': '', 'installed': 0}
+            return HttpResponse(json.dumps(data_ret))
 
         if output.find('[404]') > -1:
-            command = "sudo rm -f " + serverStatusUtil.ServerStatusUtil.lswsInstallStatusPath
-            ProcessUtilities.popenExecutioner(command)
+            try:
+                os.remove(statusPath)
+            except FileNotFoundError:
+                pass
             data_ret = {'status': 1, 'abort': 1, 'requestStatus': output, 'installed': 0}
             json_data = json.dumps(data_ret)
             return HttpResponse(json_data)
         elif output.find('[200]') > -1:
-            command = "sudo rm -f " + serverStatusUtil.ServerStatusUtil.lswsInstallStatusPath
-            ProcessUtilities.popenExecutioner(command)
+            try:
+                os.remove(statusPath)
+            except FileNotFoundError:
+                pass
             data_ret = {'status': 1, 'abort': 1, 'requestStatus': output, 'installed': 1}
             json_data = json.dumps(data_ret)
             return HttpResponse(json_data)
@@ -424,8 +432,10 @@ def switchTOLSWSStatus(request):
             return HttpResponse(json_data)
 
     except BaseException as msg:
-        command = "sudo rm -f " + serverStatusUtil.ServerStatusUtil.lswsInstallStatusPath
-        ProcessUtilities.popenExecutioner(command)
+        try:
+            os.remove(serverStatusUtil.ServerStatusUtil.lswsInstallStatusPath)
+        except OSError:
+            pass
         data_ret = {'status': 0, 'abort': 1, 'requestStatus': str(msg), 'installed': 0}
         json_data = json.dumps(data_ret)
         return HttpResponse(json_data)


### PR DESCRIPTION
## Summary

- fix Imunify worker imports so CyberPanel modules take precedence over similarly named operating-system packages
- write the complete Imunify generic-panel integration before installation, including panel, user, domain, package, reseller, admin, and database scripts
- detect existing ImunifyAV/Imunify360 configurations independent of whitespace and repair incomplete upgrade configurations
- reset and read installation status without shell commands, and report installer failures instead of false success
- pass deploy arguments directly without a shell and protect the Imunify360 key file with mode 0600

## Validation

- 169/169 applicable regression tests pass
- changed Python files compile successfully
- repository-wide discovery is unchanged from baseline: 163 tests with the same 10 local database/environment setup errors and no new failures
- live Ubuntu 26.04 validation on the existing DNS-target server:
  - ImunifyAV 8.8.5 installed successfully and service active
  - CyberPanel Imunify page loaded through an authenticated browser session
  - authenticated Imunify login reached the malware user list
  - both hosted websites appeared in the Imunify inventory
  - no browser console, request, or HTTP errors

## Related issues

- #1114
- #1825
- #1826
