### PR TITLE
Fix login redirect loops and session persistence

### DIFF
--- a/CyberCP/secMiddleware.py
+++ b/CyberCP/secMiddleware.py
@@ -139,7 +139,12 @@ class secMiddleware:
                 # validation -- the request still falls through to the response
                 # path below where the security headers (nosniff, X-Frame-Options,
                 # CSP, Referrer-Policy) are applied.
-                webmailRequest = pathActual.startswith('/webmail/')
+                # Login credentials are opaque values. Passwords commonly
+                # contain shell metacharacters, but they are passed to the
+                # password hash checker and never interpolated into a
+                # command. Scanning this endpoint rejects valid credentials
+                # before verifyLogin can authenticate them.
+                webmailRequest = pathActual.startswith('/webmail/') or pathActual == '/verifyLogin'
 
                 for key, value in ({} if webmailRequest else data).items():
                     valueAlreadyChecked = 0

--- a/CyberCP/settings.py
+++ b/CyberCP/settings.py
@@ -44,7 +44,10 @@ if not SECRET_KEY:
         import secrets as _secrets
         SECRET_KEY = _secrets.token_urlsafe(50)
         try:
-            _fd = os.open(_secret_key_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            # lscpd loads Django as the unprivileged cyberpanel user.  Keep the
+            # key private from other users while allowing that service account
+            # to read the same key across all workers.
+            _fd = os.open(_secret_key_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o640)
             with os.fdopen(_fd, 'w') as _skf:
                 _skf.write(SECRET_KEY)
         except FileExistsError:
@@ -63,6 +66,10 @@ DEBUG = os.getenv('DEBUG', 'False').lower() == 'true'
 
 # Allow configuration via environment variable, with wildcard fallback for universal compatibility
 ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '*').split(',')
+
+# Avoid collisions with stale cookies or other applications using Django's
+# generic ``sessionid`` name on the same hostname.
+SESSION_COOKIE_NAME = 'cyberpanel_sessionid'
 
 # Application definition
 

--- a/install/env_generator.py
+++ b/install/env_generator.py
@@ -183,8 +183,16 @@ LOG_LEVEL=INFO
     with open(env_file_path, 'w') as f:
         f.write(env_content)
     
-    # Set secure permissions (owner read/write only)
-    os.chmod(env_file_path, 0o600)
+    # lscpd runs as cyberpanel and must read the generated Django settings.
+    # Keep credentials inaccessible to other users while granting the service
+    # account group-read access.
+    os.chmod(env_file_path, 0o640)
+    try:
+        import shutil
+        shutil.chown(env_file_path, user='root', group='cyberpanel')
+    except (AttributeError, OSError, PermissionError):
+        # Non-root test/install environments may not have these accounts.
+        pass
     
     print(f"✓ Generated secure .env file at: {env_file_path}")
     print(f"✓ MySQL Root Password: {mysql_root_password}")

--- a/install/install.py
+++ b/install/install.py
@@ -784,6 +784,16 @@ password="%s"
         command = "chown root:cyberpanel /usr/local/CyberCP/CyberCP/settings.py"
         preFlightsChecks.call(command, self.distro, command, command, 1, 0, os.EX_OSERR)
 
+        # Django sessions and CSRF tokens require one stable SECRET_KEY across
+        # every lscpd worker.  lscpd runs as cyberpanel, so the persistent key
+        # and generated environment must be readable by that service account.
+        for path in ('/usr/local/CyberCP/secret_key', '/usr/local/CyberCP/.env'):
+            if os.path.exists(path):
+                command = "chmod 640 %s" % path
+                preFlightsChecks.call(command, self.distro, command, command, 1, 0, os.EX_OSERR)
+                command = "chown root:cyberpanel %s" % path
+                preFlightsChecks.call(command, self.distro, command, command, 1, 0, os.EX_OSERR)
+
         files = ['/etc/yum.repos.d/MariaDB.repo', '/etc/pdns/pdns.conf', '/etc/systemd/system/lscpd.service',
                  '/etc/pure-ftpd/pure-ftpd.conf', '/etc/pure-ftpd/pureftpd-pgsql.conf',
                  '/etc/pure-ftpd/pureftpd-mysql.conf', '/etc/pure-ftpd/pureftpd-ldap.conf',

--- a/loginSystem/views.py
+++ b/loginSystem/views.py
@@ -89,7 +89,6 @@ def verifyLogin(request):
                     response.set_cookie(settings.LANGUAGE_COOKIE_NAME, user_Language)
 
             admin = Administrator.objects.get(userName=username)
-
             if admin.state == 'SUSPENDED':
                 data = {'userID': 0, 'loginStatus': 0, 'error_message': 'Account currently suspended.'}
                 json_data = json.dumps(data)
@@ -100,6 +99,10 @@ def verifyLogin(request):
                     twoinit = request.session['twofa']
                 except:
                     request.session['twofa'] = 0
+                    # Persist immediately; relying only on the response
+                    # middleware can leave an existing/expired session key
+                    # unchanged behind some lscpd worker configurations.
+                    request.session.save()
                     data = {'userID': admin.pk, 'loginStatus': 2, 'error_message': "None"}
                     json_data = json.dumps(data)
                     response.write(json_data)
@@ -113,8 +116,11 @@ def verifyLogin(request):
                         import pyotp
                         totp = pyotp.TOTP(admin.secretKey)
                         twofa_code = data.get('twofa', '')
-                        if not twofa_code or str(totp.now()) != str(twofa_code):
+                        # Allow one adjacent 30-second TOTP step to account for
+                        # code entry and network delay at a boundary.
+                        if not twofa_code or not totp.verify(str(twofa_code).strip(), valid_window=1):
                             request.session['twofa'] = 0
+                            request.session.save()
                             data = {'userID': 0, 'loginStatus': 0, 'error_message': "Invalid verification code."}
                             json_data = json.dumps(data)
                             response.write(json_data)
@@ -135,6 +141,12 @@ def verifyLogin(request):
                     request.session['ipAddr'] = ipAddr
 
                 request.session.set_expiry(43200)
+                # Rotate away from any stale/expired cookie presented by the
+                # browser before persisting the authenticated session.
+                request.session.cycle_key()
+                # Persist the authenticated session before returning the JSON
+                # response so the browser's following /base/ request sees it.
+                request.session.save()
                 data = {'userID': admin.pk, 'loginStatus': 1, 'error_message': "None"}
                 json_data = json.dumps(data)
                 response.write(json_data)


### PR DESCRIPTION
## Summary

Fix CyberPanel login redirect loops caused by middleware rejection of valid passwords and unreliable session persistence during 2FA authentication.

## Problem

After submitting valid credentials, CyberPanel could return the user to the login page indefinitely:

    POST /verifyLogin 200
    GET  /base/       302 Location: /
    GET  /            200

The primary confirmed cause was secMiddleware applying command-injection character filtering to /verifyLogin. Valid passwords containing characters such as $, |, ;, or & were rejected before authentication.

Additional weaknesses in the same login path could also invalidate or lose authenticated sessions between the login response and the subsequent /base/ request.

## Changes

- Exclude /verifyLogin from generic command-character input validation.
  - Passwords remain opaque values and are handled by the password hash checker.
  - Input validation remains enabled for other application endpoints.

- Persist the 2FA challenge state explicitly.
- Persist and rotate the session after successful authentication.
- Allow one adjacent 30-second TOTP window to tolerate normal entry and clock-boundary delay.
- Use a dedicated cyberpanel_sessionid cookie to avoid collisions with stale generic sessionid cookies.
- Make the Django secret key persistent across worker processes.
- Ensure the lscpd worker account can read the shared secret key.
- Apply secure ownership and permissions to the secret-key and environment files.
- Preserve the original client-IP session-binding enforcement.

## Files Changed

- CyberCP/secMiddleware.py
- CyberCP/settings.py
- loginSystem/views.py
- install/env_generator.py
- install/install.py

## Testing

Verified locally with:

- Correct passwords containing $, |, ;, and &.
- 2FA-enabled administrator login.
- Current TOTP codes.
- TOTP codes from the adjacent time window.
- Stale session cookies.
- Multiple lscpd workers.
- Full login → 2FA → /base/ flow.

Expected result after the changes:

    POST /verifyLogin 200
    GET  /base/       200

Also verified:

- lscpd restarts cleanly.
- Django/Python files compile successfully.
- git diff --check passes.
- Original IP-binding enforcement remains enabled.

Fixes #1896