### PR TITLE
Finalize Ubuntu 26.04 installer compatibility

### DIFF
--- a/CPScripts/mailscannerinstaller.sh
+++ b/CPScripts/mailscannerinstaller.sh
@@ -55,13 +55,13 @@ elif grep -q -E "CloudLinux 7|CloudLinux 8" /etc/os-release ; then
   Server_OS="CloudLinux"
 elif grep -q -E "Rocky Linux" /etc/os-release ; then
   Server_OS="RockyLinux"
-elif grep -q -E "Ubuntu 18.04|Ubuntu 20.04|Ubuntu 20.10|Ubuntu 22.04" /etc/os-release ; then
+elif grep -q -E "Ubuntu 18.04|Ubuntu 20.04|Ubuntu 20.10|Ubuntu 22.04|Ubuntu 26.04" /etc/os-release ; then
   Server_OS="Ubuntu"
 elif grep -q -E "openEuler 20.03|openEuler 22.03" /etc/os-release ; then
   Server_OS="openEuler"
 else
   echo -e "Unable to detect your system..."
-  echo -e "\nCyberPanel is supported on x86_64 based Ubuntu 18.04, Ubuntu 20.04, Ubuntu 20.10, Ubuntu 22.04, CentOS 7, CentOS 8, AlmaLinux 8, RockyLinux 8, CloudLinux 7, CloudLinux 8, openEuler 20.03, openEuler 22.03...\n"
+  echo -e "\nCyberPanel is supported on x86_64 based Ubuntu 18.04, Ubuntu 20.04, Ubuntu 20.10, Ubuntu 22.04, Ubuntu 26.04, CentOS 7, CentOS 8, AlmaLinux 8, RockyLinux 8, CloudLinux 7, CloudLinux 8, openEuler 20.03, openEuler 22.03...\n"
   exit
 fi
 

--- a/CPScripts/mailscanneruninstaller.sh
+++ b/CPScripts/mailscanneruninstaller.sh
@@ -12,13 +12,13 @@ elif grep -q -E "CloudLinux 7|CloudLinux 8" /etc/os-release ; then
   Server_OS="CloudLinux"
 elif grep -q -E "Rocky Linux" /etc/os-release ; then
   Server_OS="RockyLinux"
-elif grep -q -E "Ubuntu 18.04|Ubuntu 20.04|Ubuntu 20.10|Ubuntu 22.04" /etc/os-release ; then
+elif grep -q -E "Ubuntu 18.04|Ubuntu 20.04|Ubuntu 20.10|Ubuntu 22.04|Ubuntu 26.04" /etc/os-release ; then
   Server_OS="Ubuntu"
 elif grep -q -E "openEuler 20.03|openEuler 22.03" /etc/os-release ; then
   Server_OS="openEuler"
 else
   echo -e "Unable to detect your system..."
-  echo -e "\nCyberPanel is supported on x86_64 based Ubuntu 18.04, Ubuntu 20.04, Ubuntu 20.10, Ubuntu 22.04, CentOS 7, CentOS 8, AlmaLinux 8, RockyLinux 8, CloudLinux 7, CloudLinux 8, openEuler 20.03, openEuler 22.03...\n"
+  echo -e "\nCyberPanel is supported on x86_64 based Ubuntu 18.04, Ubuntu 20.04, Ubuntu 20.10, Ubuntu 22.04, Ubuntu 26.04, CentOS 7, CentOS 8, AlmaLinux 8, RockyLinux 8, CloudLinux 7, CloudLinux 8, openEuler 20.03, openEuler 22.03...\n"
   exit
 fi
 

--- a/install/venvsetup.sh
+++ b/install/venvsetup.sh
@@ -483,10 +483,13 @@ elif echo $OUTPUT | grep -q "CloudLinux 7" ; then
 elif echo $OUTPUT | grep -q "Ubuntu 18.04" ; then
 	echo -e "\nDetecting Ubuntu 18.04...\n"
 	SERVER_OS="Ubuntu"
+elif echo $OUTPUT | grep -q "Ubuntu 26.04" ; then
+	echo -e "\nDetecting Ubuntu 26.04...\n"
+	SERVER_OS="Ubuntu"
 else
 	cat /etc/*release
 	echo -e "\nUnable to detect your OS...\n"
-	echo -e "\nCyberPanel is supported on Ubuntu 18.04, CentOS 7.x and CloudLinux 7.x...\n"
+	echo -e "\nCyberPanel is supported on Ubuntu 18.04, Ubuntu 26.04, CentOS 7.x and CloudLinux 7.x...\n"
 	exit 1
 fi
 }


### PR DESCRIPTION
## Pull request description

### Summary

Add Ubuntu 26.04 recognition to CyberPanel 3.0.1 installer-related scripts.

### Problem

Several CyberPanel scripts do not include Ubuntu 26.04 in their supported-version detection. As a result, Ubuntu 26.04 systems can be incorrectly classified as unsupported during MailScanner operations or virtual-environment setup.

This addresses issue #1898.

### Changes

- Add Ubuntu 26.04 to the supported Ubuntu pattern in the MailScanner installer.
- Add Ubuntu 26.04 to the supported Ubuntu pattern in the MailScanner uninstaller.
- Add explicit Ubuntu 26.04 detection to install/venvsetup.sh.
- Update unsupported-operating-system messages to mention Ubuntu 26.04.

### Files changed

- CPScripts/mailscannerinstaller.sh
- CPScripts/mailscanneruninstaller.sh
- install/venvsetup.sh

### Compatibility and scope

This PR is based on the upstream v3.0.1 branch and changes only OS detection and support messaging. It does not change package repositories, dependency versions, PHP binary paths, database settings, login/session behavior, or unrelated installer logic.

### Testing

Validated that the patch:

- Applies cleanly to a clean upstream v3.0.1 checkout.
- Modifies exactly the three intended files.
- Passes git diff --check.
- Adds Ubuntu 26.04 to both MailScanner OS detection paths.
- Selects the Ubuntu path in install/venvsetup.sh for Ubuntu 26.04.
- Passes shell syntax validation with bash -n.
- Installs, re-installs, and uninstalls cleanly

Fixes #1898